### PR TITLE
fix: recursively find SKILL.md files during project initialization

### DIFF
--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -1032,9 +1032,24 @@ function runInit(options, jonggrangHome, projectRoot) {
     ];
 
     try {
-      const skillDirs = fs.readdirSync(jonggrangSkillsDir).filter(d =>
-        fs.statSync(path.join(jonggrangSkillsDir, d)).isDirectory()
-      );
+      const findSkills = (dir, prefix = '') => {
+        let results = [];
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            const fullPath = path.join(dir, entry.name);
+            const relPath = path.join(prefix, entry.name);
+            if (fileExists(path.join(fullPath, 'SKILL.md'))) {
+              results.push(relPath);
+            } else {
+              results.push(...findSkills(fullPath, relPath));
+            }
+          }
+        }
+        return results;
+      };
+
+      const skillDirs = findSkills(jonggrangSkillsDir);
       for (const skillName of skillDirs) {
         const skillFile = path.join(jonggrangSkillsDir, skillName, 'SKILL.md');
         if (!fileExists(skillFile)) continue;


### PR DESCRIPTION
## Summary
Fix skill discovery during `jonggrang init` to recursively search nested directories for `SKILL.md` files, instead of only scanning top-level directories.

## Context
Previously, `runInit` used `fs.readdirSync` with a flat filter for directories containing `SKILL.md`. This meant skills organized in nested subdirectories (e.g., `skills/category/skill-name/SKILL.md`) were silently skipped, leading to incomplete skill installation in projects.

## Changes
- Replace flat `readdirSync` + directory filter with a recursive `findSkills` function that traverses the skill directory tree
- `findSkills` collects relative paths of all directories containing a `SKILL.md`, descending into subdirectories that don't have one
- Skill file resolution now correctly uses the full relative path (`skillName`) for nested skills

### Key Implementation Details
The new `findSkills(dir, prefix)` function:
1. Reads directory entries with `withFileTypes: true` for efficient type checking
2. For each subdirectory, checks if it directly contains a `SKILL.md`
3. If yes, adds its relative path to results
4. If no, recursively descends into it to find deeper skills
5. Returns an array of relative paths used by the existing skill copy loop

## Testing
```bash
# Create a nested skill directory structure
mkdir -p ~/.jonggrang/skills/sub-dir/nested-skill
echo "# Nested Skill" > ~/.jonggrang/skills/sub-dir/nested-skill/SKILL.md

# Run init and verify nested skill is discovered
jonggrang init

# Verify skill was copied to .claude/skills and .opencode/skills
ls .claude/skills/
ls .opencode/skills/
```

## Links
- Related: skills with nested directory structures were not found during init