### PR TITLE
feat: add missing SDLC skills to close workflow gaps

### DIFF
--- a/skills/core/breadboarding-workflow/SKILL.md
+++ b/skills/core/breadboarding-workflow/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: breadboarding-workflow
+description: Map UI elements and code relationships (affordances).
+phase: 5 (Complexity)
+role: Lead
+---
+
+# Breadboarding Workflow
+
+**Role Constraints:** Lead (Write/Bash access allowed).
+**File Access:** Do NOT use literal placeholders for file paths. Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`.
+
+## Methodology
+
+Transform a workflow description or shaped pitch into affordance tables showing UI and Code affordances with their wiring. 
+
+### 1. Locate Context
+Use the `glob` tool to find the active feature directory inside `.jonggrang/.output/features/`. Use the `read` tool to read the `pitch.md` or requirements document located there.
+
+### 2. Identify Affordances
+Break down the shaped solution into three components:
+1. **Places:** Where the user is (e.g., "Dashboard", "Settings Page").
+2. **Affordances:** What the user can act on (buttons, fields, readable data).
+3. **Connection Lines:** Where an action takes the user next.
+
+### 3. Draft the Breadboard
+Create a text-based breadboard representation. Use a simple format mapping Places to their Affordances and Connections. 
+Example:
+Place: Invoice View
+- Read: Invoice details, status
+- Action: Click "Pay Now" -> takes to Place: Payment Gateway
+
+### 4. Save the Artifact
+Use the `write` tool to save the breadboarding artifact as `breadboard.md` inside the active feature directory.
+
+## Completion Signal
+When the breadboarding is saved and the workflow is mapped, output exactly:
+
+BREADBOARDING_COMPLETE

--- a/skills/core/documenting-release/SKILL.md
+++ b/skills/core/documenting-release/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: documenting-release
+description: Cross-reference diffs to update README, ARCHITECTURE, CHANGELOG.
+phase: 16 (Complete)
+role: Lead
+---
+
+# Documenting Release
+
+**Role Constraints:** Lead (Write/Bash access allowed).
+**File Access:** Do NOT use literal placeholders for file paths. Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`.
+
+## Objective
+Ensure every documentation file in the project is accurate, up to date, and written in a friendly, user-forward voice before the feature is fully released.
+
+## Execution Steps
+
+1. **Pre-flight & Diff Analysis:**
+   - Use `bash` to run `git diff main...HEAD --stat` (or the appropriate base branch) to understand what changed.
+   - Classify changes into features, changed behavior, removals, and infrastructure.
+2. **Per-File Documentation Audit:**
+   - Locate major documentation files (`README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `CONTRIBUTING.md`) using `glob`.
+   - Read each file and cross-reference it against the git diff.
+3. **Apply Factual Updates:**
+   - Use the `edit` or `write` tool to make factual corrections directly (e.g., adding a command to a table, updating counts).
+   - Use the `bash` tool if you need to run specific scripts that generate documentation.
+4. **CHANGELOG Voice Polish:**
+   - If `CHANGELOG.md` exists, review the entry for the current feature.
+   - Polish the wording to focus on user capabilities ("You can now...") rather than implementation details. Do NOT delete or regenerate existing entries, only refine them.
+5. **Ask About Risky Changes:**
+   - If narrative changes, security model descriptions, or massive rewrites are needed, ask the user for confirmation before proceeding.
+6. **Cross-Doc Consistency Check:**
+   - Ensure the `README` aligns with `ARCHITECTURE` and `CHANGELOG`. Fix any clear factual inconsistencies.
+
+## Completion Signal
+When the documentation has been updated and verified, output exactly:
+
+DOCUMENTATION_COMPLETE

--- a/skills/core/reviewing-architecture/SKILL.md
+++ b/skills/core/reviewing-architecture/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: reviewing-architecture
+description: Eng manager-mode plan review. Lock in the execution plan, data flow, diagrams, edge cases.
+phase: 7 (Architect)
+role: Lead
+---
+
+# Reviewing Architecture (Eng Review)
+
+**Role Constraints:** Lead (Write/Bash access allowed).
+**File Access:** Do NOT use literal placeholders for file paths. Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`.
+
+## Objective
+Act as an Engineering Manager to lock in the execution plan. Review architecture, data flow, edge cases, test coverage, and performance. 
+
+## Execution Steps
+
+1. **Gather Context:** Use `glob` and `read` to find and review the feature's `pitch.md`, `strategy-review.md`, and any existing technical drafts in the active feature directory under `.jonggrang/.output/features/`.
+2. **Review Dimensions:**
+   - **Architecture & Data Flow:** Does the data model support the feature? Are DB queries optimized? 
+   - **Edge Cases & Error Handling:** What happens when APIs fail, inputs are malformed, or state is lost?
+   - **Test Coverage:** What is the testing strategy (unit, integration, E2E)?
+   - **Performance:** Are there N+1 query risks? Are assets optimized?
+   - **Security:** Are inputs sanitized? Are permissions checked properly?
+3. **Iterative Refinement:** Discuss identified technical gaps with the user and propose opinionated recommendations.
+4. **Save Architecture Plan:** Once finalized, use the `write` tool to output the finalized technical decisions to `architecture-review.md` in the active feature directory.
+
+## Completion Signal
+When the architecture plan is finalized and saved, output exactly:
+
+ARCHITECTURE_REVIEW_COMPLETE

--- a/skills/core/reviewing-product-strategy/SKILL.md
+++ b/skills/core/reviewing-product-strategy/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: reviewing-product-strategy
+description: CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises.
+phase: 6 (Brainstorm)
+role: Lead
+---
+
+# Reviewing Product Strategy (CEO Review)
+
+**Role Constraints:** Lead (Write/Bash access allowed).
+**File Access:** Do NOT use literal placeholders for file paths. Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`.
+
+## Objective
+Rethink the problem, find the 10-star product, challenge premises, and expand scope when it creates a better product. Think like a CEO/Founder.
+
+## Execution Steps
+
+1. **Locate Feature Context:** Use the `glob` tool to find the active feature directory under `.jonggrang/.output/features/` and `read` the `pitch.md` or `plan.md`.
+2. **Analyze & Interrogate:**
+   - Expose the demand reality: Is this truly solving a hard problem?
+   - Challenge the status quo: Why hasn't this been solved this way before?
+   - Desperate specificity: Who exactly is desperate for this?
+3. **Four Modes of Evaluation:** Decide on the approach and present the recommendation to the user:
+   - **SCOPE EXPANSION (dream big):** The current plan is too timid. What is the 10-star version?
+   - **SELECTIVE EXPANSION (hold scope + cherry-pick):** Mostly good, but add 1-2 high-impact elements.
+   - **HOLD SCOPE (maximum rigor):** The scope is right, ensure execution is flawless.
+   - **SCOPE REDUCTION (strip to essentials):** The plan is bloated. Cut it down to the MVP.
+4. **Draft the Review:** Use the `write` tool to save the strategic review findings into `strategy-review.md` in the active feature directory. Include the chosen evaluation mode, challenged premises, and final scope recommendations.
+
+## Completion Signal
+When the strategy review is complete and the file is written, output exactly:
+
+STRATEGY_REVIEW_COMPLETE

--- a/skills/core/shaping-requirements/SKILL.md
+++ b/skills/core/shaping-requirements/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: shaping-requirements
+description: Iteratively define problem and solution shapes.
+phase: 3 (Discovery)
+role: Lead
+---
+
+# Shaping Requirements
+
+**Role Constraints:** Lead (Write/Bash access allowed).
+**File Access:** Do NOT use literal placeholders for file paths. Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`.
+
+## Methodology
+
+Use this methodology when collaboratively shaping a solution with the user - iterating on problem definition (requirements) and solution options (shapes).
+
+### Step 1: Understand the Problem
+Before suggesting any solutions, explore the problem space.
+- What is the actual user struggle?
+- Ask clarifying questions to dig deeper into the "why" behind the request.
+- Define what is explicitly out of bounds (what we are NOT solving).
+
+### Step 2: Establish the Appetite
+- How much time/effort is this problem worth? Is it a quick patch or a major feature?
+- Constraint-driven design: The appetite determines the scope of the solution.
+
+### Step 3: Explore Solution Shapes
+Draft rough concepts, not high-fidelity designs.
+- Use natural language to describe the moving parts.
+- Propose 2-3 different conceptual approaches (shapes) with tradeoffs.
+- Keep it abstract enough to leave room for designers/engineers to invent, but concrete enough to know what we are building.
+
+### Step 4: Address Risks and Rabbit Holes
+- What could go wrong? What are the technical unknowns?
+- Call out potential "rabbit holes" where the team might get stuck.
+
+### Step 5: Write the Pitch
+Use your `write` tool to create or update `pitch.md` inside the active feature directory found via `glob` under `.jonggrang/.output/features/`.
+Structure the pitch with:
+1. Problem
+2. Appetite
+3. Solution (the shape)
+4. Rabbit holes
+5. No-gos
+
+## Completion Signal
+When the shaping process is finalized and the pitch is saved, output exactly:
+
+SHAPING_COMPLETE

--- a/skills/library/backend/assessing-code-health/SKILL.md
+++ b/skills/library/backend/assessing-code-health/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: assessing-code-health
+description: Run linters/typecheckers to calculate health score.
+phase: 10 (Compliance)
+role: Reviewer
+---
+
+# Assessing Code Health
+
+**Role Constraints:** Reviewer (STRICTLY READ-ONLY for application code). You MAY NOT modify, fix, or write to application source code.
+**File Access:** Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`. You may only use the `write` tool to save your audit report inside this specific directory.
+
+## Objective
+Run read-only static analysis tools (linters, typecheckers, etc.) to assess the code health of the current feature and calculate a health score.
+
+## Execution Steps
+
+1. **Information Gathering:**
+   - Find the active feature directory using `glob`.
+   - Identify the project's build and linting commands (e.g., `package.json` scripts like `npm run lint`, `tsc --noEmit`).
+2. **Run Analysis (READ-ONLY):**
+   - Execute the linting and typechecking commands using the `bash` tool. 
+   - DO NOT run commands that auto-fix or format code (e.g., do not use `--fix`).
+   - Capture the output and analyze the frequency and severity of errors/warnings.
+3. **Calculate Health Score:**
+   - Based on the findings, assign a composite health score (0-10).
+   - Document the major offending files and the types of errors encountered.
+4. **Generate Report:**
+   - Write the results and the calculated health score to `.jonggrang/.output/features/<active-feature-dir>/health-report.md` using the `write` tool.
+
+## Completion Signal
+When the health assessment report is saved, output exactly:
+
+HEALTH_ASSESSMENT_COMPLETE

--- a/skills/library/backend/hardening-resilience/SKILL.md
+++ b/skills/library/backend/hardening-resilience/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: hardening-resilience
+description: Evaluate error handling, i18n, text overflow, and edge cases.
+phase: 10 (Compliance)
+role: Reviewer
+---
+
+# Hardening & Resilience Review
+
+**Role Constraints:** Reviewer (STRICTLY READ-ONLY for application code). You MAY NOT modify, fix, or write to application source code.
+**File Access:** Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`. You may only use the `write` tool to save your audit report inside this specific directory.
+
+## Objective
+Evaluate the codebase for interface and backend resilience: proper error handling, i18n support, edge case management, and graceful degradation.
+
+## Execution Steps
+
+1. **Discover Context:** Use `glob` and `read` to explore the application code modified or created for the current feature.
+2. **Review Dimensions:**
+   - **Error Handling:** Are exceptions caught? Are user-friendly error messages returned? Do APIs fail gracefully?
+   - **Edge Cases:** Are empty states handled? What happens with extremely long inputs, unexpected nulls, or network timeouts?
+   - **Internationalization (i18n):** Are strings hardcoded or localized?
+   - **Data Validation:** Is boundary testing applied to inputs?
+3. **Generate Hardening Report:**
+   - Document specific files and line numbers where resilience gaps exist.
+   - Detail the impact of the missing hardening measure.
+   - Propose exactly how the code should be fixed (do not fix it yourself).
+4. **Save Report:**
+   - Write the findings using the `write` tool to `.jonggrang/.output/features/<active-feature-dir>/hardening-report.md`.
+
+## Completion Signal
+When the hardening report is saved, output exactly:
+
+HARDENING_REVIEW_COMPLETE

--- a/skills/library/frontend/auditing-interface-quality/SKILL.md
+++ b/skills/library/frontend/auditing-interface-quality/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: auditing-interface-quality
+description: Comprehensive UI/UX compliance check (A11y, performance, responsive).
+phase: 10 (Compliance)
+role: Reviewer
+---
+
+# Auditing Interface Quality
+
+**Role Constraints:** Reviewer (STRICTLY READ-ONLY for application code). You MAY NOT modify, fix, or write to application source code.
+**File Access:** Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`. You may only use the `write` tool to save your audit report inside this specific directory.
+
+## Objective
+Perform a systematic audit of the interface quality across accessibility (A11y), performance, theming, and responsive design.
+
+## Execution Steps
+
+1. **Discover Context:** Use `glob` and `read` to review the frontend components built or modified for the current feature.
+2. **Diagnostic Scan:**
+   - **Accessibility (A11y):** Check for contrast issues, missing ARIA roles, poor keyboard navigation, semantic HTML, and alt text.
+   - **Performance:** Look for layout thrashing, expensive animations, unoptimized images, or unnecessary re-renders.
+   - **Theming:** Look for hard-coded colors instead of design tokens, and broken dark mode implementations.
+   - **Responsive Design:** Check for fixed widths, touch target sizes (<44px), and horizontal scrolling issues on narrow viewports.
+3. **Compile Audit Report:**
+   - Document each issue with its Location, Severity (Critical/High/Medium/Low), Category, Impact, and Recommendation.
+   - Summarize the overall UI/UX compliance.
+4. **Save Report:**
+   - Write the final audit report using the `write` tool to `.jonggrang/.output/features/<active-feature-dir>/interface-audit.md`.
+
+## Completion Signal
+When the interface audit report is saved, output exactly:
+
+INTERFACE_AUDIT_COMPLETE

--- a/skills/library/security/auditing-security/SKILL.md
+++ b/skills/library/security/auditing-security/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: auditing-security
+description: Infrastructure-first security audit (OWASP, secrets, dependencies).
+phase: 10 (Compliance)
+role: Reviewer
+---
+
+# Auditing Security (CSO Mode)
+
+**Role Constraints:** Reviewer (STRICTLY READ-ONLY for application code). You MAY NOT modify, fix, or write to application source code.
+**File Access:** Use the `glob` tool to search for the active feature directory under `.jonggrang/.output/features/`. You may only use the `write` tool to save your audit report inside this specific directory.
+
+## Objective
+Act as Chief Security Officer. Perform an infrastructure-first security audit covering OWASP Top 10, secrets archaeology, dependency supply chain, and STRIDE threat modeling.
+
+## Execution Steps
+
+1. **Information Gathering (READ-ONLY):**
+   - Use `glob` to find target application files relevant to the feature.
+   - Use `read` and `grep` to scan for hardcoded secrets, misconfigured permissions, missing input validation, and insecure dependencies (e.g., check `package.json`, `.env.example`).
+   - Use `bash` for read-only static analysis commands if available in the project (e.g., `npm audit`, `pip-audit`). DO NOT execute code that modifies the workspace.
+2. **Analysis Dimensions:**
+   - **OWASP Top 10:** Injection, Broken Auth, Sensitive Data Exposure, etc.
+   - **STRIDE:** Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege.
+   - **Supply Chain:** Vulnerable packages or risky third-party integrations.
+3. **Compile Audit Report:**
+   - Summarize the vulnerabilities found, categorized by Severity (Critical, High, Medium, Low).
+   - Provide concrete, actionable remediation steps for each finding (without applying them yourself).
+4. **Save Report:**
+   - Write the final report using the `write` tool to `.jonggrang/.output/features/<active-feature-dir>/security-audit.md`.
+
+## Completion Signal
+When the audit report is successfully saved, output exactly:
+
+SECURITY_AUDIT_COMPLETE


### PR DESCRIPTION
Resolves #6.

This PR introduces the remaining core and library skills necessary to fully support the 16-phase Jonggrang Orchestrate workflow. 

### Additions:
- **Phase 3 (Discovery)**: `skills/core/shaping-requirements` (Lead)
- **Phase 5 (Complexity)**: `skills/core/breadboarding-workflow` (Lead)
- **Phase 6 (Brainstorm)**: `skills/core/reviewing-product-strategy` (Lead)
- **Phase 7 (Architect)**: `skills/core/reviewing-architecture` (Lead)
- **Phase 10 (Compliance)**: 
  - `skills/library/security/auditing-security`
  - `skills/library/backend/hardening-resilience`
  - `skills/library/backend/assessing-code-health`
  - `skills/library/frontend/auditing-interface-quality`
  *(All Phase 10 skills correctly restrict the Reviewer agent to **read-only** application analysis and audit report generation)*
- **Phase 16 (Complete)**: `skills/core/documenting-release` (Lead)

### Changes
All scripts and auto-executing bash logic from the original sources (gstack, impeccable) have been safely adapted for LLM agent use (relying on declarative `glob`, `read`, and `bash` tools usage) and include correct completion signals.