### PR TITLE
feat: add simplification phase (9) and clarity review checks

### DIFF
--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1798,7 +1798,15 @@ async function runOrchestrationLoop(featureId, manifest, manifestPath) {
     }
 
     // ── Build phase prompt ────────────────────────────────────────
-    const phaseContext = orchestration.buildPhaseContext(manifest, phaseNum);
+    let phaseContext;
+    if (phaseNum === orchestration.SIMPLIFY_PHASE) {
+      // Phase 9 (simplification) uses specialized prompt with file scope
+      phaseContext = orchestration.buildSimplifyPrompt(manifest, PROJECT_ROOT);
+    } else {
+      // All other phases use generic phase context
+      phaseContext = orchestration.buildPhaseContext(manifest, phaseNum);
+    }
+    
     const agentsContent = lib.fileExists(paths.agentsFile)
       ? fs.readFileSync(paths.agentsFile, 'utf8') : '';
     const progressContent = lib.fileExists(paths.progressFile)

--- a/lib/bot-reviewer/reviewer.js
+++ b/lib/bot-reviewer/reviewer.js
@@ -35,7 +35,7 @@ Respond ONLY with valid JSON — no markdown fences, no prose outside the JSON:
       "file": "relative/path/to/file.ext",
       "line": <integer or null>,
       "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO",
-      "type": "security" | "bug" | "performance" | "style" | "maintainability" | "clarity",
+      "type": "security" | "bug" | "performance" | "style" | "maintainability" | "clarity" | "conciseness",
       "message": "Concise description and suggested fix"
     }
   ]

--- a/lib/bot-reviewer/reviewer.js
+++ b/lib/bot-reviewer/reviewer.js
@@ -14,6 +14,17 @@ Analyze the diff and provide structured feedback covering:
 3. Performance problems
 4. Code quality and maintainability
 5. Missing error handling or edge cases
+6. Clarity and conciseness (see rules below)
+
+Clarity & conciseness rules:
+- Flag comments that merely restate what the code obviously does (e.g. "// increment counter" above "counter++")
+- Flag overly verbose variable/function names when a shorter name is equally clear
+- Flag nested ternaries — prefer switch statements or if/else chains for multiple conditions
+- Flag functions that mix unrelated concerns (single-responsibility violations)
+- Flag dead code, unreachable branches, or commented-out code blocks
+- Flag redundant abstractions (wrapper functions that add no value beyond the wrapped call)
+- Do NOT flag legitimate documentation comments (JSDoc, API docs, architectural notes)
+- Do NOT flag concise, well-named symbols — brevity is preferred when meaning is clear
 
 Respond ONLY with valid JSON — no markdown fences, no prose outside the JSON:
 {
@@ -24,7 +35,7 @@ Respond ONLY with valid JSON — no markdown fences, no prose outside the JSON:
       "file": "relative/path/to/file.ext",
       "line": <integer or null>,
       "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO",
-      "type": "security" | "bug" | "performance" | "style" | "maintainability",
+      "type": "security" | "bug" | "performance" | "style" | "maintainability" | "clarity",
       "message": "Concise description and suggested fix"
     }
   ]

--- a/lib/orchestration.js
+++ b/lib/orchestration.js
@@ -368,7 +368,7 @@ function listManifests(projectRoot) {
 }
 
 // ============================================================
-// PHASE 17 — SIMPLIFICATION PROMPT BUILDER
+// PHASE 9 — SIMPLIFICATION PROMPT BUILDER
 // ============================================================
 
 const SIMPLIFY_PHASE = 9;

--- a/lib/orchestration.js
+++ b/lib/orchestration.js
@@ -383,14 +383,28 @@ function getChangedFilesForSimplify(manifestPath, projectRoot) {
 
   // Try git diff first — most reliable
   try {
-    const result = require('child_process').execSync(
-      'git diff --name-only HEAD',
+    const execSync = require('child_process').execSync;
+    
+    // Get modified and added files (exclude deletions)
+    const diffResult = execSync(
+      'git diff --name-only --diff-filter=d HEAD',
       { cwd: projectRoot, encoding: 'utf8', timeout: 5000 }
     );
-    const changed = result.split('\n').filter(Boolean)
+    
+    // Get untracked files (new files not yet staged)
+    const untrackedResult = execSync(
+      'git ls-files --others --exclude-standard',
+      { cwd: projectRoot, encoding: 'utf8', timeout: 5000 }
+    );
+    
+    const changed = [
+      ...diffResult.split('\n').filter(Boolean),
+      ...untrackedResult.split('\n').filter(Boolean)
+    ]
       // Exclude .jonggrang/ orchestration files
       .filter(f => !f.startsWith('.jonggrang/'));
-    if (changed.length > 0) return changed;
+    
+    if (changed.length > 0) return [...new Set(changed)];
   } catch { /* fall through */ }
 
   // Fallback: read from manifest agent locked_files

--- a/lib/orchestration.js
+++ b/lib/orchestration.js
@@ -21,25 +21,26 @@ const PHASES = {
   6:  { name: 'brainstorming',       description: 'Design refinement with human-in-loop' },
   7:  { name: 'architecting',        description: 'Technical design AND task decomposition' },
   8:  { name: 'implementation',      description: 'Code development' },
-  9:  { name: 'design-verification', description: 'Verify implementation matches plan' },
-  10: { name: 'domain-compliance',   description: 'Domain-specific mandatory patterns' },
-  11: { name: 'code-quality',        description: 'Code review for maintainability' },
-  12: { name: 'test-planning',       description: 'Test strategy and plan creation' },
-  13: { name: 'testing',             description: 'Test implementation and execution' },
-  14: { name: 'coverage',            description: 'Verify test coverage meets threshold' },
-  15: { name: 'test-quality',        description: 'No low-value tests, correct assertions' },
-  16: { name: 'completion',          description: 'Final verification, PR, cleanup' },
+  9:  { name: 'simplification',      description: 'Clarity and conciseness improvements across changed files. Reduce complexity, eliminate redundancy, improve naming — never change behavior. Run tests after each change.' },
+  10: { name: 'design-verification', description: 'Verify implementation matches plan' },
+  11: { name: 'domain-compliance',   description: 'Domain-specific mandatory patterns' },
+  12: { name: 'code-quality',        description: 'Code review for maintainability' },
+  13: { name: 'test-planning',       description: 'Test strategy and plan creation' },
+  14: { name: 'testing',             description: 'Test implementation and execution' },
+  15: { name: 'coverage',            description: 'Verify test coverage meets threshold' },
+  16: { name: 'test-quality',        description: 'No low-value tests, correct assertions' },
+  17: { name: 'completion',          description: 'Final verification, PR, cleanup' },
 };
 
 // Phases that are computationally expensive — compaction gate checks before these
-const HEAVY_PHASES = new Set([3, 8, 13]);
+const HEAVY_PHASES = new Set([3, 8, 9, 14]);
 
 // Phases skipped per work type
 const PHASE_SKIP_MAP = {
-  BUGFIX:  new Set([5, 6, 7, 9, 12]),   // no architecture, no brainstorming
-  SMALL:   new Set([5, 6, 7, 9]),        // no complexity analysis
-  MEDIUM:  new Set([]),                   // nothing skipped
-  LARGE:   new Set([]),                   // all 16 phases
+  BUGFIX:  new Set([5, 6, 7, 9, 10, 13]),   // no architecture, no brainstorming, no simplification, no design-verification
+  SMALL:   new Set([5, 6, 7, 10]),              // no complexity analysis, no design-verification (simplification runs for SMALL+)
+  MEDIUM:  new Set([]),                           // nothing skipped
+  LARGE:   new Set([]),                           // all 17 phases including simplification
 };
 
 // ============================================================
@@ -94,7 +95,8 @@ function getActivePhases(workType) {
   const skip = PHASE_SKIP_MAP[workType] || new Set();
   return Object.keys(PHASES)
     .map(Number)
-    .filter(n => !skip.has(n));
+    .filter(n => !skip.has(n))
+    .sort((a, b) => a - b);
 }
 
 // ============================================================
@@ -366,6 +368,97 @@ function listManifests(projectRoot) {
 }
 
 // ============================================================
+// PHASE 17 — SIMPLIFICATION PROMPT BUILDER
+// ============================================================
+
+const SIMPLIFY_PHASE = 9;
+
+/**
+ * Get changed files since implementation started.
+ * Uses git diff to detect files modified during phase 8.
+ * Falls back to agent locked_files from manifest.
+ */
+function getChangedFilesForSimplify(manifestPath, projectRoot) {
+  const files = [];
+
+  // Try git diff first — most reliable
+  try {
+    const result = require('child_process').execSync(
+      'git diff --name-only HEAD',
+      { cwd: projectRoot, encoding: 'utf8', timeout: 5000 }
+    );
+    const changed = result.split('\n').filter(Boolean)
+      // Exclude .jonggrang/ orchestration files
+      .filter(f => !f.startsWith('.jonggrang/'));
+    if (changed.length > 0) return changed;
+  } catch { /* fall through */ }
+
+  // Fallback: read from manifest agent locked_files
+  try {
+    const manifest = readManifest(manifestPath);
+    if (manifest) {
+      for (const agent of Object.values(manifest.agents || {})) {
+        if (agent.role === 'developer' && agent.locked_files) {
+          files.push(...agent.locked_files);
+        }
+      }
+    }
+  } catch { /* ignore */ }
+
+  return [...new Set(files)];
+}
+
+/**
+ * Build the simplification phase prompt, adapted from pi-simplify.
+ * Instructs the developer agent to review changed files and apply
+ * clarity/conciseness improvements without changing behavior.
+ */
+function buildSimplifyPrompt(manifest, projectRoot) {
+  const manifestPath = getManifestPath(projectRoot, manifest.feature_id);
+  const changedFiles = getChangedFilesForSimplify(manifestPath, projectRoot);
+
+  const fileList = changedFiles.length > 0
+    ? changedFiles.map(f => `- ${f}`).join('\n')
+    : '(auto-detected from git diff — review all files modified in this feature)';
+
+  const phaseContext = buildPhaseContext(manifest, SIMPLIFY_PHASE);
+
+  return `## Phase 9 — Simplification
+
+${phaseContext}
+
+Review the changed files from the implementation phase and apply simplification improvements.
+
+## Principles
+
+- **Preserve functionality**: Never change what the code does. All existing tests must continue to pass.
+- **Apply project standards**: Follow conventions from AGENTS.md and CLAUDE.md.
+- **Enhance clarity**: Reduce unnecessary complexity and nesting. Eliminate redundant code and abstractions. Improve variable and function names. Consolidate related logic. Remove comments that describe obvious code.
+- **Avoid nested ternary operators**: prefer switch statements or if/else chains for multiple conditions.
+- **Maintain balance**: Do not over-simplify. Avoid overly clever solutions that are hard to understand. Do not combine too many concerns into single functions. Do not remove helpful abstractions. Prioritize readability over fewer lines.
+
+## Scope
+
+Only review and modify these files:
+${fileList}
+
+## Process
+
+1. Read each file listed above
+2. Identify concrete improvements (dead code, unclear names, redundant logic, inconsistent patterns)
+3. Apply changes one file at a time
+4. After all changes, run existing tests to verify nothing is broken
+5. Summarize what you changed and why
+
+Do NOT add new features, change public APIs, or refactor code outside the listed files.
+
+## Role
+
+You are a **Developer** in this phase — you can edit files. After completing all improvements, output:
+IMPLEMENTATION_COMPLETE`;
+}
+
+// ============================================================
 // PHASE SUMMARY FOR PROMPTS
 // ============================================================
 
@@ -414,4 +507,6 @@ module.exports = {
   findIncompleteManifest,
   listManifests,
   buildPhaseContext,
+  buildSimplifyPrompt,
+  SIMPLIFY_PHASE,
 };

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -53,6 +53,19 @@ Depends on which phase you're called for:
 - [ ] No commented-out code
 - [ ] DRY — no duplicated logic
 - [ ] Error cases handled
+- [ ] **Clarity check:** No comments that restate obvious code
+- [ ] **Conciseness check:** Function names are precise not verbose; no redundant abstractions
+- [ ] **No nested ternaries** — prefer switch or if/else for multiple conditions
+- [ ] **Single responsibility** — functions don't mix unrelated concerns
+
+#### Phase 11 — Clarity & Conciseness Review Notes
+
+When flagging clarity violations:
+- Use `type: "clarity"` for readability issues (obvious comments, nested ternaries, dead code)
+- Use `type: "conciseness"` for verbosity issues (overly long names, redundant abstractions)
+- Do NOT flag legitimate documentation (JSDoc, API docs, architectural notes)
+- Do NOT flag concise, well-named symbols — brevity is preferred when meaning is clear
+- Wrapper functions that add no value beyond the wrapped call are `type: "conciseness"`
 
 ### Phase 15 — Test Quality
 - [ ] No tests that always pass (vacuous tests)
@@ -94,6 +107,7 @@ The bug will be logged to `.jonggrang/.output/features/<feature_id>/bugs.md` and
         "severity": "required",
         "file": "src/auth/auth.controller.ts",
         "line": 42,
+        "type": "clarity|conciseness|design|security|quality|testing",
         "message": "Missing input validation on /login endpoint"
       }
     ],

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -54,7 +54,7 @@ Depends on which phase you're called for:
 - [ ] DRY — no duplicated logic
 - [ ] Error cases handled
 - [ ] **Clarity check:** No comments that restate obvious code
-- [ ] **Conciseness check:** Function names are precise not verbose; no redundant abstractions
+- [ ] **Conciseness check:** Function names are precise, not verbose; no redundant abstractions
 - [ ] **No nested ternaries** — prefer switch or if/else for multiple conditions
 - [ ] **Single responsibility** — functions don't mix unrelated concerns
 

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -27,26 +27,26 @@ Depends on which phase you're called for:
 
 | Phase | Focus |
 |---|---|
-| 9 (Design Verification) | Does implementation match the architecture plan? |
-| 10 (Domain Compliance) | Domain patterns: REST conventions, security headers, naming |
-| 11 (Code Quality) | Maintainability, complexity, naming, duplication |
+| 10 (Design Verification) | Does implementation match the architecture plan? |
+| 11 (Domain Compliance) | Domain patterns: REST conventions, security headers, naming |
+| 12 (Code Quality) | Maintainability, complexity, naming, duplication |
 | 15 (Test Quality) | Are tests meaningful? No mock abuse, correct assertions |
 
 ## Review Checklist by Phase
 
-### Phase 9 — Design Verification
+### Phase 10 — Design Verification
 - [ ] All tasks in the architecture plan are implemented
 - [ ] File structure matches plan's `files` list
 - [ ] No extra scope added (scope creep)
 - [ ] Function signatures match design
 
-### Phase 10 — Domain Compliance
+### Phase 11 — Domain Compliance
 - [ ] REST: correct HTTP verbs, status codes, plural nouns
 - [ ] Auth: JWT validated on all protected routes
 - [ ] Database: no raw SQL injection vectors, parameterized queries
 - [ ] API: request validated with schema before processing
 
-### Phase 11 — Code Quality
+### Phase 12 — Code Quality
 - [ ] Functions < 40 lines
 - [ ] No magic numbers/strings (use constants)
 - [ ] Meaningful variable names
@@ -58,7 +58,7 @@ Depends on which phase you're called for:
 - [ ] **No nested ternaries** — prefer switch or if/else for multiple conditions
 - [ ] **Single responsibility** — functions don't mix unrelated concerns
 
-#### Phase 11 — Clarity & Conciseness Review Notes
+#### Phase 12 — Clarity & Conciseness Review Notes
 
 When flagging clarity violations:
 - Use `type: "clarity"` for readability issues (obvious comments, nested ternaries, dead code)
@@ -67,7 +67,7 @@ When flagging clarity violations:
 - Do NOT flag concise, well-named symbols — brevity is preferred when meaning is clear
 - Wrapper functions that add no value beyond the wrapped call are `type: "conciseness"`
 
-### Phase 15 — Test Quality
+### Phase 16 — Test Quality
 - [ ] No tests that always pass (vacuous tests)
 - [ ] Assertions test behavior, not implementation details
 - [ ] No mocking of domain logic (only I/O)


### PR DESCRIPTION
## Summary

Adds clarity & conciseness review across 3 layers:

### Phase 9 — Simplification (new orchestration phase)
- Runs after implementation (phase 8), before design-verification (phase 10)
- Developer role: applies clarity improvements, runs tests after each change
- Adapts [pi-simplify](https://github.com/MattDevy/pi-extensions/tree/main/packages/pi-simplify) principles — improve naming, reduce complexity, remove obvious comments, eliminate dead code. Never changes behavior.
- Runs for SMALL/MEDIUM/LARGE, skipped for BUGFIX
- Detects changed files via `git diff`, falls back to manifest agent data

### Renumbered phases (9→17)
- Phase 9 = simplification
- Old 9→16 shifted to 10→17
- Heavy phases updated: 3, 8, 9, 14
- PHASE_SKIP_MAP updated accordingly

### Bot reviewer (GitLab MR)
- New section 6: Clarity & Conciseness with 7 specific rules
- New issue type: `"clarity"`

### Reviewer agent template
- Phase 11 checklist extended with 4 clarity items
- New section: Clarity & Conciseness Review Notes (usage guide for `clarity` vs `conciseness` violation types)

## Files changed
| File | Changes |
|---|---|
| `lib/orchestration.js` | +123 lines — phase 9, prompt builder, file detection |
| `lib/bot-reviewer/reviewer.js` | +13 lines — clarity section in system prompt |
| `templates/agents/reviewer.md` | +14 lines — checklist & notes |