### PR TITLE
fix(review): address PR #29 review findings --model/--effort gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Inside the chat, use `/` commands to trigger jonggrang workflow operations witho
 
 All other Pi built-in commands (`/compact`, `/help`, Ctrl+P model cycling, etc.) work as normal.
 
-Security hooks (`hooks/jonggrang/jonggrang-extension.ts`) are loaded automatically on every `jonggrang agent` session — no manual installation needed. The extension blocks access to `.env` and credential files, intercepts secret-leaking bash commands, sanitizes sensitive output, and enforces the feedback loop gate.
+Security hooks (`hooks/pi/jonggrang-extension.ts`) are loaded automatically on every `jonggrang agent` session — no manual installation needed. The extension blocks access to `.env` and credential files, intercepts secret-leaking bash commands, sanitizes sensitive output, and enforces the feedback loop gate.
 
 > Requires the jonggrang engine (`npm install -g @earendil-works/pi-coding-agent`). Run `jonggrang login` first to configure a provider.
 
@@ -477,7 +477,7 @@ Hooks enforce quality gates outside the LLM's context. The same rules apply rega
 | 8 | Stop | `Stop` | `session.idle` | `agent_end` | Block exit until review + tests pass |
 | 8 | Stop | `Stop` | `session.idle` | `agent_end` | Final quality gate (defense in depth) |
 
-Jonggrang hooks live in `hooks/jonggrang/jonggrang-extension.ts` and are loaded automatically via `--extension` on every `jonggrang agent` invocation — no separate installation step required.
+Jonggrang hooks live in `hooks/pi/jonggrang-extension.ts` and are loaded automatically via `--extension` on every `jonggrang agent` invocation — no separate installation step required.
 
 **Feedback Loop (Level 2 enforcement):**
 

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1175,6 +1175,7 @@ async function cmdApprove(args, opts = {}) {
   if (!TOOL_SET && !process.env.JONGGRANG_TOOL) {
     TOOL = lib.readConfig(CONFIG_FILE, 'tool', DEFAULT_TOOL);
   }
+  resolveModelAndEffort();
 
   const planContent = fs.readFileSync(PLAN_FILE, 'utf8');
 
@@ -1347,6 +1348,7 @@ async function cmdBug(args) {
   if (!TOOL_SET && !process.env.JONGGRANG_TOOL) {
     TOOL = lib.readConfig(CONFIG_FILE, 'tool', DEFAULT_TOOL);
   }
+  resolveModelAndEffort();
 
   const isInteractiveTTY = process.stdin.isTTY && process.stdout.isTTY;
   const jonggrangDir = path.join(PROJECT_ROOT, '.jonggrang');
@@ -1717,6 +1719,7 @@ async function cmdOrchestrate(descriptionParts) {
   const description = descriptionParts.join(' ').trim();
 
   checkDeps();
+  resolveModelAndEffort();
 
   // ── Check for resume (must come before empty-description guard) ──
   if (ORCHESTRATE_RESUME) {
@@ -1863,7 +1866,7 @@ async function runOrchestrationLoop(featureId, manifest, manifestPath) {
     }
 
     // ── Run agent ─────────────────────────────────────────────────
-    const exitCode = await lib.runAgent(prompt, activeTool, activeMode, PROJECT_ROOT, { debug: DEBUG });
+    const exitCode = await lib.runAgent(prompt, activeTool, activeMode, PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
 
     if (exitCode !== 0) {
       logWarn(`Phase ${phaseNum} agent exited with code ${exitCode}`);

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -1150,7 +1150,8 @@ function runAgent(prompt, tool, permMode, projectRoot, options = {}) {
         if (!line.trim()) return;
         debugLine(line);
         let obj;
-        try { obj = JSON.parse(line); } catch {
+        try { obj = JSON.parse(line); } catch (err) {
+          process.stderr.write(`[codex] JSON parse error: ${err.message}\n  line: ${line.slice(0, 200)}\n`);
           process.stdout.write(line + '\n');
           atLineStart = true;
           return;
@@ -1171,7 +1172,13 @@ function runAgent(prompt, tool, permMode, projectRoot, options = {}) {
             }
           } else if (item.type === 'function_call') {
             const name   = item.name || '?';
-            const args   = (() => { try { return JSON.parse(item.arguments || '{}'); } catch { return {}; } })();
+            const args = (() => {
+              try { return JSON.parse(item.arguments || '{}'); }
+              catch (err) {
+                process.stderr.write(`[codex] function_call arguments parse error: ${err.message}\n  arguments: ${(item.arguments || '').slice(0, 200)}\n`);
+                return {};
+              }
+            })();
             const detail = args.command || args.path || args.file_path || args.query || args.url || '';
             if (!atLineStart) process.stdout.write('\n');
             process.stdout.write(`\x1b[90m▸ ${name}\x1b[0m`);


### PR DESCRIPTION
## Summary

Fixes review gaps from PR #29 (`feat(cli): add --model and --effort to plan, work, review`).

### Changes

**`bin/jonggrang.js`**
- `cmdApprove`: add `resolveModelAndEffort()` so config-based `model`/`effort` are respected when decomposing plans into tasks.
- `cmdBug convert`: add `resolveModelAndEffort()` so config-based `model`/`effort` are respected when converting bugs to tasks.
- `cmdOrchestrate`: add `resolveModelAndEffort()` and pass `model`/`effort` into `runOrchestrationLoop` so the orchestrate subcommand respects model/effort pinning.
- `runOrchestrationLoop`: pass `model: MODEL, effort: EFFORT` to `runAgent`.

**`lib/jonggrang.js`**
- Codex backend: log JSON parse errors to stderr instead of silently swallowing. Malformed lines are still echoed to stdout (stream boundary behavior), but failures are now visible.

**`lib/hooks.js`**
- Remove dead `codex_handler` entries from all 8 `HOOK_DEFINITIONS`. Codex CLI has no plugin/extension system; these keys were never consumed by any hook generator.

**`README.md`**
- Revert `hooks/jonggrang/` back to `hooks/pi/` to match actual filesystem and code references.