### PR TITLE
docs: restruktur README, tambah onboarding docs & kontributor

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,14 @@
+# Authors
+
+## Porcupine Team
+
+Jonggrang dibuat dan dikelola oleh **Porcupine Team**.
+
+### Active Contributors
+
+- **Eka Irawan (Ibnu)** <anak10thn@gmail.com> — arsitektur, orchestration engine, skill system, CLI, web dashboard
+- **Ahmad Anshorimuslim Syuhada (Ans)** <ans4175@gmail.com> — arsitektur, skill libraries, Pi SDK integration, TUI, hooks, refactor, dokumentasi
+
+---
+
+_Untuk daftar kontributor lengkap berdasarkan commit, lihat `git shortlog -sn`._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,451 +1,137 @@
 # Contributing to Jonggrang
 
-Thank you for your interest in contributing to Jonggrang! This guide covers everything you need to get started.
+Senang kamu tertarik kontribusi! Panduan singkat supaya prosesnya lancar.
+
+---
+
+## Prinsip Utama
+
+Jonggrang adalah alat untuk **mendisiplinkan AI coding agent**. Maka kode Jonggrang sendiri juga harus disiplin. Setiap kontribusi harus:
+
+1. **Punya issue dulu** — diskusikan sebelum coding. Hindari PR yang datang tiba-tiba tanpa konteks.
+2. **Satu PR, satu concern** — jangan gabung bugfix + fitur baru + refactor dalam satu PR.
+3. **Test kalau memungkinkan** — terutama untuk `lib/` dan perubahan logic.
+4. **Update docs kalau relevan** — kalau kamu ubah behavior, update `docs/` yang terkait.
 
 ---
 
 ## Quick Setup
 
-### Prerequisites
-
-- **Node.js** >= 18.0.0
-- **npm** (comes with Node.js)
-- **git**
-- **jq** (`brew install jq` on macOS, `apt install jq` on Ubuntu)
-- An AI coding agent (at least one):
-  - [OpenCode](https://opencode.ai/) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-
-### Install & Build
-
 ```bash
-# Clone the repo
-git clone https://github.com/porcupine/jonggrang.git
+git clone git@github.com:porcupine-md/jonggrang.git
 cd jonggrang
-
-# Install root + client dependencies
 make install
-
-# Or manually:
-npm install && cd client && npm install
-
-# Build the web dashboard client
-npm run build
+make build
 ```
 
-### Verify
-
-```bash
-# Check the CLI works
-node bin/jonggrang.js version
-
-# Run the dev server
-npm run dev:server    # starts Express + Socket.io on :3001
-
-# Run the dashboard client (optional, for web UI development)
-npm run dev:client    # starts Vite dev server for client/
-```
-
-### Release Process
-
-```bash
-make release          # bump patch version + rebuild (default)
-make release BUMP=minor     # bump minor
-make release-major    # bump major
-make build-binary     # compile standalone binary with Bun
-```
+→ [Full development setup guide](docs/QUICKSETUP.md)
 
 ---
 
-## Architecture Overview
+## Workflow Kontribusi
 
-Jonggrang is built on a **Thin Agent / Fat Platform** model. Understanding this distinction is fundamental to contributing effectively.
+### 1. Pilih atau buat issue
 
-### The Five-Layer Stack
+Cek [GitHub Issues](https://github.com/porcupine-md/jonggrang/issues). Kalau belum ada yang cocok, buat issue baru. Jelaskan:
+- Apa yang ingin diubah/diperbaiki
+- Kenapa perlu
+- Kalau fitur baru: bagaimana perilaku yang diharapkan
+
+### 2. Branch
+
+```bash
+git checkout -b feat/nama-fitur     # fitur baru
+git checkout -b fix/nama-bug        # bugfix
+git checkout -b docs/apa-yang-diupdate  # dokumentasi
+```
+
+### 3. Commit
+
+Kami pakai conventional commits:
 
 ```
-LAYER 1: AGENT          — Stateless workers (<150 lines each)
-LAYER 2: SKILL           — Two-tier progressive knowledge loading
-LAYER 3: ORCHESTRATION   — 16-phase state machine with MANIFEST.yaml
-LAYER 4: HOOK            — Deterministic enforcement (8 layers of defense)
-LAYER 5: INFRASTRUCTURE  — Token gates, dirty bits, file locks
+feat: tambah support --deep mode untuk plan staging
+fix: compaction gate crash saat context window kosong
+docs: update QUICKSTART dengan troubleshooting
+refactor: ekstrak feedback loop ke file sendiri
 ```
 
-### Key Architectural Principle
+Bahasa commit: **campur Indonesia/Inggris boleh**, yang penting jelas dan deskriptif.
 
-**Coordinators plan. Executors implement. Never both.**
+### 4. Test & check
 
-- Roles with `Task` tool (Lead, TestLead) cannot edit files
-- Roles with `Edit`/`Write` (Developer, Tester) cannot spawn sub-agents
-- Reviewer is strictly read-only
+```bash
+npm test            # run test suite
+npm run check       # syntax + structure check
+```
 
-### Codebase Map
+### 5. Buka Pull Request
 
-| Path | What it is |
-|------|-----------|
-| `bin/jonggrang.js` | CLI entry point — parses commands, dispatches to lib/ |
-| `server.js` | Express + Socket.io server for web dashboard |
-| `lib/jonggrang.js` | Core logic: `init`, `plan`, `work`, `status`, `review` commands |
-| `lib/orchestration.js` | 16-phase pipeline engine — the "kernel" |
-| `lib/gateway.js` | Skill routing: maps task intent to skill file paths |
-| `lib/feedback.js` | Dirty bit tracking + feedback loop state machine |
-| `lib/compaction.js` | Context usage measurement + compaction gate thresholds |
-| `lib/hooks.js` | Hook installation for Claude Code and OpenCode |
-| `lib/roles.js` | Five role definitions (lead, developer, reviewer, test-lead, tester) |
-| `lib/locks.js` | File ownership locking for parallel worktree execution |
-| `hooks/claude/*.sh` | Eight enforcement layers as bash scripts for Claude Code |
-| `hooks/opencode/plugin.js` | Same enforcement logic as OpenCode plugin (JavaScript) |
-| `skills/core/*/SKILL.md` | Tier 1 skills — always loaded into agent prompts |
-| `skills/library/*/SKILL.md` | Tier 2 skills — JIT loaded via Gateway routing |
-| `templates/agents/*.md` | Role templates: lead.md, developer.md, reviewer.md, test-lead.md, tester.md |
-| `templates/AGENTS.md.template` | Template for the project AGENTS.md |
-| `templates/CLAUDE.md.template` | Template for Claude Code CLAUDE.md |
-| `client/src/` | Vue.js web dashboard (Kanban board, logs, phase tracking) |
-| `docs/` | Full documentation |
+Deskripsi PR harus menjawab:
+- **What** — apa yang berubah
+- **Why** — kenapa berubah
+- **How to test** — langkah verifikasi
+
+Setelah PR dibuka, maintainer akan review dalam 1-3 hari kerja.
 
 ---
 
-## How to Contribute
+## Panduan Teknis
 
-### 1. Fork and Branch
+### Area kontribusi dan file terkait
 
-```bash
-# Fork on GitHub, then:
-git clone https://github.com/YOUR_USERNAME/jonggrang.git
-cd jonggrang
-git checkout -b feat/my-feature
-```
+| Area | File | Cocok kalau kamu... |
+|------|------|--------------------|
+| CLI command baru | `bin/jonggrang.js`, `lib/jonggrang.js` | Mau tambah `jonggrang xyz` |
+| Orchestration phase | `lib/orchestration.js` | Mau ubah alur kerja |
+| Hook sistem | `hooks/{claude,opencode,pi}/` | Mau tambah enforcement rules |
+| Core skill | `skills/core/<nama>/SKILL.md` | Mau tambah prompt template |
+| Library skill | `skills/library/<domain>/<nama>/SKILL.md` | Mau tambah domain knowledge |
+| Dashboard UI | `client/src/` | Mau ubah tampilan web |
+| Dashboard API | `server.js` | Mau tambah endpoint |
+| Template init | `templates/` | Mau ubah hasil `jonggrang init` |
+| Dokumentasi | `docs/` | Mau perbaiki/terjemahkan docs |
 
-Use conventional branch prefixes:
+### Struktur skill
 
-| Prefix | Use for |
-|--------|---------|
-| `feat/` | New features |
-| `fix/` | Bug fixes |
-| `docs/` | Documentation changes |
-| `refactor/` | Code restructuring |
-| `skill/` | New or updated skills |
-| `hook/` | New or updated hooks |
+Kalau bikin skill baru, gunakan format:
 
-### 2. Make Changes
-
-#### Changing Core Logic (`lib/`)
-
-The `lib/` modules are plain Node.js (no TypeScript, no build step). Key points:
-
-- `lib/jonggrang.js` is the main orchestrator. Commands like `plan`, `work`, `review` are defined here.
-- `lib/orchestration.js` handles the 16-phase pipeline. Each phase is numbered (1-16) and has a defined role.
-- `lib/gateway.js` uses keyword-based routing to map task descriptions to skill paths. If you add a new library skill, you must update the routing table here.
-- `lib/feedback.js` manages the domain-based dirty bit state machine. Domains are detected by file path patterns.
-- `lib/compaction.js` reads session transcripts to calculate token usage.
-
-#### Adding a New Skill
-
-Skills are markdown prompt templates. There are two tiers:
-
-**Core Skill** (loaded into every agent prompt):
-
-```bash
-mkdir -p skills/core/my-skill
-cat > skills/core/my-skill/SKILL.md << 'EOF'
+```markdown
 ---
-name: my-skill
-description: What this skill does (one line)
-type: scaffold | transform | validate | generate | orchestrate
+name: nama-skill
+description: Apa yang dilakukan skill ini
+type: scaffold
 tier: core
-project_types: [web-app, api, library, cli, tui]
-trigger: "natural language trigger phrases"
+project_types: [web-app, api]
+trigger: "kata kunci yang memicu skill ini"
 ---
 
 ## Context
-Background information for the agent. Use {{variable}} for interpolation.
-Available variables: {{project_name}}, {{project_type}}, {{stack}}, {{test_framework}}
+Background info yang dibutuhkan agent.
 
 ## Instructions
-1. Step one
-2. Step two
+1. Langkah pertama
+2. Langkah kedua
 
 ## Validation
-- [ ] Check one
-- [ ] Check two
-EOF
+- [ ] Cek yang harus dipenuhi
 ```
 
-**Library Skill** (JIT loaded via Gateway):
+### Gaya kode
 
-```bash
-mkdir -p skills/library/backend/my-pattern
-cat > skills/library/backend/my-pattern/SKILL.md << 'EOF'
----
-name: my-pattern
-description: Deep domain knowledge about X
-type: pattern
-tier: library
-domain: backend
-trigger: "specific keywords that trigger gateway routing"
----
-
-## Context
-Deep domain knowledge here.
-
-## Instructions
-1. Step one
-
-## Validation
-- [ ] Check one
-EOF
-```
-
-After adding a library skill, update the corresponding Gateway:
-
-1. Add the skill to the routing table in `skills/core/gateway-{domain}/SKILL.md`
-2. Update the keyword matching in `lib/gateway.js`
-
-**Skill Design Rules:**
-
-- Core skills: keep under 500 lines
-- Library skills: as deep as needed (they're loaded on-demand)
-- Every skill MUST have frontmatter, Context, Instructions, and Validation sections
-- Use `{{variable}}` interpolation for project config values
-- Triggers should be specific enough to avoid false positives
-
-#### Adding or Modifying Hooks
-
-Hooks are the enforcement layer. There are two hook platforms:
-
-- **Claude Code**: Bash scripts in `hooks/claude/*.sh`
-- **OpenCode**: JavaScript plugin in `hooks/opencode/plugin.js`
-
-The eight enforcement layers:
-
-| Layer | Mechanism | Purpose |
-|-------|-----------|---------|
-| 1 | CLAUDE.md / AGENTS.md | Full ruleset loaded at session start |
-| 2 | Core Skills | Procedural workflows |
-| 3 | Agent Definitions | Role behavior, tool restrictions |
-| 4 | PromptSubmit hooks | Pre-validate prompts |
-| 5 | PreToolUse hooks | Block before action (agent-first, compaction gate) |
-| 6 | PostToolUse hooks | Track modifications (dirty bit) |
-| 7 | SubagentStop hooks | Block premature exit (output enforcement) |
-| 8 | Stop hooks | Block exit until review + tests pass |
-
-When modifying hooks, ensure behavioral parity between Claude Code and OpenCode implementations.
-
-#### Adding Agent Role Templates
-
-Edit files in `templates/agents/`. Key rules:
-
-- Agent prompts must be strictly under 150 lines
-- Must include role-specific tool restrictions
-- Must include the completion signal protocol
-- Must reference the Gateway for skill resolution
-
-### 3. Test Your Changes
-
-Jonggrang uses a manual validation approach for most changes. For each change:
-
-1. **Core logic changes**: Run the relevant command end-to-end:
-
-```bash
-# Test init
-node bin/jonggrang.js init --name test-project --type api --stack express-typescript --autonomy balanced --force
-
-# Test work loop
-node bin/jonggrang.js plan "simple feature"
-node bin/jonggrang.js work --dry-run
-
-# Test orchestrate
-node bin/jonggrang.js orchestrate --dry-run "fix a bug"
-
-# Test dashboard
-node bin/jonggrang.js web --port 8080 --no-open
-```
-
-2. **Skill changes**: Test via the Gateway:
-
-```bash
-node -e "
-const gw = require('./lib/gateway');
-const r = gw.buildGatewayResponse('YOUR TEST DESCRIPTION', './skills');
-console.log(r);
-"
-```
-
-3. **Hook changes**: Create a test project and verify the hook fires correctly:
-
-```bash
-# Install hooks to a test project
-node bin/jonggrang.js init --name hook-test --type api --tool claude --force
-# Check the generated settings
-cat .claude/settings.json
-# Verify hook scripts are executable
-ls -la hooks/claude/
-```
-
-### 4. Commit
-
-Use conventional commit messages:
-
-```
-feat(orchestration): add phase skip logic for BUGFIX work type
-fix(gateway): correct keyword routing for React hooks
-docs(readme): add web dashboard section
-skill(auth): add JWT refresh token flow
-hook(feedback): fix domain detection for monorepo paths
-```
-
-Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `skill`, `hook`
-
-### 5. Push and Create PR
-
-```bash
-git push origin feat/my-feature
-```
-
-Create a Pull Request with:
-
-- **Description**: What changed and why
-- **Testing**: How you verified the change
-- **Docs**: Whether documentation needs updating (and which files)
+- **JavaScript plain**, bukan TypeScript (kecuali `hooks/pi/` yang emang `.ts`)
+- **Jangan over-engineer** — fungsi kecil, satu tanggung jawab
+- **Nama yang jelas** — `compactionGate.js` lebih baik dari `util2.js`
+- **Komentar sparingly** — kode yang bersih menjelaskan dirinya sendiri
 
 ---
 
-## Code Conventions
+## Butuh Bantuan?
 
-### General
-
-- **Language**: Plain Node.js for `lib/` and `server.js`. No TypeScript transpilation step — the project runs directly with `node`.
-- **Client**: Vue 3 with Vite for the web dashboard (`client/src/`).
-- **Style**: 4-space indentation, semicolons, single quotes.
-- **No `any` types** (when migrating to TypeScript in future).
-- **Error handling**: Always include meaningful error messages. Never swallow errors silently.
-
-### Module Structure
-
-Each module in `lib/` exports functions or a single object. No classes — prefer functional style:
-
-```javascript
-// lib/something.js
-const fs = require('fs');
-const path = require('path');
-
-function doSomething(input) {
-  // ...
-  return result;
-}
-
-module.exports = { doSomething };
-```
-
-### Skill Markdown Conventions
-
-- Frontmatter must be valid YAML between `---` delimiters
-- Use `{{variable}}` interpolation for dynamic values (resolved from `.jonggrang/jonggrang.json`)
-- Validation sections use `- [ ]` checklist syntax
-- Keep core skills focused; deep domain knowledge goes in library skills
-
-### Hook Conventions
-
-- Bash hooks must be executable (`chmod +x`)
-- Exit code 0 = allow, exit code 2 = block
-- Output JSON to stdout for structured feedback
-- OpenCode plugin mirrors all Claude Code hook behavior
-- Never put business logic in hooks that belongs in skills or lib/
-
----
-
-## Project Files Understanding
-
-When contributing, you'll encounter these key files in any Jonggrang-managed project:
-
-| File | Who writes | Purpose |
-|------|-----------|---------|
-| `AGENTS.md` | Human (curated) | Project conventions, patterns, gotchas — the single most important file for output quality |
-| `.jonggrang/jonggrang.json` | `jonggrang init` | Project config: tool, mode, work settings, hooks, testing |
-| `.jonggrang/jonggrang-tasks.json` | `jonggrang plan` | Task board state with dependencies, files, and status |
-| `.jonggrang/progress.txt` | Agent (auto) | Append-only learnings log — prevents repeating mistakes |
-| `.jonggrang/.output/features/*/MANIFEST.yaml` | Orchestrator | Phase state for orchestrate mode — survives session resets |
-
-**Golden Rule**: Agents propose changes to `AGENTS.md` via `.jonggrang/progress.txt`, but humans curate `AGENTS.md`. Never let an agent write directly to `AGENTS.md`.
-
----
-
-## Common Contribution Scenarios
-
-### "I want to add a new library skill"
-
-1. Create `skills/library/{domain}/{skill-name}/SKILL.md` with proper frontmatter
-2. Add keyword entries to the appropriate gateway (`skills/core/gateway-{domain}/SKILL.md`)
-3. Update the routing table in `lib/gateway.js`
-4. Test via Gateway resolution: `node -e "const gw = require('./lib/gateway'); ..."`
-5. Update `docs/SKILLS.md` catalog
-
-### "I want to add a new hook enforcement"
-
-1. Write the bash script in `hooks/claude/your-hook.sh`
-2. Write the equivalent JavaScript logic in `hooks/opencode/plugin.js`
-3. Register the hook in `hooks/claude/settings.json`
-4. Update the enforcement layer documentation in:
-   - `README.md` (Platform Architecture section)
-   - `docs/WORKFLOW.md` (Hook System section)
-   - `docs/ORCHESTRATION.md` (Eight-Layer Defense section)
-5. Test by creating a test project and verifying the hook fires
-
-### "I want to add a new orchestration phase"
-
-1. Update `lib/orchestration.js` — add phase definition
-2. Update `lib/roles.js` — add role mapping for the phase
-3. Update `templates/agents/` — add role template if new role
-4. Update phase skipping logic for work types
-5. Update `MANIFEST.yaml` schema in docs
-6. Update `docs/WORKFLOW.md` and `docs/JONGGRANG.md` phase tables
-7. Update `SKILL.md` role mapping section
-
-### "I want to add a new command"
-
-1. Add the command handler in `lib/jonggrang.js`
-2. Wire it up in `bin/jonggrang.js`
-3. Add it to the CLI help text
-4. Update `README.md` Commands section
-5. Add it to `SKILL.md` Commands Reference
-
-### "I want to fix a bug in the feedback loop"
-
-1. Understand the state machine in `lib/feedback.js`
-2. The dirty bit state lives in `.jonggrang/.ephemeral/feedback-loop-state.json`
-3. Domain detection is pattern-based: file path -> domain mapping
-4. The feedback loop hooks are in `hooks/claude/feedback-loop.sh`
-5. Ensure both Claude Code and OpenCode implementations stay in sync
-
----
-
-## Debugging Tips
-
-- **Dry run first**: `jonggrang work --dry-run` shows the prompt without executing
-- **Verbose mode**: Set `JONGGRANG_VERBOSE=1` for detailed logging
-- **Check MANIFEST**: `cat .jonggrang/.output/features/*/MANIFEST.yaml` for orchestration state
-- **Check feedback state**: `cat .jonggrang/.ephemeral/feedback-loop-state.json` for dirty bits
-- **Check compaction**: `cat .jonggrang/.ephemeral/compaction-state.json` for token usage
-- **Check locks**: `ls .jonggrang/locks/` for file ownership in team mode
-- **Read progress**: `cat .jonggrang/progress.txt` for agent learnings log
-- **Resume orchestrate**: `jonggrang orchestrate --resume` picks up from last MANIFEST state
-
----
-
-## Resources
-
-| Doc | Content |
-|-----|---------|
-| [README.md](README.md) | Overview, commands, platform architecture |
-| [docs/JONGGRANG.md](docs/JONGGRANG.md) | Full specification, philosophy, five-role model |
-| [docs/ORCHESTRATION.md](docs/ORCHESTRATION.md) | Deep architecture: thin agents, hooks, state management |
-| [docs/WORKFLOW.md](docs/WORKFLOW.md) | Detailed workflow: work loop, orchestrate, hooks, compaction |
-| [docs/SKILLS.md](docs/SKILLS.md) | Skill system: two-tier, gateway, creating custom skills |
-| [docs/CONFIG.md](docs/CONFIG.md) | Configuration reference for `jonggrang.json` |
-| [docs/EXAMPLE.md](docs/EXAMPLE.md) | End-to-end walkthroughs (Work Loop + Orchestrate) |
-| [SKILL.md](SKILL.md) | Agent instructions — what every agent reads first |
+Buka [GitHub Issues](https://github.com/porcupine-md/jonggrang/issues) atau tanya langsung ke maintainer.
 
 ---
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+Dengan berkontribusi, kamu setuju bahwa kontribusimu dilisensikan di bawah [MIT License](LICENSE) yang sama dengan proyek ini.

--- a/README.md
+++ b/README.md
@@ -1,763 +1,145 @@
 # Jonggrang
 
-> AI Development Workflow Orchestrator — from project bootstrap to delivery.
+> AI Development Workflow Orchestrator — from idea to production-ready code.
 
-Jonggrang is a CLI tool that orchestrates AI coding agents to handle your development workflow. It uses a **Work Loop** model — decompose a feature into tasks, implement them one-by-one with a fresh agent per task.
+Jonggrang is a CLI tool that orchestrates AI coding agents through a disciplined **Plan → Implement → Simplify → Test → Review** pipeline. It decomposes features into atomic tasks and executes them one-by-one with a fresh agent per task — no accumulated confusion, no drifting context.
 
-Supports four AI agent backends: [OpenCode](https://opencode.ai/), [Claude Code](https://claude.ai/code), [OpenAI Codex CLI](https://github.com/openai/codex), and **Jonggrang** (built on the [Pi](https://pi.dev/) SDK — multi-provider, TypeScript-extensible).
-
-Inspired by the [Ralph Loop](https://github.com/snarktank/ralph), [Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/) (Addy Osmani), and the [collapsed SDLC](https://boristane.com/blog/the-software-development-lifecycle-is-dead/) (Boris Tane).
+Supports four AI Coding Agents: [OpenCode](https://opencode.ai/), [Claude Code](https://claude.ai/code), [OpenAI Codex CLI](https://github.com/openai/codex), and **Jonggrang** (built on [Pi SDK](https://pi.dev/) — multi-provider, TypeScript-extensible).
 
 ---
 
-## Philosophy
+## What Makes It Different
 
-AI agents write code fast. Too fast. The bottleneck is no longer *writing* — it's *knowing when to stop, reflect, and clean up*.
+AI agents write code fast. Too fast. The bottleneck isn't speed — it's **knowing when to stop and clean up.**
 
-Jonggrang is built around one belief: **a codebase shaped by a disciplined process is cleaner than one shaped by raw speed.** Every feature passes through the same pipeline — not because every step is always necessary, but because skipping steps is how complexity accumulates silently.
+Jonggrang enforces a pipeline where every feature passes through the same gates: Plan → Implement → Simplify → Test → Review. Not because every step is always necessary, but because skipping steps is how complexity accumulates silently.
 
-### The Pipeline Is the Quality Gate
+**Fresh context per task.** Each task starts with a clean agent instance. No stale assumptions carrying forward. **Hooks police in real-time** — secrets blocked, context overload prevented, exit refused until quality gates pass. **Simplify phase** revisits every changed file to reduce complexity before the PR opens.
 
-```
-                ┌─────────────────────────────────────┐
-                │              Hooks                  │
-                │  (active throughout — guards every  │
-                │   tool call, file edit, and exit)   │
-                └──────┬──────────────────────────────┘
-                       │ enforces invariants in real-time
-                       ▼
-Plan  →  Implement ⟲  →  Simplify  →  Test  →  Review
-               ▲____|
-          (loops until
-          quality gates
-             pass)
-```
+The agent will always take the shortest path. Jonggrang makes sure the shortest path is also the right one.
 
-Each stage has a specific job:
-
-- **Plan** — the agent reads your intent and produces a structured task list. You review it before a single line of code is written. Humans stay in the loop at the point where it costs the least to change course.
-
-- **Implement** — each task runs in a *fresh context*. No accumulated confusion, no prompt memory carrying forward wrong assumptions. The agent starts clean every time. **Hooks run here** — blocking secret exposure, enforcing delegation, preventing context overload, and refusing to let the agent exit until the loop conditions are met.
-
-- **Hooks** — not a final stage, but a continuous enforcement layer woven into the implement loop. Every tool call, every file edit, every agent exit passes through hooks first. They police what the agent cannot be trusted to police itself: no secrets leaking into context, no orchestrator making direct edits it should delegate, no agent spawning when the context window is near-full, no exit until review and tests are green.
-
-- **Simplify** — after implementation, before the PR is opened, the agent revisits every changed file with a single mandate: *reduce complexity without changing behavior*. Rename the unclear variable. Collapse the redundant function. Remove the comment that just restates the code. This phase exists because the first pass is never the last word.
-
-- **Test** — the agent writes the tests, runs them, and verifies coverage. Tests are not an afterthought appended at the end; they are part of the definition of done for every task.
-
-- **Review** — a dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan?
-
-### Why This Matters
-
-An AI agent without structure produces a codebase that looks finished but is made of layers. Each feature adds another layer — slightly different naming conventions, subtly duplicated logic, tests that assert the wrong thing. It works until it doesn't.
-
-The pipeline is the answer to that. It is not bureaucracy — it is the minimum structure required to keep the output coherent over time.
-
-Jonggrang is opinionated because it has to be. The agent will always take the shortest path. The framework's job is to make sure the shortest path is also the right one.
+→ [Read the full philosophy & architecture](docs/PHILOSOPHY.md)
 
 ---
 
-## How It Works
+## I Just Want to Use It
 
-### Work Loop
-
-```
-You describe what you want
-        |
-        v
-  jonggrang plan  -->  Phase 1: AI writes .jonggrang/plan.md (high-level, human-editable)
-        |              Review / edit the plan in your editor
-        v
-  jonggrang approve  -->  Phase 2: AI reads plan.md → decomposes into tasks
-        |                 plan.md archived, jonggrang-tasks.json written
-        v
-  jonggrang work  -->  For each task:
-        |            1. Fresh context (no accumulated confusion)
-        |            2. Read AGENTS.md + .jonggrang/progress.txt (project knowledge)
-        |            3. Pick highest priority unblocked task
-        |            4. Implement via AI agent (opencode/claude/jonggrang)
-        |            5. Validate (typecheck, tests, lint)
-        |            6. Commit if pass
-        |            7. Log learnings
-        |            8. Repeat
-        v
-  jonggrang review  -->  Comprehensive code review
-```
-
-**Shorthand options:**
 ```bash
-jonggrang plan "feature" --yes           # plan + auto-approve + tasks in one shot
-jonggrang plan "feature" --deep          # 3-phase deep analysis → enriched plan (Affected Areas, Risks, Alternatives)
-jonggrang work "feature" --yes           # full pipeline: plan → approve → execute
-jonggrang work "feature" --deep --yes    # deep mode full pipeline
+# In your project directory:
+jonggrang init
+jonggrang plan "what you want to build"    # AI writes a plan — you review it
+jonggrang approve                          # Decompose plan into tasks
+jonggrang work                             # Execute tasks one by one
+jonggrang review                           # Comprehensive code review
+```
+
+**One-shot shortcut:**
+```bash
+jonggrang work "REST API for todo management" --yes
+```
+
+**Interactive chat:**
+```bash
+jonggrang agent    # Full TUI chat with /plan, /work, /review, etc.
+```
+
+→ [Step-by-step guide for beginners](docs/QUICKSTART.md)
+
+---
+
+## I Want to Set Up for Development
+
+```bash
+git clone <repo-url> && cd jonggrang
+make install
+make build
+```
+
+Project entry points: CLI binary, Pi TUI extension, web dashboard server. Hooks live in `hooks/`, skills in `skills/`, orchestration engine reads `MANIFEST.yaml`.
+
+→ [Full development setup guide](docs/QUICKSETUP.md)
+
+---
+
+## Commands at a Glance
+
+| Command | What it does |
+|---------|-------------|
+| `jonggrang init` | Interactive wizard — sets up `.jonggrang/`, `AGENTS.md`, hooks, skills |
+| `jonggrang plan "desc"` | AI writes `.jonggrang/plan.md` — human reviews before code |
+| `jonggrang approve` | Decomposes plan into atomic tasks in `jonggrang-tasks.json` |
+| `jonggrang work` | Executes task queue with fresh context per task |
+| `jonggrang status` | Shows task board |
+| `jonggrang review` | Comprehensive code review → markdown report |
+| `jonggrang agent` | Full TUI chat session with `/plan`, `/work`, `/review` commands |
+| `jonggrang web` | Visual Kanban dashboard with real-time logs |
+
+```bash
+# Quick flags
+jonggrang plan "feature" --yes       # Skip review, auto-approve
+jonggrang work "feature" --yes       # Full pipeline in one command
+jonggrang plan "feature" --deep      # 3-phase deep analysis (risks, alternatives)
+jonggrang work --mode autonomous     # Override autonomy mode
+jonggrang work --task task-003       # Execute specific task only
 ```
 
 ---
 
 ## Requirements
 
-- **AI agent** (pick one):
-  - [OpenCode](https://opencode.ai/) (`--tool opencode`) — `curl -fsSL https://opencode.ai/install | bash`
-  - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`--tool claude`) — `npm install -g @anthropic-ai/claude-code`
-  - **Jonggrang** (`--tool jonggrang`, Pi SDK, multi-provider) — `npm install -g @earendil-works/pi-coding-agent`
-- [jq](https://jqlang.github.io/jq/) — `brew install jq`
+- **Node.js** (latest LTS)
+- **An AI agent** — pick one:
+  - [OpenCode](https://opencode.ai/) → `curl -fsSL https://opencode.ai/install | bash`
+  - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) → `npm install -g @anthropic-ai/claude-code`
+  - [OpenAI Codex CLI](https://github.com/openai/codex) → `npm install -g @openai/codex`
+  - Jonggrang (Pi SDK) → `npm install -g @earendil-works/pi-coding-agent`
+- [jq](https://jqlang.github.io/jq/) → `brew install jq`
 - git
-
-## Install
-
-```bash
-npx jonggrang init
-```
-
-Or install globally:
-
-```bash
-npm install -g jonggrang
-jonggrang init
-```
-
----
-
-## Quick Start
-
-```bash
-# 1. Go to your project
-cd my-project
-
-# 2. Initialize Jonggrang
-jonggrang init
-
-# 3a. Two-phase work loop (review plan before decompose)
-jonggrang plan "REST API for todo management"   # generates plan.md for review
-jonggrang approve                               # approve → decomposes to tasks
-jonggrang work                                  # execute tasks
-
-# 3b. One-shot (skip review)
-jonggrang plan "REST API for todo management" --yes   # plan + approve + tasks
-jonggrang work                                        # execute tasks
-
-# 3c. Full pipeline in one command
-jonggrang work "REST API for todo management" --yes   # plan → approve → execute
-
-# 4. Review results
-jonggrang review
-```
-
-### One-liner Init
-
-```bash
-# With OpenCode (default)
-jonggrang init --name my-app --type api --stack express-typescript --autonomy balanced --force
-
-# With Claude Code
-jonggrang init --name my-app --type api --tool claude --autonomy autonomous --force
-
-# With Jonggrang (Pi SDK — supports Anthropic, OpenAI, Gemini, DeepSeek, and more)
-jonggrang init --name my-app --type api --tool jonggrang --autonomy autonomous --force
-
-```
-
----
-
-## Commands
-
-### `jonggrang init`
-
-Interactive wizard that sets up your project. Generates:
-- `.jonggrang/jonggrang.json` — project configuration
-- `AGENTS.md` — project knowledge for AI agents (human-curated)
-- `.jonggrang/jonggrang-tasks.json` — task board
-- `.jonggrang/progress.txt` — append-only learnings log
-- `.claude/skills/`, `.opencode/skills/`, `.jonggrang/skills/`, `.codex/skills/` — prompt templates filtered by your project type
-- `.claude/settings.json` — Claude Code enforcement hooks
-- `.opencode/plugins/jonggrang.js` — OpenCode enforcement plugin
-- `.jonggrang/extensions/jonggrang.ts` — Jonggrang (Pi) enforcement extension
-
-**Flags to bypass the wizard:**
-
-| Flag | Values | Description |
-|------|--------|-------------|
-| `--name` | any string | Project name |
-| `--type` | `web-app`, `api`, `library`, `cli`, `tui` | Project type |
-| `--work-mode` | `solo`, `team` | Solo or team mode |
-| `--team-size` | `2-5` | Team size (if team) |
-| `--state` | `new`, `existing` | New or existing project |
-| `--stack` | `nextjs-typescript`, `express-typescript`, `go`, `python-fastapi`, `library-typescript`, `rust`, `python`, `node-typescript` | Tech stack |
-| `--tool` | `opencode`, `claude`, `jonggrang`, `codex` | AI agent tool (default: jonggrang) |
-| `--autonomy` | `supervised`, `balanced`, `autonomous` | Default autonomy mode |
-| `--ci` | `github-actions`, `gitlab-ci`, `none` | CI/CD provider |
-| `--testing` | `vitest`, `jest`, `go-test`, `pytest`, `none` | Test framework |
-| `--force` | — | Overwrite existing config |
-
-**What `--tool jonggrang` sets up:**
-- Installs `.jonggrang/extensions/jonggrang.ts` — TypeScript Pi extension with full enforcement hooks (file protection, secret blocking, output sanitization, feedback loop, quality gates)
-- Skills copied to `.jonggrang/skills/` for Pi agent discovery
-- Global config at `~/.jonggrang/settings.json`, project config at `.jonggrang/jonggrang.json`
-- Supports any provider via env var or `jonggrang login`
-
-After init, configure your AI provider:
-
-```bash
-jonggrang login    # add provider credentials (OAuth or API key)
-jonggrang model    # select which model to use
-```
-
-### `jonggrang plan <description>`
-
-**Phase 1** — AI generates `.jonggrang/plan.md`, a human-readable draft plan with YAML frontmatter (`feature`, `branch`, `work_type`). You review and edit the plan before anything gets decomposed into tasks.
-
-```bash
-jonggrang plan "user authentication with JWT, email registration, and password reset"
-# → writes .jonggrang/plan.md
-# → interactive prompt: Approve / Edit / Open $EDITOR / Save for later / Abort
-
-jonggrang plan "user auth" --yes   # skip interactive prompt, auto-approve
-```
-
-### `jonggrang approve`
-
-**Phase 2** — AI reads the approved `plan.md` and decomposes it into atomic tasks in `jonggrang-tasks.json`. Each task is:
-- Small enough for one AI context window
-- Has clear acceptance criteria
-- Has file ownership (prevents conflicts)
-- Has dependency ordering (`blocked_by`)
-
-```bash
-jonggrang approve
-# → reads .jonggrang/plan.md
-# → writes .jonggrang/jonggrang-tasks.json
-# → archives plan to .jonggrang/.output/features/<id>/plan.md
-```
-
-> **Rule: completed tasks are immutable.** They reflect real code. Any correction must be a new task that fixes/replaces the previous implementation.
-
-### `jonggrang work`
-
-Runs the simple development loop. Each iteration is **stateless** — a fresh agent instance with clean context.
-
-```bash
-jonggrang work                                    # use config defaults
-jonggrang work "feature" --yes                    # plan → approve → execute in one shot
-jonggrang work --ignore-plan                      # skip pending plan warning, run existing tasks
-jonggrang work --mode autonomous                  # override autonomy mode
-jonggrang work --tool claude                      # override AI tool
-jonggrang work --max-iterations 5
-jonggrang work --task task-003                    # work on specific task
-jonggrang work --branch feat/auth                 # create/use a branch
-jonggrang work --dry-run                          # show prompts, don't execute
-jonggrang work --debug                            # dump raw JSON from opencode/claude to stderr
-
-# Pin model/effort per invocation (--tool and --model compose freely):
-jonggrang plan "add auth" --tool claude --model opus --effort xhigh
-jonggrang work --tool opencode --model anthropic/claude-opus-4-7 --effort high
-jonggrang work --tool jonggrang --model anthropic/claude-sonnet-4-5 --effort medium
-jonggrang work --tool codex --model codex-1 --effort high
-```
-
-**`--model` / `--effort` backend mapping:**
-
-| jonggrang flag | `--tool claude` | `--tool opencode` | `--tool jonggrang` | `--tool codex` |
-|---|---|---|---|---|
-| `--model` | `--model <alias\|id>` e.g. `opus`, `claude-opus-4-7` | `--model <provider/model>` e.g. `anthropic/claude-opus-4-7` | `--model <provider/model>` e.g. `anthropic/claude-sonnet-4-5` | `--model <name>` e.g. `codex-1`, `gpt-5.4` |
-| `--effort` | `--effort low\|medium\|high\|max\|xhigh` | `--variant <level>` | SDK `thinkingLevel`: `off\|minimal\|low\|medium\|high\|xhigh` | `--config reasoning_effort=<level>` |
-
-Resolution order: `--model` flag → `JONGGRANG_MODEL` env → `tools.<tool>.model` in `jonggrang.json` → `model` top-level → backend default.
-
-### `jonggrang status`
-
-Shows the task board.
-
-```
-==============================
-  JONGGRANG Task Board
-==============================
-
-Project: my-app
-Tasks: 2/5 completed
-
-ID          Status       Role       Title
---------------------------------------------------------------
-task-001    completed    lead       Design auth architecture
-task-002    completed    developer  Implement JWT tokens
-task-003    in_progress  reviewer   Review auth implementation
-task-004    pending      test-lead  Plan auth tests
-task-005    pending      tester     Execute auth test suite
-```
-
-### `jonggrang review`
-
-Runs a comprehensive code review on all changes:
-- Code quality and consistency
-- Security vulnerabilities
-- Test coverage
-- Performance patterns
-
-Output goes to `jonggrang-log/review-{timestamp}.md`.
-
-### `jonggrang agent`
-
-Opens a full interactive TUI chat session powered by the Pi engine. Chat with the AI directly — no plan/phase required.
-
-```bash
-jonggrang agent
-```
-
-Inside the chat, use `/` commands to trigger jonggrang workflow operations without leaving the session:
-
-| Command | Description |
-|---------|-------------|
-| `/plan <description>` | Generate `.jonggrang/plan.md` for a feature |
-| `/approve` | Decompose the current plan into tasks |
-| `/work [description]` | Execute the task queue |
-| `/status` | Show the project task board |
-| `/review` | Run a code review |
-| `/config` | Open Jonggrang settings (autonomy mode, agent tool) |
-| `/login` | Add provider credentials |
-| `/logout` | Remove provider credentials |
-| `/model` | Switch AI model |
-
-All other Pi built-in commands (`/compact`, `/help`, Ctrl+P model cycling, etc.) work as normal.
-
-Security hooks (`hooks/pi/jonggrang-extension.ts`) are loaded automatically on every `jonggrang agent` session — no manual installation needed. The extension blocks access to `.env` and credential files, intercepts secret-leaking bash commands, sanitizes sensitive output, and enforces the feedback loop gate.
-
-> Requires the jonggrang engine (`npm install -g @earendil-works/pi-coding-agent`). Run `jonggrang login` first to configure a provider.
-
-### `jonggrang login`
-
-Add provider credentials for the Jonggrang (Pi) engine. Supports OAuth subscriptions and API keys.
-
-```bash
-jonggrang login
-```
-
-A TUI menu lets you pick the provider:
-
-**OAuth subscriptions** (no API key needed — uses your existing subscription):
-- Anthropic Claude Pro/Max
-- GitHub Copilot
-- ChatGPT Plus/Pro (Codex)
-
-**API key providers** (paste your key):
-- Anthropic, OpenAI, Google Gemini, DeepSeek, Mistral, Groq, xAI, OpenRouter, Azure OpenAI, Cloudflare, Fireworks, Together AI, Hugging Face, Cerebras, and more
-
-Credentials are stored in `~/.jonggrang/agent/auth.json`.
-
-### `jonggrang logout`
-
-Remove stored credentials for a provider.
-
-```bash
-jonggrang logout
-# → shows configured providers → select one to remove
-```
-
-### `jonggrang model`
-
-Select which AI model the Jonggrang engine will use. Shows models available for your configured providers.
-
-```bash
-jonggrang model
-# → TUI list of available models grouped by provider
-# → saves selection to .jonggrang/jonggrang.json
-```
-
-Requires at least one provider configured via `jonggrang login` (or an API key set as an environment variable).
-
-### Interactive Menu
-
-Run `jonggrang` without arguments (or `jonggrang menu`) to launch a full-screen TUI menu built on Pi TUI. Displays live project status (pending plan, task progress) in the header and lets you navigate with keyboard. Falls back to a plain `@clack/prompts` menu if Pi TUI is unavailable.
-
----
-
-## Platform Architecture
-
-Jonggrang is built on a **Thin Agent / Fat Platform** model. The AI models are stateless workers — all intelligence, state, and enforcement lives in the platform.
-
-### Five-Layer Stack
-
-```
-┌─────────────────────────────────────────────┐
-│  AGENT LAYER       Stateless workers (<150L) │
-│  Lead · Developer · Reviewer · TestLead · Tester
-├─────────────────────────────────────────────┤
-│  SKILL LAYER       Two-tier progressive load │
-│  Core (BIOS) · Library (JIT via Gateway)    │
-├─────────────────────────────────────────────┤
-│  ORCHESTRATION     16-phase state machine    │
-│  MANIFEST.yaml · Work type · Phase skip     │
-├─────────────────────────────────────────────┤
-│  HOOK LAYER        Deterministic enforcement │
-│  Claude Code hooks · OpenCode plugin        │
-│  Jonggrang extension (.jonggrang/extensions)│
-├─────────────────────────────────────────────┤
-│  INFRASTRUCTURE    Compaction · Feedback     │
-│  Token gates · Dirty bits · Lock files      │
-└─────────────────────────────────────────────┘
-```
-
-### Five-Role Assembly Line
-
-| Role | Agent | Does | Output |
-|------|-------|------|--------|
-| **Lead** | `*-lead` | Designs architecture, decomposes into tasks. Never writes code. | Architecture Plan JSON |
-| **Developer** | `*-developer` | Implements specific tasks from the plan. | Source code + tests |
-| **Reviewer** | `*-reviewer` | Validates design, compliance, and quality. Rejects non-compliant work. | Review Report JSON |
-| **Test Lead** | `test-lead` | Analyzes implementation, designs test strategy. | Test Plan JSON |
-| **Tester** | `*-tester` | Writes and runs tests from the plan. | Test Results JSON |
-
-**Tool restriction boundary:**
-
-| Role | Can Use | Cannot Use |
-|------|---------|-----------|
-| Lead, Test Lead | `Task`, `Read`, `TodoWrite` | `Edit`, `Write`, `Bash` |
-| Developer, Tester | `Edit`, `Write`, `Bash`, `Read` | `Task` |
-| Reviewer | `Read`, `Bash` | `Edit`, `Write`, `Task` |
-
-Coordinators plan. Executors implement. Never both.
-
-### Two-Tier Skill System
-
-Skills live in two tiers:
-
-```
-skills/
-├── core/             ← Tier 1 (BIOS) — always available
-│   ├── gateway-backend/
-│   ├── gateway-frontend/
-│   ├── gateway-api/
-│   ├── gateway-testing/
-│   ├── gateway-database/
-│   ├── orchestrating-feature/
-│   ├── iterating-to-completion/
-│   ├── dispatching-parallel-agents/
-│   ├── persisting-agent-outputs/
-│   └── [all standard skills: auth, scaffold-api, testing, ...]
-└── library/          ← Tier 2 (Hard Drive) — loaded on-demand via Gateway
-    ├── backend/
-    │   ├── developing-with-tdd/
-    │   ├── debugging-systematically/
-    │   └── error-handling-patterns/
-    ├── frontend/
-    │   ├── debugging-react-hooks/
-    │   └── optimizing-react-performance/
-    ├── testing/
-    │   ├── unit-testing-patterns/
-    │   └── fixing-flaky-tests/
-    ├── database/
-    │   └── safe-migrations/
-    ├── api/
-    │   └── input-validation/
-    └── security/
-        └── rate-limiting/
-```
-
-**Gateway Pattern** — agents don't hardcode skill paths. They invoke a domain gateway which detects intent and returns the exact skill files to load:
-
-```
-Agent: "I need to fix a React infinite loop"
-  ↓
-Invokes: gateway-frontend
-  ↓
-Detects: "infinite loop", "useEffect"
-  ↓
-Returns: Read skills/library/frontend/debugging-react-hooks/SKILL.md
-```
-
-### Deterministic Hooks (Universal)
-
-Hooks enforce quality gates outside the LLM's context. The same rules apply regardless of which AI tool is used:
-
-| Layer | Event | Claude Code | OpenCode | Jonggrang (Pi) | Enforcement |
-|-------|-------|-------------|----------|----------------|-------------|
-| 5 | Pre-tool | `PreToolUse` | `tool.execute.before` | `tool_call` | Block direct edits (agent-first) |
-| 5 | Pre-tool | `PreToolUse` | `tool.execute.before` | `tool_call` | Block agent spawn if context > 85% |
-| 6 | Post-tool | `PostToolUse` | `tool.execute.after` | `tool_result` | Set dirty bit when files modified |
-| 6 | File edit | `PostToolUse` | `file.edited` | `tool_result` | Track domain (backend/frontend/testing) |
-| 7 | Sub-stop | `SubagentStop` | `session.updated` | `agent_end` | Block exit if output in wrong location |
-| 8 | Stop | `Stop` | `session.idle` | `agent_end` | Block exit until review + tests pass |
-| 8 | Stop | `Stop` | `session.idle` | `agent_end` | Final quality gate (defense in depth) |
-
-Jonggrang hooks live in `hooks/pi/jonggrang-extension.ts` and are loaded automatically via `--extension` on every `jonggrang agent` invocation — no separate installation step required.
-
-**Feedback Loop (Level 2 enforcement):**
-
-When a developer modifies files, the dirty bit is set. The agent cannot exit until a reviewer AND tester have passed for every modified domain:
-
-```json
-{
-  "active": true,
-  "modified_domains": ["backend", "frontend"],
-  "domain_phases": {
-    "backend":  { "review": "PASS", "testing": "PASS" },
-    "frontend": { "review": "PASS", "testing": "FAIL" }
-  }
-}
-```
-Exit is blocked until ALL domains have review=PASS AND testing=PASS.
-
-### Compaction Gate
-
-Before phases 3, 8, and 13 (heavy execution), the platform checks context usage:
-
-| Usage | Threshold | Action |
-|-------|-----------|--------|
-| < 75% | — | Proceed |
-| 75–80% | `WARN` | Warning, proceed |
-| 80–85% | `MUST` | Strong warning, proceed |
-| > 85% | `BLOCK` | Hard block — run `/compact` first |
-
-Claude Code: reads `~/.claude/projects/{hash}/*.jsonl` transcripts.
-OpenCode: refreshes on `session.compacted` event.
-Jonggrang: checks via `before_provider_request` event in Pi extension.
-
-### Persistent State
-
-```
-.jonggrang/
-├── .output/
-│   └── features/{feature-id}/
-│       ├── MANIFEST.yaml           ← Phase tracking (survives session resets)
-│       ├── 07-lead-architecture-plan.json
-│       ├── 08-developer-task-001.json
-│       ├── 09-reviewer-design-check.json
-│       ├── 12-test-lead-plan.json
-│       └── 13-tester-results.json
-├── .ephemeral/
-│   ├── feedback-loop-state.json    ← Dirty bits (cleared on restart)
-│   └── compaction-state.json       ← Token usage cache
-└── locks/
-    └── {agent}.lock                ← File ownership during parallel runs
-```
-
----
-
-## Autonomy Modes
-
-| Mode | Behavior | Best for |
-|------|----------|----------|
-| **supervised** | Pauses at brainstorming (Phase 6) for human design input | Critical systems |
-| **balanced** | Auto-runs, pauses on failures or ambiguity | Daily development |
-| **autonomous** | Full loop — plans, implements, commits. Human reviews at the end | Well-defined tasks |
-
-```bash
-jonggrang work --mode supervised
-```
-
----
-
-## Skill System
-
-Skills are **markdown prompt templates** that guide AI agents through specific tasks.
-
-### Built-in Core Skills
-
-| Skill | Type | Description |
-|-------|------|-------------|
-| `prd` | generate | Generate PRD from feature description |
-| `scaffold-api` | scaffold | API endpoint with route, validation, tests |
-| `scaffold-webapp` | scaffold | Web app page with components, data fetching |
-| `scaffold-library` | scaffold | Library with build config, exports, tests |
-| `scaffold-deploy` | scaffold | Dockerfile, CI/CD config, environment configs |
-| `component` | scaffold | UI component with test and story |
-| `migration` | scaffold | Database migration with model update |
-| `auth` | scaffold | Authentication flow end-to-end |
-| `testing` | generate | Test suite for existing code |
-| `gateway-deploy` | gateway | Route deploy intents to specific library skills |
-| `orchestrating-feature` | orchestrate | 16-phase full workflow orchestration |
-| `iterating-to-completion` | orchestrate | Completion promises + scratchpads + loop detection |
-| `dispatching-parallel-agents` | orchestrate | Independent task parallel dispatch |
-
-### Custom Skills
-
-```bash
-mkdir -p skills/core/my-skill
-cat > skills/core/my-skill/SKILL.md << 'EOF'
----
-name: my-skill
-description: What this skill does
-type: scaffold
-tier: core
-project_types: [web-app, api]
-trigger: "natural language trigger"
----
-
-## Context
-Background info.
-
-## Instructions
-1. Step one
-2. Step two
-
-## Validation
-- [ ] Check one
-EOF
-```
-
-For deep-domain skills (JIT loaded), put them in `skills/library/{domain}/`:
-
-```bash
-mkdir -p skills/library/backend/my-pattern
-cat > skills/library/backend/my-pattern/SKILL.md << 'EOF'
----
-name: my-pattern
-description: Deep domain knowledge
-type: pattern
-tier: library
-domains: [backend]
-trigger: "specific keywords that trigger gateway routing"
----
-...
-EOF
-```
-
----
-
-## Project Files
-
-After `jonggrang init`, your project will have:
-
-```
-your-project/
-├── AGENTS.md                # Project knowledge (edit this!)
-├── skills/
-│   ├── core/                # Tier 1 — always loaded
-│   └── library/             # Tier 2 — JIT via gateway
-├── .jonggrang/
-│   ├── jonggrang.json       # Project config
-│   ├── jonggrang-tasks.json # Task board state
-│   ├── plan.md              # Draft plan (exists between plan → approve)
-│   ├── progress.txt         # Auto-generated learnings
-│   ├── .output/
-│   │   └── features/<id>/
-│   │       ├── plan.md      # Archived plan (after approve)
-│   │       └── MANIFEST.yaml
-│   ├── .ephemeral/          # Runtime state (feedback loop, compaction)
-│   └── locks/               # File ownership locks
-├── .claude/
-│   ├── settings.json        # Claude Code enforcement hooks
-│   └── skills/              # Skills for Claude Code agent
-├── .opencode/
-│   ├── plugins/
-│   │   └── jonggrang.js     # OpenCode enforcement plugin
-│   └── skills/              # Skills for OpenCode agent
-└── .jonggrang/
-    ├── skills/              # Skills for Jonggrang (Pi) agent
-    └── extensions/
-        └── jonggrang.ts     # Jonggrang (Pi) enforcement extension
-```
-
-### AGENTS.md
-
-The most important file for output quality. Tells AI agents about your project's conventions, patterns, and gotchas. **Human-curated** — research shows human-written AGENTS.md improves agent success ~4%.
-
-### .jonggrang/progress.txt
-
-Append-only log written by the agent after each task. Captures learnings and prevents repeating mistakes across sessions.
 
 ---
 
 ## Configuration
 
-Jonggrang uses a **two-layer settings** system:
-
-| Layer | File | Scope |
-|-------|------|-------|
-| Global | `~/.jonggrang/settings.json` | User-wide defaults |
-| Project | `.jonggrang/jonggrang.json` | Project overrides (wins over global) |
-
-Edit via `/config` inside `jonggrang agent`, or directly in the files.
-
-See `.jonggrang/jonggrang.json` after init:
-
 ```jsonc
+// .jonggrang/jonggrang.json (after init)
 {
-  "tool": "opencode",          // opencode | claude | jonggrang
-  "model": "",                 // default model for --tool (backend-specific format; see docs/CONFIG.md)
-  "effort": "",                // default effort/thinking level
-  "tools": {                   // optional per-tool overrides for model/effort
-    "claude":     { "model": "opus",                              "effort": "high" },
-    "opencode":   { "model": "anthropic/claude-opus-4-7",         "effort": "max"  },
-    "jonggrang":  { "model": "anthropic/claude-sonnet-4-5",       "effort": "high" }
-  },
-  "provider": "anthropic",     // set by jonggrang model (jonggrang tool only)
-  "mode": {
-    "autonomy": "balanced"
-  },
-  "work": {
-    "max_iterations": 10,
-    "retry_limit": 2,
-    "kill_after_fails": 3
-  },
-  "hooks": {
-    "pre_commit": ["npm test"]
-  },
-  "orchestration": {
-    "compaction": {
-      "warn_threshold": 0.75,
-      "block_threshold": 0.85
-    }
-  }
+  "tool": "opencode",          // opencode | claude | jonggrang | codex
+  "mode": { "autonomy": "balanced" },
+  "work": { "max_iterations": 10 }
 }
 ```
 
-Full reference: [docs/CONFIG.md](docs/CONFIG.md)
+Two-layer: `~/.jonggrang/settings.json` (global) → `.jonggrang/jonggrang.json` (project overrides).
 
----
-
-## Web Dashboard
-
-```bash
-jonggrang web
-jonggrang web --port 8080 --no-open
-```
-
-The dashboard provides a visual Kanban board, real-time agent logs, parallel group management, diff review, and orchestration phase tracking.
-
-**API endpoints include:**
-- `GET  /api/jonggrang/manifests` — list all orchestration runs
-- `GET  /api/jonggrang/manifests/:id` — get phase details
-- `POST /api/jonggrang/orchestrate` — start new orchestration
-- `POST /api/jonggrang/orchestrate/resume` — resume incomplete run
-- `GET  /api/jonggrang/compaction` — current context usage
-- `GET  /api/jonggrang/feedback-state` — current dirty bit state
-- `POST /api/jonggrang/plan` — Phase 1: generate plan.md
-- `GET  /api/jonggrang/plan/content` — read current plan.md
-- `PUT  /api/jonggrang/plan/content` — save edited plan.md from UI
-- `DELETE /api/jonggrang/plan/content` — discard pending plan
-- `POST /api/jonggrang/approve` — Phase 2: decompose plan.md → tasks
-
-WebSocket emits `plan_update: { exists, content }` whenever plan.md changes.
-
----
-
-## Release Workflow
-
-```bash
-make install        # install root + client deps
-make build          # standard build pipeline
-make release        # bump version + rebuild (default: patch)
-make release BUMP=minor
-make release-major
-```
-
-Binary build (Bun):
-
-```bash
-make build-binary
-make build-binary BIN_OUT=out/jonggrang-darwin
-```
+→ [Full config reference](docs/CONFIG.md)
 
 ---
 
 ## Documentation
 
-- [JONGGRANG.md](docs/JONGGRANG.md) — Full specification
-- [SKILLS.md](docs/SKILLS.md) — Skill system documentation
-- [WORKFLOW.md](docs/WORKFLOW.md) — Detailed workflow documentation
-- [CONFIG.md](docs/CONFIG.md) — Configuration reference
+| Doc | Content |
+|-----|---------|
+| [QUICKSTART.md](docs/QUICKSTART.md) | Beginner's step-by-step guide |
+| [QUICKSETUP.md](docs/QUICKSETUP.md) | Development setup for contributors |
+| [PHILOSOPHY.md](docs/PHILOSOPHY.md) | Philosophy, pipeline, architecture deep-dive |
+| [JONGGRANG.md](docs/JONGGRANG.md) | Full specification |
+| [WORKFLOW.md](docs/WORKFLOW.md) | Detailed workflow documentation |
+| [SKILLS.md](docs/SKILLS.md) | Skill system reference |
+| [CONFIG.md](docs/CONFIG.md) | Configuration reference |
+
+---
+
+## Contributors
+
+Jonggrang dibuat dan dikelola oleh:
+
+- **[Eka Irawan (Ibnu)](https://github.com/anak10thn)** — arsitektur, orchestration engine, skill system
+- **[Ahmad Anshorimuslim Syuhada](https://github.com/ans4175)** — Pi SDK integration, TUI, hooks
 
 ---
 
 ## License
 
 MIT © Porcupine Team
+
+Lihat [LICENSE](LICENSE) untuk teks lengkap. Ringkasannya: **bebas pakai untuk apa pun, termasuk komersial, tanpa garansi. Kontributor dilindungi dari tuntutan.**

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Two-layer: `~/.jonggrang/settings.json` (global) → `.jonggrang/jonggrang.json`
 
 Jonggrang dibuat dan dikelola oleh:
 
-- **[Eka Irawan (Ibnu)](https://github.com/anak10thn)** — arsitektur, orchestration engine, skill system
-- **[Ahmad Anshorimuslim Syuhada](https://github.com/ans4175)** — Pi SDK integration, TUI, hooks
+- **[Eka Irawan (Ibnu)](https://github.com/anak10thn)**
+- **[Ahmad Anshorimuslim Syuhada (Ans)](https://github.com/ans-4175)**
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -1,0 +1,309 @@
+# Philosophy & Architecture
+
+> Why Jonggrang exists, how it's built, and what happens under the hood.
+
+---
+
+## Philosophy
+
+AI agents write code fast. Too fast. The bottleneck is no longer *writing* — it's *knowing when to stop, reflect, and clean up*.
+
+Jonggrang is built around one belief: **a codebase shaped by a disciplined process is cleaner than one shaped by raw speed.** Every feature passes through the same pipeline — not because every step is always necessary, but because skipping steps is how complexity accumulates silently.
+
+An AI agent without structure produces a codebase that looks finished but is made of layers. Each feature adds another layer — slightly different naming conventions, subtly duplicated logic, tests that assert the wrong thing. It works until it doesn't.
+
+The pipeline is the answer to that. It is not bureaucracy — it is the minimum structure required to keep the output coherent over time.
+
+Jonggrang is opinionated because it has to be. The agent will always take the shortest path. The framework's job is to make sure the shortest path is also the right one.
+
+---
+
+## The Pipeline Is the Quality Gate
+
+```
+                ┌─────────────────────────────────────┐
+                │              Hooks                  │
+                │  (active throughout — guards every  │
+                │   tool call, file edit, and exit)   │
+                └──────┬──────────────────────────────┘
+                       │ enforces invariants in real-time
+                       ▼
+Plan  →  Implement ⟲  →  Simplify  →  Test  →  Review
+               ▲____|
+          (loops until
+          quality gates
+             pass)
+```
+
+Each stage has a specific job:
+
+### Plan
+The agent reads your intent and produces a structured task list. You review it before a single line of code is written. Humans stay in the loop at the point where it costs the least to change course.
+
+### Implement
+Each task runs in a *fresh context*. No accumulated confusion, no prompt memory carrying forward wrong assumptions. The agent starts clean every time. **Hooks run here** — blocking secret exposure, enforcing delegation, preventing context overload, and refusing to let the agent exit until the loop conditions are met.
+
+### Simplify
+After implementation, before the PR is opened, the agent revisits every changed file with a single mandate: *reduce complexity without changing behavior*. Rename the unclear variable. Collapse the redundant function. Remove the comment that just restates the code. This phase exists because the first pass is never the last word.
+
+### Test
+The agent writes the tests, runs them, and verifies coverage. Tests are not an afterthought appended at the end; they are part of the definition of done for every task.
+
+### Review
+A dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan?
+
+### Hooks (Continuous Enforcement)
+Not a final stage, but a continuous enforcement layer woven into the implement loop. Every tool call, every file edit, every agent exit passes through hooks first. They police what the agent cannot be trusted to police itself: no secrets leaking into context, no orchestrator making direct edits it should delegate, no agent spawning when the context window is near-full, no exit until review and tests are green.
+
+---
+
+## How It Works
+
+### Work Loop
+
+```
+You describe what you want
+        |
+        v
+  jonggrang plan  -->  Phase 1: AI writes .jonggrang/plan.md (high-level, human-editable)
+        |              Review / edit the plan in your editor
+        v
+  jonggrang approve  -->  Phase 2: AI reads plan.md → decomposes into tasks
+        |                 plan.md archived, jonggrang-tasks.json written
+        v
+  jonggrang work  -->  For each task:
+        |            1. Fresh context (no accumulated confusion)
+        |            2. Read AGENTS.md + .jonggrang/progress.txt (project knowledge)
+        |            3. Pick highest priority unblocked task
+        |            4. Implement via AI agent (opencode/claude/jonggrang)
+        |            5. Validate (typecheck, tests, lint)
+        |            6. Commit if pass
+        |            7. Log learnings
+        |            8. Repeat
+        v
+  jonggrang review  -->  Comprehensive code review
+```
+
+**Shorthand options:**
+```bash
+jonggrang plan "feature" --yes           # plan + auto-approve + tasks in one shot
+jonggrang plan "feature" --deep          # 3-phase deep analysis → enriched plan (Affected Areas, Risks, Alternatives)
+jonggrang work "feature" --yes           # full pipeline: plan → approve → execute
+jonggrang work "feature" --deep --yes    # deep mode full pipeline
+```
+
+---
+
+## Platform Architecture
+
+Jonggrang is built on a **Thin Agent / Fat Platform** model. The AI models are stateless workers — all intelligence, state, and enforcement lives in the platform.
+
+### Five-Layer Stack
+
+```
+┌─────────────────────────────────────────────┐
+│  AGENT LAYER       Stateless workers (<150L) │
+│  Lead · Developer · Reviewer · TestLead · Tester
+├─────────────────────────────────────────────┤
+│  SKILL LAYER       Two-tier progressive load │
+│  Core (BIOS) · Library (JIT via Gateway)    │
+├─────────────────────────────────────────────┤
+│  ORCHESTRATION     16-phase state machine    │
+│  MANIFEST.yaml · Work type · Phase skip     │
+├─────────────────────────────────────────────┤
+│  HOOK LAYER        Deterministic enforcement │
+│  Claude Code hooks · OpenCode plugin        │
+│  Jonggrang extension (.jonggrang/extensions)│
+├─────────────────────────────────────────────┤
+│  INFRASTRUCTURE    Compaction · Feedback     │
+│  Token gates · Dirty bits · Lock files      │
+└─────────────────────────────────────────────┘
+```
+
+### Five-Role Assembly Line
+
+| Role | Agent | Does | Output |
+|------|-------|------|--------|
+| **Lead** | `*-lead` | Designs architecture, decomposes into tasks. Never writes code. | Architecture Plan JSON |
+| **Developer** | `*-developer` | Implements specific tasks from the plan. | Source code + tests |
+| **Reviewer** | `*-reviewer` | Validates design, compliance, and quality. Rejects non-compliant work. | Review Report JSON |
+| **Test Lead** | `test-lead` | Analyzes implementation, designs test strategy. | Test Plan JSON |
+| **Tester** | `*-tester` | Writes and runs tests from the plan. | Test Results JSON |
+
+**Tool restriction boundary:**
+
+| Role | Can Use | Cannot Use |
+|------|---------|-----------|
+| Lead, Test Lead | `Task`, `Read`, `TodoWrite` | `Edit`, `Write`, `Bash` |
+| Developer, Tester | `Edit`, `Write`, `Bash`, `Read` | `Task` |
+| Reviewer | `Read`, `Bash` | `Edit`, `Write`, `Task` |
+
+Coordinators plan. Executors implement. Never both.
+
+### Two-Tier Skill System
+
+Skills live in two tiers:
+
+```
+skills/
+├── core/             ← Tier 1 (BIOS) — always available
+│   ├── gateway-backend/
+│   ├── gateway-frontend/
+│   ├── gateway-api/
+│   ├── gateway-testing/
+│   ├── gateway-database/
+│   ├── orchestrating-feature/
+│   ├── iterating-to-completion/
+│   ├── dispatching-parallel-agents/
+│   ├── persisting-agent-outputs/
+│   └── [all standard skills: auth, scaffold-api, testing, ...]
+└── library/          ← Tier 2 (Hard Drive) — loaded on-demand via Gateway
+    ├── backend/
+    │   ├── developing-with-tdd/
+    │   ├── debugging-systematically/
+    │   └── error-handling-patterns/
+    ├── frontend/
+    │   ├── debugging-react-hooks/
+    │   └── optimizing-react-performance/
+    ├── testing/
+    │   ├── unit-testing-patterns/
+    │   └── fixing-flaky-tests/
+    ├── database/
+    │   └── safe-migrations/
+    ├── api/
+    │   └── input-validation/
+    └── security/
+        └── rate-limiting/
+```
+
+**Gateway Pattern** — agents don't hardcode skill paths. They invoke a domain gateway which detects intent and returns the exact skill files to load:
+
+```
+Agent: "I need to fix a React infinite loop"
+  ↓
+Invokes: gateway-frontend
+  ↓
+Detects: "infinite loop", "useEffect"
+  ↓
+Returns: Read skills/library/frontend/debugging-react-hooks/SKILL.md
+```
+
+### Deterministic Hooks (Universal)
+
+Hooks enforce quality gates outside the LLM's context. The same rules apply regardless of which AI tool is used:
+
+| Layer | Event | Claude Code | OpenCode | Jonggrang (Pi) | Enforcement |
+|-------|-------|-------------|----------|----------------|-------------|
+| 5 | Pre-tool | `PreToolUse` | `tool.execute.before` | `tool_call` | Block direct edits (agent-first) |
+| 5 | Pre-tool | `PreToolUse` | `tool.execute.before` | `tool_call` | Block agent spawn if context > 85% |
+| 6 | Post-tool | `PostToolUse` | `tool.execute.after` | `tool_result` | Set dirty bit when files modified |
+| 6 | File edit | `PostToolUse` | `file.edited` | `tool_result` | Track domain (backend/frontend/testing) |
+| 7 | Sub-stop | `SubagentStop` | `session.updated` | `agent_end` | Block exit if output in wrong location |
+| 8 | Stop | `Stop` | `session.idle` | `agent_end` | Block exit until review + tests pass |
+| 8 | Stop | `Stop` | `session.idle` | `agent_end` | Final quality gate (defense in depth) |
+
+Jonggrang hooks live in `hooks/pi/jonggrang-extension.ts` and are loaded automatically via `--extension` on every `jonggrang agent` invocation — no separate installation step required.
+
+**Feedback Loop (Level 2 enforcement):**
+
+When a developer modifies files, the dirty bit is set. The agent cannot exit until a reviewer AND tester have passed for every modified domain:
+
+```json
+{
+  "active": true,
+  "modified_domains": ["backend", "frontend"],
+  "domain_phases": {
+    "backend":  { "review": "PASS", "testing": "PASS" },
+    "frontend": { "review": "PASS", "testing": "FAIL" }
+  }
+}
+```
+Exit is blocked until ALL domains have review=PASS AND testing=PASS.
+
+### Compaction Gate
+
+Before phases 3, 8, and 13 (heavy execution), the platform checks context usage:
+
+| Usage | Threshold | Action |
+|-------|-----------|--------|
+| < 75% | — | Proceed |
+| 75–80% | `WARN` | Warning, proceed |
+| 80–85% | `MUST` | Strong warning, proceed |
+| > 85% | `BLOCK` | Hard block — run `/compact` first |
+
+Claude Code: reads `~/.claude/projects/{hash}/*.jsonl` transcripts.
+OpenCode: refreshes on `session.compacted` event.
+Jonggrang: checks via `before_provider_request` event in Pi extension.
+
+### Persistent State
+
+```
+.jonggrang/
+├── .output/
+│   └── features/{feature-id}/
+│       ├── MANIFEST.yaml           ← Phase tracking (survives session resets)
+│       ├── 07-lead-architecture-plan.json
+│       ├── 08-developer-task-001.json
+│       ├── 09-reviewer-design-check.json
+│       ├── 12-test-lead-plan.json
+│       └── 13-tester-results.json
+├── .ephemeral/
+│   ├── feedback-loop-state.json    ← Dirty bits (cleared on restart)
+│   └── compaction-state.json       ← Token usage cache
+└── locks/
+    └── {agent}.lock                ← File ownership during parallel runs
+```
+
+---
+
+## Autonomy Modes
+
+| Mode | Behavior | Best for |
+|------|----------|----------|
+| **supervised** | Pauses at brainstorming (Phase 6) for human design input | Critical systems |
+| **balanced** | Auto-runs, pauses on failures or ambiguity | Daily development |
+| **autonomous** | Full loop — plans, implements, commits. Human reviews at the end | Well-defined tasks |
+
+---
+
+## Project Files Structure
+
+After `jonggrang init`, your project will have:
+
+```
+your-project/
+├── AGENTS.md                # Project knowledge (edit this!)
+├── skills/
+│   ├── core/                # Tier 1 — always loaded
+│   └── library/             # Tier 2 — JIT via gateway
+├── .jonggrang/
+│   ├── jonggrang.json       # Project config
+│   ├── jonggrang-tasks.json # Task board state
+│   ├── plan.md              # Draft plan (exists between plan → approve)
+│   ├── progress.txt         # Auto-generated learnings
+│   ├── .output/
+│   │   └── features/<id>/
+│   │       ├── plan.md      # Archived plan (after approve)
+│   │       └── MANIFEST.yaml
+│   ├── .ephemeral/          # Runtime state (feedback loop, compaction)
+│   └── locks/               # File ownership locks
+├── .claude/
+│   ├── settings.json        # Claude Code enforcement hooks
+│   └── skills/              # Skills for Claude Code agent
+├── .opencode/
+│   ├── plugins/
+│   │   └── jonggrang.js     # OpenCode enforcement plugin
+│   └── skills/              # Skills for OpenCode agent
+└── .jonggrang/
+    ├── skills/              # Skills for Jonggrang (Pi) agent
+    └── extensions/
+        └── jonggrang.ts     # Jonggrang (Pi) enforcement extension
+```
+
+### AGENTS.md
+
+The most important file for output quality. Tells AI agents about your project's conventions, patterns, and gotchas. **Human-curated** — research shows human-written AGENTS.md improves agent success ~4%.
+
+### .jonggrang/progress.txt
+
+Append-only log written by the agent after each task. Captures learnings and prevents repeating mistakes across sessions.

--- a/docs/QUICKSETUP.md
+++ b/docs/QUICKSETUP.md
@@ -1,0 +1,219 @@
+# Development Setup Guide
+
+> For contributors. Clone, build, and start hacking on Jonggrang itself.
+
+---
+
+## Prerequisites
+
+```bash
+node --version     # ≥ 18
+npm --version
+git --version
+
+# Optional for binary builds:
+bun --version      # npm install -g bun
+```
+
+---
+
+## Clone & Install
+
+```bash
+git clone <repo-url> jonggrang
+cd jonggrang
+make install        # npm install + cd client && npm install
+```
+
+---
+
+## Project Structure
+
+```
+jonggrang/
+├── bin/
+│   └── jonggrang.js          # CLI entry point
+├── lib/
+│   ├── jonggrang.js          # Core CLI logic
+│   ├── orchestration.js      # 16-phase state machine
+│   ├── hooks.js              # Hook loader (Claude, OpenCode, Pi)
+│   ├── feedback.js           # Feedback loop (dirty bits)
+│   ├── compaction.js         # Compaction gate
+│   ├── gateway.js            # Skill gateway routing
+│   ├── roles.js              # 5-role assembly line
+│   ├── settings.js           # Two-layer config management
+│   ├── locks.js              # File ownership locks
+│   ├── tui.js                # Pi TUI integration
+│   ├── bot-reviewer/         # Automated review bot
+│   └── tui/                  # TUI components
+├── hooks/
+│   ├── claude/               # Claude Code hook definitions
+│   ├── opencode/             # OpenCode plugin
+│   └── pi/                   # Pi SDK extension (jonggrang-extension.ts)
+├── skills/
+│   ├── core/                 # Tier 1 — always loaded (28 skills)
+│   └── library/              # Tier 2 — JIT via gateway
+├── client/
+│   ├── src/                  # Web dashboard (React + Vite)
+│   ├── dist/                 # Built client assets
+│   └── package.json
+├── scripts/
+│   ├── check.sh              # Validation script (syntax, structure)
+│   └── ensure-build.sh       # Auto-build client if needed
+├── test/
+│   └── backend-args.test.js  # Backend argument parsing tests
+├── templates/                # Init templates
+├── docs/                     # Documentation
+└── server.js                 # Express + Socket.IO dashboard server
+```
+
+### Key Entry Points
+
+| Entry | What it does |
+|-------|-------------|
+| `bin/jonggrang.js` | CLI command router — parses args, delegates to lib/ |
+| `server.js` | Web dashboard — Express + Socket.IO, serves client/dist |
+| `client/` | Dashboard frontend — React app built with Vite |
+| `hooks/pi/jonggrang-extension.ts` | Pi SDK extension — loaded via `--extension` on `jonggrang agent` |
+
+---
+
+## Build & Run
+
+```bash
+# Standard build (client only — lib/ is plain JS)
+make build          # cd client && npm install && npm run build
+
+# Run CLI
+node bin/jonggrang.js init
+node bin/jonggrang.js plan "test feature"
+
+# Run dashboard
+node server.js      # serves at http://localhost:8080
+
+# Dev mode (hot-reload dashboard)
+npm run dev:client  # Vite dev server
+npm run dev:server  # Express with auto-restart (you'll need nodemon/etc.)
+```
+
+---
+
+## Validation
+
+```bash
+# Full check (syntax + structure)
+npm run check
+
+# Quick syntax-only check
+npm run check:quick
+
+# Run tests
+npm test
+```
+
+---
+
+## Binary Build (Bun)
+
+```bash
+make build-binary                            # dist/jonggrang
+make build-binary BIN_OUT=out/jonggrang-darwin
+```
+
+---
+
+## Release Workflow
+
+```bash
+make release                # patch bump + build
+make release BUMP=minor
+make release-major
+```
+
+---
+
+## Architecture Overview
+
+Jonggrang is built on a **Thin Agent / Fat Platform** model:
+
+```
+┌─────────────────────────────────────────────┐
+│  AGENT LAYER       Stateless workers (<150L) │
+│  Lead · Developer · Reviewer · TestLead · Tester
+├─────────────────────────────────────────────┤
+│  SKILL LAYER       Two-tier progressive load │
+│  Core (BIOS) · Library (JIT via Gateway)    │
+├─────────────────────────────────────────────┤
+│  ORCHESTRATION     16-phase state machine    │
+│  MANIFEST.yaml · Work type · Phase skip     │
+├─────────────────────────────────────────────┤
+│  HOOK LAYER        Deterministic enforcement │
+│  Claude Code hooks · OpenCode plugin · Pi   │
+├─────────────────────────────────────────────┤
+│  INFRASTRUCTURE    Compaction · Feedback     │
+│  Token gates · Dirty bits · Lock files      │
+└─────────────────────────────────────────────┘
+```
+
+### State Machine (`lib/orchestration.js`)
+
+The 16-phase orchestration engine drives the entire workflow. Each phase outputs a structured artifact (JSON/YAML) to `.jonggrang/.output/features/{id}/`. Phases can be skipped based on work type. State persists across session restarts via MANIFEST.yaml.
+
+→ [Full orchestration docs](ORCHESTRATION.md)
+
+### Skill System (`skills/`)
+
+Skills are markdown prompt templates loaded by agents. **Core skills** are always available (like BIOS). **Library skills** are loaded on-demand via domain gateways (`gateway-backend`, `gateway-frontend`, etc.) that detect intent from natural language.
+
+→ [Skill system docs](SKILLS.md)
+
+### Hooks (`hooks/`)
+
+Deterministic enforcement that operates outside the LLM's context. Same rules apply regardless of AI backend. Three layers: pre-tool (block secrets/spawn), post-tool (dirty bits), stop (exit gates).
+
+### Feedback Loop (`lib/feedback.js`)
+
+Tracks which domains (backend/frontend/testing) were modified. When dirty bits are set, the agent cannot exit until both review and testing pass for every modified domain.
+
+### Compaction Gate (`lib/compaction.js`)
+
+Monitors context usage before heavy execution phases. Warns at 75%, hard-blocks at 85%. Each backend reads context differently: Claude Code reads JSONL transcripts, OpenCode listens for `session.compacted`, Jonggrang uses `before_provider_request` in Pi extension.
+
+---
+
+## Key Files to Edit
+
+| Task | File |
+|------|------|
+| Add a CLI command | `bin/jonggrang.js` → `lib/jonggrang.js` |
+| Add an orchestration phase | `lib/orchestration.js` |
+| Add a hook | `hooks/{claude\|opencode\|pi}/` |
+| Add a core skill | `skills/core/<name>/SKILL.md` |
+| Add a library skill | `skills/library/<domain>/<name>/SKILL.md` |
+| Modify the dashboard | `client/src/` |
+| Change init templates | `templates/` |
+| Update the dashboard API | `server.js` |
+
+---
+
+## Testing
+
+```bash
+npm test   # runs test/backend-args.test.js
+```
+
+The test suite validates backend argument parsing — ensuring `--model`, `--effort`, and `--tool` flags map correctly to each AI backend's native arguments.
+
+---
+
+## Documentation
+
+| Doc | Content |
+|-----|---------|
+| [PHILOSOPHY.md](PHILOSOPHY.md) | Full philosophy & architecture deep-dive |
+| [JONGGRANG.md](JONGGRANG.md) | Full specification |
+| [WORKFLOW.md](WORKFLOW.md) | Detailed workflow documentation |
+| [ORCHESTRATION.md](ORCHESTRATION.md) | 16-phase state machine reference |
+| [SKILLS.md](SKILLS.md) | Skill system reference |
+| [CONFIG.md](CONFIG.md) | Configuration reference |
+| [AGENTTOOLS.md](AGENTTOOLS.md) | Agent tool integration details |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,209 @@
+# Quick Start Guide
+
+> For beginners. Get Jonggrang running and build your first feature in 5 minutes.
+
+---
+
+## Prerequisites
+
+Make sure you have these installed:
+
+```bash
+node --version     # ≥ 18
+git --version
+jq --version       # brew install jq (macOS) or apt install jq (Linux)
+```
+
+Pick and install an AI agent backend:
+
+```bash
+# Option A: OpenCode (free, recommended)
+curl -fsSL https://opencode.ai/install | bash
+
+# Option B: Claude Code (requires Anthropic account)
+npm install -g @anthropic-ai/claude-code
+
+# Option C: Jonggrang / Pi (multi-provider, most flexible)
+npm install -g @earendil-works/pi-coding-agent
+```
+
+---
+
+## Step 1: Initialize Your Project
+
+```bash
+cd your-project
+jonggrang init
+```
+
+This launches an interactive wizard. It will ask you:
+- Project name
+- Project type (web-app, api, cli, etc.)
+- Tech stack
+- Which AI tool to use
+
+Or skip the wizard:
+
+```bash
+jonggrang init --name my-app --type api --stack express-typescript --tool opencode --force
+```
+
+After init, you'll see new files:
+- `AGENTS.md` — edit this! Tell the AI about your project conventions
+- `.jonggrang/` — config, task board, progress log
+- `skills/` — AI prompt templates
+
+---
+
+## Step 2: Plan Your Feature
+
+Tell Jonggrang what you want to build:
+
+```bash
+jonggrang plan "user authentication with JWT and password reset"
+```
+
+The AI writes a plan to `.jonggrang/plan.md`. **Read and edit it** before continuing — this is your chance to correct the AI's assumptions before any code is written.
+
+---
+
+## Step 3: Approve the Plan
+
+```bash
+jonggrang approve
+```
+
+The AI decomposes your plan into atomic tasks. Each task is small enough for one AI context window, with clear acceptance criteria and dependency ordering.
+
+Check the task board:
+
+```bash
+jonggrang status
+```
+
+---
+
+## Step 4: Execute
+
+```bash
+jonggrang work
+```
+
+Jonggrang works through the task queue. Each task gets a **fresh AI agent** — no accumulated confusion between tasks.
+
+Watch it:
+- Implement the task
+- Run type checks and tests
+- Commit if everything passes
+- Log what it learned
+- Move to the next task
+
+---
+
+## Step 5: Review
+
+```bash
+jonggrang review
+```
+
+A comprehensive code review across all changes. The report is saved to `jonggrang-log/review-{timestamp}.md`.
+
+---
+
+## Common Workflows
+
+### I want to skip plan review (one-shot)
+
+```bash
+jonggrang work "add REST API for todos" --yes
+```
+
+This runs plan → approve → execute in one command. Good for well-defined, low-risk features.
+
+### I want to use Claude Code instead of OpenCode
+
+```bash
+jonggrang work --tool claude
+```
+
+Or set it permanently in `.jonggrang/jonggrang.json`:
+```json
+{ "tool": "claude" }
+```
+
+### I want more control (supervised mode)
+
+```bash
+jonggrang work --mode supervised
+```
+
+The agent will pause and ask for your input at key decision points.
+
+### I want full autonomy
+
+```bash
+jonggrang work --mode autonomous
+```
+
+The agent plans, implements, and commits everything. You review at the end.
+
+### I want to use the TUI chat
+
+```bash
+jonggrang agent
+```
+
+Opens a full interactive chat session. Use `/plan`, `/work`, `/review`, `/status` commands without leaving the chat.
+
+### I want a visual dashboard
+
+```bash
+jonggrang web
+```
+
+Opens a browser with a Kanban board, real-time agent logs, and diff viewer.
+
+---
+
+## Troubleshooting
+
+### "command not found: jonggrang"
+
+Install globally:
+```bash
+npm install -g jonggrang
+```
+
+Or use npx:
+```bash
+npx jonggrang init
+```
+
+### "No AI tool configured"
+
+Run `jonggrang init` first, or install one of the supported tools:
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+### Task fails repeatedly
+
+```bash
+jonggrang work --task task-003   # Retry specific task
+jonggrang work --max-iterations 3  # Limit retries
+```
+
+Check `.jonggrang/progress.txt` for what the agent learned from failures.
+
+### Plan looks wrong
+
+Edit `.jonggrang/plan.md` directly before running `jonggrang approve`. The AI only reads it at approval time — you have full control until then.
+
+---
+
+## Next Steps
+
+- [Configure your project](CONFIG.md) — autonomy mode, hooks, CI
+- [Understand the philosophy](PHILOSOPHY.md) — why the pipeline exists
+- [Learn the skill system](SKILLS.md) — create custom AI behaviors
+- [Full command reference](../README.md#commands-at-a-glance)


### PR DESCRIPTION
## Apa yang berubah

**README dipangkas drastis** (~300 → ~115 baris). Sekarang punya dua jalur audience jelas:
- **I Just Want to Use It** → 5 perintah pertama + shortcut
- **I Want to Set Up for Development** → clone, install, build + link

## File baru

| File | Isi |
|------|-----|
| `docs/QUICKSTART.md` | Panduan step-by-step untuk pengguna awam: prerequisites, 5 langkah, common workflows, troubleshooting |
| `docs/QUICKSETUP.md` | Panduan development untuk kontributor: project structure, build/run, architecture overview, key files to edit |
| `docs/PHILOSOPHY.md` | Philosophy & architecture detail dipindahkan dari README (pipeline, 5-layer stack, 5-role assembly, hooks, skill system) |
| `AUTHORS.md` | Daftar kontributor |
| `CONTRIBUTING.md` | Panduan kontribusi: workflow, conventional commits, code style, area kontribusi, skill format |

## Perubahan kecil

- Tambah Codex CLI ke daftar AI agent backends
- Tambah section Contributors di README
- Penjelasan singkat MIT License di README (aman komersial, kontributor terlindungi)