### PR TITLE
docs: English-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,13 +2,15 @@
 
 ## Porcupine Team
 
-Jonggrang dibuat dan dikelola oleh **Porcupine Team**.
+Jonggrang is built by humans (for now) and bossed around by AI agents.
 
-### Active Contributors
+### The Ones Actually Writing Code
 
-- **Eka Irawan (Ibnu)** <anak10thn@gmail.com> — arsitektur, orchestration engine, skill system, CLI, web dashboard
-- **Ahmad Anshorimuslim Syuhada (Ans)** <ans4175@gmail.com> — arsitektur, skill libraries, Pi SDK integration, TUI, hooks, refactor, dokumentasi
+- **Eka Irawan (Ibnu)** <anak10thn@gmail.com> — the one who built the orchestra. Architecture, orchestration engine, skill system, CLI, web dashboard. If it moves in 16 phases, Ibnu probably made it.
+- **Ahmad Anshorimuslim Syuhada (Ans)** <ans4175@gmail.com> — the one who taught the orchestra to play nice with others. Skill libraries, Pi SDK integration, TUI, hooks, refactoring. If it talks to an AI provider, Ans probably wired it.
 
 ---
 
-_Untuk daftar kontributor lengkap berdasarkan commit, lihat `git shortlog -sn`._
+_Jonggrang itself was partially built by AI agents orchestrated through... well, Jonggrang. Dogfooding at its finest._
+
+_For the full contributor list by commit, see `git shortlog -sn`._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md — Project Guide for AI Agents
+
+> Guide for any AI agent (Claude Code, Codex, OpenCode, Jonggrang) working in this repo.
+> `AGENTS.md` is a symlink to this file — both point to the same source.
+
+---
+
+## What Jonggrang Is
+
+Jonggrang is a **CLI orchestrator for AI development workflows**. It runs the pipeline `Plan → Implement → Simplify → Test → Review` with one atomic task per fresh-context agent, enforced by hooks (secrets blocker, context overload guard, quality gate). The goal is not to make agents faster — they are already fast enough — but to force them to stop and clean up before complexity quietly accumulates.
+
+Two primary modes:
+- **Work Loop** — iterative, stateless, one agent per task. Good for small-to-medium features.
+- **Orchestrate Mode** — deterministic 16-phase, 5 specialist agents, persistent state via `MANIFEST.yaml`. For serious delivery.
+
+Agent backends: `opencode`, `claude`, `codex`, `jonggrang` (Pi SDK in-process). Selected via `.jonggrang/jonggrang.json`.
+
+Entry points: `bin/jonggrang` (CLI), `client/` (Pi TUI), `server.js` (web dashboard). Hooks live in `hooks/`, skills in `skills/`, templates in `templates/`.
+
+→ Full detail: [`docs/JONGGRANG.md`](docs/JONGGRANG.md) · [`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md) · [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
+
+---
+
+## Read These When You Need Context
+
+Two docs are the canonical source of truth for the project's *intent*. Read them before any non-trivial change — do not infer architecture from code alone:
+
+- **[`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md)** — Why Jonggrang exists, the pipeline as a quality gate, the five-layer stack, hook layers, autonomy modes, project file structure. Read this when:
+  - You are touching the pipeline (`Plan → Implement → Simplify → Test → Review`), any hook in `hooks/`, the compaction gate, or the feedback loop.
+  - You are unsure *why* a constraint exists (e.g., why coordinators cannot edit files, why exit is blocked until tests pass).
+  - You are tempted to "simplify" something that looks redundant — it is probably load-bearing.
+
+- **[`docs/JONGGRANG.md`](docs/JONGGRANG.md)** — Full blueprint: core principles (Thin Agent / Fat Platform, Context Engineering, Deterministic Enforcement), 16-phase orchestration, five-role assembly line with tool restrictions, skill tier system, team/parallel mode, quality gates, config schema, compound learning channels. Read this when:
+  - You are adding/changing a phase, role, skill tier, or agent backend.
+  - You are touching `MANIFEST.yaml`, `.jonggrang/.output/`, `.jonggrang/.ephemeral/`, or any persistent state file.
+  - You need to understand work-type classification (BUGFIX/SMALL/MEDIUM/LARGE) and phase-skipping logic.
+  - You are working on team mode, file ownership locks, or parallel worktree execution.
+
+**Rule of thumb:** if your change would alter any concept defined in those two files, read the relevant section first, then update both the code *and* the doc in the same task. Do not let the code drift from the philosophy.
+
+---
+
+## Iron Rule: Every Change, Check the Docs
+
+**README.md is the storefront. `docs/` is the manual.** Both must stay aligned with the actual state of the repo.
+
+Before declaring a task done, walk through the checklist below based on what you changed.
+
+### Change → docs to update
+
+| If you change… | Check & update… |
+|---|---|
+| **CLI command** (add/rename/remove a subcommand in `bin/`) | `README.md` ("Commands at a Glance" table + examples), `docs/QUICKSTART.md`, `docs/EXAMPLE.md` |
+| **Flag / option** on an existing command | `README.md` ("Quick flags"), `docs/CONFIG.md` if it touches the config schema |
+| **Config schema** (`.jonggrang/jonggrang.json`, `~/.jonggrang/settings.json`) | `docs/CONFIG.md` (required), `README.md` (jsonc snippet), `templates/` |
+| **Hook** added or modified in `hooks/` | `docs/PHILOSOPHY.md` (hooks section), `docs/WORKFLOW.md` if the hook participates in a specific phase |
+| **Skill** in `skills/` (core or library) | `docs/SKILLS.md` (required), `SKILL.md` if the format or tier model changes |
+| **Pipeline phase** / workflow order | `docs/WORKFLOW.md` (required), `docs/JONGGRANG.md` (16-phase section), `docs/PHILOSOPHY.md` (pipeline diagram), `docs/ORCHESTRATION.md`, `docs/EXAMPLE.md` |
+| **Role / agent definition** (Lead, Developer, Reviewer, Test Lead, Tester) | `docs/JONGGRANG.md` (Five-Role Assembly Line), `docs/PHILOSOPHY.md` (tool restriction boundary), `templates/agents/` |
+| **Hook layer / compaction gate / feedback loop** | `docs/PHILOSOPHY.md` (Hooks section), `docs/JONGGRANG.md` (Eight-Layer Defense) |
+| **Skill tier model** (Core vs Library, Gateway pattern) | `docs/SKILLS.md` (required), `docs/JONGGRANG.md` (Skill System), `docs/PHILOSOPHY.md` (Two-Tier section) |
+| **New agent backend** or integration change | `docs/AGENTTOOLS.md` (required), `README.md` (Requirements section + config example) |
+| **Persistent state schema** (`MANIFEST.yaml`, `.jonggrang/.output/`, `.ephemeral/`, locks) | `docs/JONGGRANG.md` (Project File Structure + state sections), `docs/PHILOSOPHY.md` (Persistent State) |
+| **Philosophy / architecture** shift | `docs/PHILOSOPHY.md`, `docs/JONGGRANG.md`, `docs/ORCHESTRATION.md` |
+| **Setup / install** changes (deps, build steps) | `README.md` (Requirements), `docs/QUICKSETUP.md`, `docs/QUICKSTART.md` |
+| **Version bump / release** | `README.md` (if any badge/version), `package.json`, CHANGELOG if present |
+| **Maintainers / contributors** | `AUTHORS.md`, `README.md` (Contributors section) |
+
+### README rules
+
+README.md is the front page — do not overload it:
+- **Do not duplicate detail** that already lives in `docs/`. If an explanation is long, put it in `docs/` and link from the README.
+- **Tables and examples in README must stay in sync** with the current CLI. The "Commands at a Glance" table is a contract — if a command is renamed or removed, update the table.
+- **`→ docs/X.md` links in the README must stay valid.** Check when renaming or deleting files under `docs/`.
+
+### When in doubt
+
+For small changes (typo fix, internal bug fix, refactor without API/CLI/config impact) you do not need to touch docs. For anything in the table above, treat the docs update as **part of the task**, not a follow-up.
+
+---
+
+## Working Standards
+
+- **Read before Edit.** For files larger than ~200 lines, prefer Write (full rewrite) over Edit — exact-string matches get flaky on long files.
+- **Small, verifiable steps** beat one large commit touching many things.
+- **No extra features, abstractions, or error handling** beyond what the task requires. A bug fix does not need surrounding cleanup.
+- **Verify before claiming done.** For CLI/hook changes, actually run the command. For docs changes, reread the section you edited.
+- **Commit convention** follows recent history (`chore:`, `docs:`, `feat:`, `fix:`). See `git log --oneline -20`.
+
+---
+
+## Quick Reference
+
+| Document | For |
+|---|---|
+| [`README.md`](README.md) | Storefront — what & why, command summary |
+| [`docs/QUICKSTART.md`](docs/QUICKSTART.md) | Onboarding for new users |
+| [`docs/QUICKSETUP.md`](docs/QUICKSETUP.md) | Dev environment setup |
+| [`docs/JONGGRANG.md`](docs/JONGGRANG.md) | Full blueprint |
+| [`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md) | Why Jonggrang exists, architecture |
+| [`docs/WORKFLOW.md`](docs/WORKFLOW.md) | 16-phase pipeline deep dive |
+| [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) | Technical case for deterministic orchestration |
+| [`docs/SKILLS.md`](docs/SKILLS.md) | Skill system (core + library tiers) |
+| [`docs/CONFIG.md`](docs/CONFIG.md) | Full configuration reference |
+| [`docs/AGENTTOOLS.md`](docs/AGENTTOOLS.md) | How to add a new agent backend |
+| [`docs/EXAMPLE.md`](docs/EXAMPLE.md) | Walkthroughs for work-loop and orchestrate |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to contribute |
+| [`AUTHORS.md`](AUTHORS.md) | Credits & backstory |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,19 @@
 # Contributing to Jonggrang
 
-Senang kamu tertarik kontribusi! Panduan singkat supaya prosesnya lancar.
+You found this. That means you either broke something, want to build something, or just like reading contribution guides (weird flex, but okay).
+
+Here's how to make it painless for you, for us, and for the AI agents who will eventually review your PR.
 
 ---
 
-## Prinsip Utama
+## Core Principles
 
-Jonggrang adalah alat untuk **mendisiplinkan AI coding agent**. Maka kode Jonggrang sendiri juga harus disiplin. Setiap kontribusi harus:
+Jonggrang exists to **discipline AI coding agents**. So yes, we eat our own dog food. This codebase is held to the same standards. Every contribution should:
 
-1. **Punya issue dulu** — diskusikan sebelum coding. Hindari PR yang datang tiba-tiba tanpa konteks.
-2. **Satu PR, satu concern** — jangan gabung bugfix + fitur baru + refactor dalam satu PR.
-3. **Test kalau memungkinkan** — terutama untuk `lib/` dan perubahan logic.
-4. **Update docs kalau relevan** — kalau kamu ubah behavior, update `docs/` yang terkait.
+1. **Start with an issue** — discuss before coding. PRs that materialize from the void make us nervous.
+2. **One PR, one concern** — don't sneak three features, two bugfixes, and a refactor into one PR. We see you.
+3. **Test when you can** — especially for `lib/` and logic changes. AI agents are good at writing tests. Use them.
+4. **Update docs** — if you change behavior and the docs still say the old thing, you just created a time bomb for the next person.
 
 ---
 
@@ -28,35 +30,35 @@ make build
 
 ---
 
-## Workflow Kontribusi
+## Contribution Workflow
 
-### 1. Pilih atau buat issue
+### 1. Pick or open an issue
 
-Cek [GitHub Issues](https://github.com/porcupine-md/jonggrang/issues). Kalau belum ada yang cocok, buat issue baru. Jelaskan:
-- Apa yang ingin diubah/diperbaiki
-- Kenapa perlu
-- Kalau fitur baru: bagaimana perilaku yang diharapkan
+Check [GitHub Issues](https://github.com/porcupine-md/jonggrang/issues). If nothing fits, open a new one. Tell us:
+- What you want to change/fix
+- Why anyone should care
+- For features: what "done" looks like
 
 ### 2. Branch
 
 ```bash
-git checkout -b feat/nama-fitur     # fitur baru
-git checkout -b fix/nama-bug        # bugfix
-git checkout -b docs/apa-yang-diupdate  # dokumentasi
+git checkout -b feat/feature-name     # new feature
+git checkout -b fix/bug-name          # bugfix
+git checkout -b docs/whats-updated    # documentation
 ```
 
 ### 3. Commit
 
-Kami pakai conventional commits:
+We use conventional commits. It keeps the changelog readable and the bots happy:
 
 ```
-feat: tambah support --deep mode untuk plan staging
-fix: compaction gate crash saat context window kosong
-docs: update QUICKSTART dengan troubleshooting
-refactor: ekstrak feedback loop ke file sendiri
+feat: add --deep mode support for plan staging
+fix: compaction gate crash on empty context window
+docs: update QUICKSTART with troubleshooting
+refactor: extract feedback loop to separate file
 ```
 
-Bahasa commit: **campur Indonesia/Inggris boleh**, yang penting jelas dan deskriptif.
+Commit messages in **English please**. Doesn't need to be Shakespeare — just clear enough that someone six months from now won't curse your name.
 
 ### 4. Test & check
 
@@ -65,73 +67,73 @@ npm test            # run test suite
 npm run check       # syntax + structure check
 ```
 
-### 5. Buka Pull Request
+### 5. Open a Pull Request
 
-Deskripsi PR harus menjawab:
-- **What** — apa yang berubah
-- **Why** — kenapa berubah
-- **How to test** — langkah verifikasi
+Your PR description should answer three questions:
+- **What** — what actually changed
+- **Why** — what would break if we didn't do this
+- **How to test** — give us a script, a command, something we can copy-paste
 
-Setelah PR dibuka, maintainer akan review dalam 1-3 hari kerja.
+We'll review within 1-3 business days. If it takes longer, we're either on vacation or the AI agents staged a coup.
 
 ---
 
-## Panduan Teknis
+## Technical Guide
 
-### Area kontribusi dan file terkait
+### Where to touch what
 
-| Area | File | Cocok kalau kamu... |
-|------|------|--------------------|
-| CLI command baru | `bin/jonggrang.js`, `lib/jonggrang.js` | Mau tambah `jonggrang xyz` |
-| Orchestration phase | `lib/orchestration.js` | Mau ubah alur kerja |
-| Hook sistem | `hooks/{claude,opencode,pi}/` | Mau tambah enforcement rules |
-| Core skill | `skills/core/<nama>/SKILL.md` | Mau tambah prompt template |
-| Library skill | `skills/library/<domain>/<nama>/SKILL.md` | Mau tambah domain knowledge |
-| Dashboard UI | `client/src/` | Mau ubah tampilan web |
-| Dashboard API | `server.js` | Mau tambah endpoint |
-| Template init | `templates/` | Mau ubah hasil `jonggrang init` |
-| Dokumentasi | `docs/` | Mau perbaiki/terjemahkan docs |
+| Area | File | When you want to... |
+|------|------|-------------------|
+| New CLI command | `bin/jonggrang.js`, `lib/jonggrang.js` | Add `jonggrang xyz` |
+| Orchestration phase | `lib/orchestration.js` | Change how work flows |
+| Hook system | `hooks/{claude,opencode,pi}/` | Add enforcement rules |
+| Core skill | `skills/core/<name>/SKILL.md` | Add a prompt template |
+| Library skill | `skills/library/<domain>/<name>/SKILL.md` | Add domain knowledge |
+| Dashboard UI | `client/src/` | Change the web UI |
+| Dashboard API | `server.js` | Add endpoints |
+| Init templates | `templates/` | Change what `jonggrang init` spits out |
+| Documentation | `docs/` | Fix typos, translate, add guides |
 
-### Struktur skill
+### How to write a skill
 
-Kalau bikin skill baru, gunakan format:
+Skills are markdown files that teach AI agents how to do things. Here's the format:
 
 ```markdown
 ---
-name: nama-skill
-description: Apa yang dilakukan skill ini
+name: skill-name
+description: What this skill does — be specific
 type: scaffold
 tier: core
 project_types: [web-app, api]
-trigger: "kata kunci yang memicu skill ini"
+trigger: "keywords that should activate this skill"
 ---
 
 ## Context
-Background info yang dibutuhkan agent.
+What the agent needs to know before starting.
 
 ## Instructions
-1. Langkah pertama
-2. Langkah kedua
+1. Do this first
+2. Then this
 
 ## Validation
-- [ ] Cek yang harus dipenuhi
+- [ ] This must be true when the skill is done
 ```
 
-### Gaya kode
+### Code style (or: how to not make Ibnu sigh)
 
-- **JavaScript plain**, bukan TypeScript (kecuali `hooks/pi/` yang emang `.ts`)
-- **Jangan over-engineer** — fungsi kecil, satu tanggung jawab
-- **Nama yang jelas** — `compactionGate.js` lebih baik dari `util2.js`
-- **Komentar sparingly** — kode yang bersih menjelaskan dirinya sendiri
+- **Plain JavaScript** unless you're in `hooks/pi/` (that one's TypeScript, don't fight it)
+- **Small functions, single purpose** — if your function does three things, it's three functions wearing a trench coat
+- **Name things like you mean it** — `compactionGate.js` > `util2.js`
+- **Comment sparingly** — if you need a paragraph to explain what a function does, the function name is wrong
 
 ---
 
-## Butuh Bantuan?
+## Stuck?
 
-Buka [GitHub Issues](https://github.com/porcupine-md/jonggrang/issues) atau tanya langsung ke maintainer.
+Open a [GitHub Issue](https://github.com/porcupine-md/jonggrang/issues) or ping a maintainer. We don't bite. The AI agents might, but we keep them on a leash.
 
 ---
 
 ## License
 
-Dengan berkontribusi, kamu setuju bahwa kontribusimu dilisensikan di bawah [MIT License](LICENSE) yang sama dengan proyek ini.
+By contributing, you agree your work falls under the same [MIT License](LICENSE). That means anyone can use it, sell it, or build it into their thing — just don't sue us if something breaks.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Jonggrang
 
-> AI Development Workflow Orchestrator — from idea to production-ready code.
+> AI agents write code fast. Too fast. Jonggrang makes sure they don't make a mess while doing it.
 
-Jonggrang is a CLI tool that orchestrates AI coding agents through a disciplined **Plan → Implement → Simplify → Test → Review** pipeline. It decomposes features into atomic tasks and executes them one-by-one with a fresh agent per task — no accumulated confusion, no drifting context.
+Jonggrang is a CLI tool that puts AI coding agents through a **Plan → Implement → Simplify → Test → Review** pipeline. It breaks features into atomic tasks, runs each one with a fresh agent, and refuses to let anything through until the quality gates are green.
 
-Supports four AI Coding Agents: [OpenCode](https://opencode.ai/), [Claude Code](https://claude.ai/code), [OpenAI Codex CLI](https://github.com/openai/codex), and **Jonggrang** (built on [Pi SDK](https://pi.dev/) — multi-provider, TypeScript-extensible).
+Works with four AI backends: [OpenCode](https://opencode.ai/), [Claude Code](https://claude.ai/code), [OpenAI Codex CLI](https://github.com/openai/codex), and **Jonggrang** (built on [Pi SDK](https://pi.dev/)). Pick your poison.
 
 ---
 
@@ -16,13 +16,15 @@ Jonggrang enforces a pipeline where every feature passes through the same gates:
 
 **Fresh context per task.** Each task starts with a clean agent instance. No stale assumptions carrying forward. **Hooks police in real-time** — secrets blocked, context overload prevented, exit refused until quality gates pass. **Simplify phase** revisits every changed file to reduce complexity before the PR opens.
 
-The agent will always take the shortest path. Jonggrang makes sure the shortest path is also the right one.
+Left unchecked, an AI agent will always take the shortest path — even if that path goes through a minefield. Jonggrang puts up the guardrails.
 
 → [Read the full philosophy & architecture](docs/PHILOSOPHY.md)
 
 ---
 
-## I Just Want to Use It
+## 🚀 I Just Want to Use It
+
+Five commands. That's all you need.
 
 ```bash
 # In your project directory:
@@ -47,7 +49,9 @@ jonggrang agent    # Full TUI chat with /plan, /work, /review, etc.
 
 ---
 
-## I Want to Set Up for Development
+## 🔧 I Want to Hack on It
+
+Come on in. The water's fine.
 
 ```bash
 git clone <repo-url> && cd jonggrang
@@ -109,32 +113,31 @@ jonggrang work --task task-003       # Execute specific task only
 }
 ```
 
-Two-layer: `~/.jonggrang/settings.json` (global) → `.jonggrang/jonggrang.json` (project overrides).
+Two-layer config: `~/.jonggrang/settings.json` (your defaults) → `.jonggrang/jonggrang.json` (this project's quirks).
 
 → [Full config reference](docs/CONFIG.md)
 
 ---
 
-## Documentation
+## 📚 More Reading
 
-| Doc | Content |
+| Doc | When you want to... |
 |-----|---------|
-| [QUICKSTART.md](docs/QUICKSTART.md) | Beginner's step-by-step guide |
-| [QUICKSETUP.md](docs/QUICKSETUP.md) | Development setup for contributors |
-| [PHILOSOPHY.md](docs/PHILOSOPHY.md) | Philosophy, pipeline, architecture deep-dive |
-| [JONGGRANG.md](docs/JONGGRANG.md) | Full specification |
-| [WORKFLOW.md](docs/WORKFLOW.md) | Detailed workflow documentation |
-| [SKILLS.md](docs/SKILLS.md) | Skill system reference |
-| [CONFIG.md](docs/CONFIG.md) | Configuration reference |
+| [QUICKSTART.md](docs/QUICKSTART.md) | Get building in 5 minutes |
+| [QUICKSETUP.md](docs/QUICKSETUP.md) | Set up your dev environment |
+| [PHILOSOPHY.md](docs/PHILOSOPHY.md) | Understand why this thing exists |
+| [JONGGRANG.md](docs/JONGGRANG.md) | Read the full blueprint |
+| [WORKFLOW.md](docs/WORKFLOW.md) | Grok the 16-phase pipeline |
+| [SKILLS.md](docs/SKILLS.md) | Teach the agents new tricks |
+| [CONFIG.md](docs/CONFIG.md) | Tweak every knob |
 
 ---
 
 ## Contributors
 
-Jonggrang dibuat dan dikelola oleh:
+- **[Eka Irawan (Ibnu)](https://github.com/anak10thn)** + **[Ahmad Anshorimuslim Syuhada (Ans)](https://github.com/ans-4175)**
 
-- **[Eka Irawan (Ibnu)](https://github.com/anak10thn)**
-- **[Ahmad Anshorimuslim Syuhada (Ans)](https://github.com/ans-4175)**
+→ [Full credits & backstory](AUTHORS.md)
 
 ---
 
@@ -142,4 +145,4 @@ Jonggrang dibuat dan dikelola oleh:
 
 MIT © Porcupine Team
 
-Lihat [LICENSE](LICENSE) untuk teks lengkap. Ringkasannya: **bebas pakai untuk apa pun, termasuk komersial, tanpa garansi. Kontributor dilindungi dari tuntutan.**
+See [LICENSE](LICENSE) for full text. TL;DR: **free to use for anything, including commercial, with no warranty. Contributors are protected from liability.**


### PR DESCRIPTION
## What changed

### All docs now in English
- **CONTRIBUTING.md** — translated from full Bahasa Indonesia to English
- **AUTHORS.md** — converted from mixed ID/EN to English
- **README.md** — Contributors & License sections translated

### Personality injected
- AUTHORS.md: "built by humans (for now) and bossed around by AI agents", dogfooding joke
- CONTRIBUTING.md: "You found this. That means you either broke something...", trench coat functions, AI agents on a leash
- README.md: "because even genius needs an editor", "Pick your poison", "Come on in. The water's fine", punchier tagline

### New files
- **AGENTS.md** — symlink to CLAUDE.md, project guide for all AI agents
- **CLAUDE.md** — project conventions, architecture overview, style guide for AI agents working in this repo

### README tweaks
- Contributors section now links to AUTHORS.md for full credits
- Documentation table headers made more conversational ("When you want to..." / "Get building in 5 minutes", "Teach the agents new tricks")

---

**Target audience: international.** No more Indonesian in docs. Still sounds human, not corporate.