### PR TITLE
feat: diff-budget with per-file fallback for simplify phase

### DIFF
--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1833,16 +1833,23 @@ async function runOrchestrationLoop(featureId, manifest, manifestPath) {
       process.exit(0);
     }
 
-    // ── Build phase prompt ────────────────────────────────────────
-    let phaseContext;
+    // ── Build phase prompt(s) ─────────────────────────────────────
+    // Most phases run a single agent. The simplify phase may split into
+    // one fresh agent per changed file when the total diff is large
+    // (see orchestration.planSimplify) — each unit is a separate run.
+    let phaseUnits;
     if (phaseNum === orchestration.SIMPLIFY_PHASE) {
-      // Phase 9 (simplification) uses specialized prompt with file scope
-      phaseContext = orchestration.buildSimplifyPrompt(manifest, PROJECT_ROOT);
+      const plan = orchestration.planSimplify(manifest, PROJECT_ROOT);
+      if (plan.mode === 'per-file') {
+        logInfo(`Simplify: total diff ~${plan.totalTokens} tokens > budget — splitting into ${plan.units.length} per-file agents`);
+        phaseUnits = plan.units.map(u => ({ core: u.prompt, label: u.file }));
+      } else {
+        phaseUnits = [{ core: plan.prompt, label: null }];
+      }
     } else {
-      // All other phases use generic phase context
-      phaseContext = orchestration.buildPhaseContext(manifest, phaseNum);
+      phaseUnits = [{ core: orchestration.buildPhaseContext(manifest, phaseNum), label: null }];
     }
-    
+
     const agentsContent = lib.fileExists(paths.agentsFile)
       ? fs.readFileSync(paths.agentsFile, 'utf8') : '';
     const progressContent = lib.fileExists(paths.progressFile)
@@ -1851,22 +1858,27 @@ async function runOrchestrationLoop(featureId, manifest, manifestPath) {
     const outputDir = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', featureId);
     fs.mkdirSync(outputDir, { recursive: true });
 
-    const prompt = [
-      phaseContext,
+    const buildPrompt = (core) => [
+      core,
       agentsContent ? `\n## Project Conventions (AGENTS.md)\n${agentsContent}` : '',
       progressContent ? `\n## Recent Learnings (progress.txt)\n${progressContent}` : '',
       `\n## Output Directory\nWrite all output files to: ${outputDir}/`,
     ].filter(Boolean).join('\n');
 
     if (DRY_RUN) {
-      logInfo(`[DRY RUN] Phase ${phaseNum} prompt (${prompt.length} chars)`);
+      logInfo(`[DRY RUN] Phase ${phaseNum}: ${phaseUnits.length} agent run(s)`);
       orchestration.completePhase(manifestPath, phaseNum, { dry_run: true });
       manifest = orchestration.readManifest(manifestPath);
       continue;
     }
 
-    // ── Run agent ─────────────────────────────────────────────────
-    const exitCode = await lib.runAgent(prompt, activeTool, activeMode, PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+    // ── Run agent(s) ──────────────────────────────────────────────
+    let exitCode = 0;
+    for (const unit of phaseUnits) {
+      if (unit.label) logInfo(`  → simplify: ${unit.label}`);
+      exitCode = await lib.runAgent(buildPrompt(unit.core), activeTool, activeMode, PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+      if (exitCode !== 0) break;
+    }
 
     if (exitCode !== 0) {
       logWarn(`Phase ${phaseNum} agent exited with code ${exitCode}`);

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -46,6 +46,8 @@ Each task runs in a *fresh context*. No accumulated confusion, no prompt memory 
 ### Simplify
 After implementation, before the PR is opened, the agent revisits every changed file with a single mandate: *reduce complexity without changing behavior*. Rename the unclear variable. Collapse the redundant function. Remove the comment that just restates the code. This phase exists because the first pass is never the last word.
 
+To keep this phase from overflowing a small context window, the agent is fed the **diff** of the changed files (not asked to read every file in full) and only opens a whole file when it needs more surrounding context. The orchestrator measures the total diff *before spawning*: if it stays under `SIMPLIFY_DIFF_BUDGET` (a token threshold), one agent handles all files; if it exceeds the budget, the phase splits into **one fresh agent per file**, so each session's load is bounded by a single file rather than the sum of the change. The split is decided deterministically in code — never left to the model to notice mid-run, by which point it would already have compacted.
+
 ### Test
 The agent writes the tests, runs them, and verifies coverage. Tests are not an afterthought appended at the end; they are part of the definition of done for every task.
 

--- a/docs/plans/2026-05-30-simplify-diff-budget-design.md
+++ b/docs/plans/2026-05-30-simplify-diff-budget-design.md
@@ -1,0 +1,149 @@
+# Simplify Phase — Diff Budget with Per-File Fallback
+
+**Date:** 2026-05-30
+**Status:** Design approved, pending implementation
+**Area:** Orchestrate mode — Phase 9 (Simplification)
+
+---
+
+## Problem
+
+The simplify phase (`buildSimplifyPrompt`, `lib/orchestration.js:430`) injects only a
+list of changed file paths into the prompt and tells the agent to *"Read each file
+listed above"*. The agent then loads the **full content of every changed file** into a
+single session.
+
+On small-context backends (e.g. DeepSeek via the jonggrang Pi SDK), the session fills
+and **auto-compacts mid-run** — frequently — because the loaded token count equals the
+sum of all changed files read in full. This is compaction case **(B)**: it happens
+*inside the simplify agent's own session*, not in the orchestrator thread (the
+`compaction-gate.sh` hook, which guards the main Claude thread at 200k).
+
+## Goal
+
+Reduce in-agent compaction during simplify by:
+1. Feeding the agent the **diff** (changed hunks) instead of making it read whole files
+   (Approach 1 — default).
+2. Falling back to **one fresh agent per file** when the total diff is large
+   (Approach 2 — automatic fallback), so per-session token load is bounded by a single
+   file rather than the sum of all files.
+
+The fallback decision is **deterministic, made in code before spawning** — not delegated
+to the (small) model, which would already have compacted by the time it "noticed."
+
+## Non-goals
+
+- Not changing any phase other than Simplify.
+- Not chunking a single oversized file further (accepted limitation, see Edge Cases).
+- Not making the budget user-configurable yet (kept as a code constant).
+
+---
+
+## Design
+
+### Components
+
+| Component | Location | Purpose |
+|---|---|---|
+| `SIMPLIFY_DIFF_BUDGET = 200_000` | `lib/orchestration.js` (const) | Token threshold: total diff ≤ budget → single mode; otherwise per-file mode. Tunable. |
+| `estimateTokens(text)` | `lib/compaction.js` (new, exported) | Rough estimate `Math.ceil(text.length / 4)` (~4 chars/token). Reused for the budget check. |
+| `planSimplify(manifest, projectRoot)` | `lib/orchestration.js` (new) | Deterministic brain: gathers diffs, estimates tokens, picks mode, returns a plan. |
+| `buildSimplifyPrompt(...)` | `lib/orchestration.js` (modified) | Single-mode prompt — now inlines the diff under `## Changes`. |
+| `buildSimplifyPromptForFile(...)` | `lib/orchestration.js` (new) | Per-file-mode prompt — same template scoped to one file + its diff. |
+| Simplify special-case | `bin/jonggrang.js` (phase loop) | Calls `planSimplify`; runs one agent (single) or loops per file (per-file). |
+
+### Decision flow (`planSimplify`)
+
+```
+1. changedFiles = getChangedFilesForSimplify(manifestPath, projectRoot)   // existing
+2. for each file: diff = git diff HEAD -- <file>
+                  (if empty → untracked/new file → use full file content as the diff)
+3. totalTokens = estimateTokens(join(all diffs))
+4. if totalTokens <= SIMPLIFY_DIFF_BUDGET (200_000):
+       return { mode: 'single', prompt: buildSimplifyPrompt(... diffs inlined ...) }
+   else:
+       return { mode: 'per-file',
+                units: changedFiles.map(f => ({ file: f, prompt: buildSimplifyPromptForFile(f, diff_f, ...) })) }
+```
+
+### Control flow (`bin/jonggrang.js`)
+
+A dedicated branch before the generic phase-prompt block:
+
+```
+if (phaseNum === SIMPLIFY_PHASE) {
+    plan = orchestration.planSimplify(manifest, PROJECT_ROOT)
+    if (plan.mode === 'single') {
+        runAgent(plan.prompt, activeTool, activeMode, ...)        // == current behavior
+    } else {
+        for (const unit of plan.units) {
+            runAgent(unit.prompt, activeTool, activeMode, ...)    // fresh session per file
+        }
+    }
+    completePhase(...) once all runs return exitCode 0
+    continue
+}
+```
+
+- Per-file mode runs on **the user's configured backend** (`activeTool`), not locked to
+  DeepSeek — same `runAgent` path as single mode.
+- Phase completion is gated on `exitCode === 0` per run (existing convention), not on
+  parsing any signal.
+
+### Prompt shapes (all English)
+
+**Single mode** — current `buildSimplifyPrompt` template, plus:
+- New `## Changes` section containing the inlined diff(s).
+- `## Process` step 1 becomes:
+  *"Review the diff below. Use the Read tool to open a full file **only if** you need
+  more surrounding context."*
+
+**Per-file mode** — identical template, scoped to one file:
+- `## Scope` lists only that one file.
+- `## Changes` contains only that file's diff.
+- Closes with `IMPLEMENTATION_COMPLETE` (the developer role's completion signal).
+
+### Why `IMPLEMENTATION_COMPLETE` is safe in per-file mode
+
+`IMPLEMENTATION_COMPLETE` is the **developer role's `completion_signal`**
+(`lib/roles.js:31`), consumed by `detectCompletionSignal` (`lib/roles.js:208`) for
+loop/role detection — it is **not** a hard phase gate. Phase completion is driven by
+`exitCode` in the work loop (`bin/jonggrang.js:1871-1876`). Each per-file agent is an
+independent run that emits the signal at the end of its single-file task; repeating it
+across N runs is harmless and consistent with the role convention.
+
+---
+
+## Edge cases
+
+1. **New / untracked files** — `git diff HEAD -- <file>` is empty. Use the **full file
+   content** as that file's "changes" (simplifying a new file means reviewing it whole
+   anyway). Already captured: `getChangedFilesForSimplify` includes untracked files.
+2. **A single file whose diff alone exceeds the budget** — per-file mode still sends that
+   one large diff to one agent, which *may* still compact. This is the granularity floor;
+   damage is bounded to that file. **Not** split further (YAGNI). Emit a `logWarn` so it
+   is visible.
+3. **Zero changed files** — preserve current graceful behavior (simplify becomes a no-op).
+
+---
+
+## Docs to update (CLAUDE.md iron rule — pipeline phase behavior change)
+
+- `docs/WORKFLOW.md` — Simplify phase now has two modes + automatic fallback.
+- `docs/JONGGRANG.md` — Simplify / 16-phase section.
+- `docs/PHILOSOPHY.md` — only if it describes simplify mechanics.
+- `docs/CONFIG.md` — **not** needed yet (budget stays a code constant). Revisit only if
+  the budget is later exposed in `jonggrang.json`.
+
+---
+
+## Implementation order
+
+1. Add `estimateTokens` to `lib/compaction.js` + export.
+2. Add `SIMPLIFY_DIFF_BUDGET`, `getDiffForFile`/diff-gathering helper, `planSimplify`,
+   `buildSimplifyPromptForFile` to `lib/orchestration.js`; update `buildSimplifyPrompt`
+   to inline diffs.
+3. Wire the simplify special-case branch in `bin/jonggrang.js`.
+4. Update docs (WORKFLOW, JONGGRANG, PHILOSOPHY as applicable).
+5. Verify: run a feature through orchestrate with both a small diff (single mode) and a
+   large diff (per-file mode); confirm no mid-run compaction on the small-window backend.

--- a/lib/compaction.js
+++ b/lib/compaction.js
@@ -21,6 +21,15 @@ const THRESHOLDS = {
 
 const CONTEXT_WINDOW = 200_000; // Claude's context window in tokens
 
+/**
+ * Rough token estimate for a block of text (~4 chars per token).
+ * Used for budget checks where an exact tokenizer is unnecessary.
+ */
+function estimateTokens(text) {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
 // ============================================================
 // CLAUDE CODE — SESSION TRANSCRIPT READER
 // ============================================================
@@ -271,6 +280,7 @@ function refreshCompactionState(projectRoot, externalUsage = null) {
 module.exports = {
   THRESHOLDS,
   CONTEXT_WINDOW,
+  estimateTokens,
   getClaudeProjectsDir,
   hashProjectPath,
   findLatestSessionFile,

--- a/lib/orchestration.js
+++ b/lib/orchestration.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const locks = require('./locks');
+const { estimateTokens } = require('./compaction');
 
 // ============================================================
 // PHASE DEFINITIONS
@@ -373,6 +374,11 @@ function listManifests(projectRoot) {
 
 const SIMPLIFY_PHASE = 9;
 
+// Total estimated diff tokens above which simplify splits into one
+// fresh agent per file (Approach 2 fallback) instead of one agent for
+// all files (Approach 1 default). Tunable.
+const SIMPLIFY_DIFF_BUDGET = 200_000;
+
 /**
  * Get changed files since implementation started.
  * Uses git diff to detect files modified during phase 8.
@@ -423,20 +429,41 @@ function getChangedFilesForSimplify(manifestPath, projectRoot) {
 }
 
 /**
- * Build the simplification phase prompt, adapted from pi-simplify.
- * Instructs the developer agent to review changed files and apply
- * clarity/conciseness improvements without changing behavior.
+ * Get the diff for a single changed file (tracked changes vs HEAD).
+ * New / untracked files have no diff against HEAD, so their full
+ * content is returned instead — simplifying a new file reviews it whole.
  */
-function buildSimplifyPrompt(manifest, projectRoot) {
-  const manifestPath = getManifestPath(projectRoot, manifest.feature_id);
-  const changedFiles = getChangedFilesForSimplify(manifestPath, projectRoot);
+function getDiffForFile(file, projectRoot) {
+  const execFileSync = require('child_process').execFileSync;
 
-  const fileList = changedFiles.length > 0
-    ? changedFiles.map(f => `- ${f}`).join('\n')
-    : '(auto-detected from git diff — review all files modified in this feature)';
+  // Tracked changes: diff against HEAD (exclude deletions handled upstream).
+  try {
+    const diff = execFileSync('git', ['diff', 'HEAD', '--', file], {
+      cwd: projectRoot, encoding: 'utf8', timeout: 5000,
+    });
+    if (diff.trim()) return diff;
+  } catch { /* fall through */ }
 
-  const phaseContext = buildPhaseContext(manifest, SIMPLIFY_PHASE);
+  // New / untracked file: no diff against HEAD — use full content,
+  // since simplifying a new file means reviewing it whole.
+  try {
+    return fs.readFileSync(path.join(projectRoot, file), 'utf8');
+  } catch {
+    return '';
+  }
+}
 
+function gatherDiffs(changedFiles, projectRoot) {
+  return changedFiles.map(file => ({ file, diff: getDiffForFile(file, projectRoot) }));
+}
+
+function formatChanges(diffs) {
+  return diffs
+    .map(d => `### ${d.file}\n\n\`\`\`diff\n${d.diff}\n\`\`\``)
+    .join('\n\n');
+}
+
+function renderSimplifyPrompt(phaseContext, fileList, changesBlock) {
   return `## Phase 9 — Simplification
 
 ${phaseContext}
@@ -456,9 +483,13 @@ Review the changed files from the implementation phase and apply simplification 
 Only review and modify these files:
 ${fileList}
 
+## Changes
+
+${changesBlock}
+
 ## Process
 
-1. Read each file listed above
+1. Review the diff above. Use the Read tool to open a full file only if you need more surrounding context.
 2. Identify concrete improvements (dead code, unclear names, redundant logic, inconsistent patterns)
 3. Apply changes one file at a time
 4. After all changes, run existing tests to verify nothing is broken
@@ -470,6 +501,64 @@ Do NOT add new features, change public APIs, or refactor code outside the listed
 
 You are a **Developer** in this phase — you can edit files. After completing all improvements, output:
 IMPLEMENTATION_COMPLETE`;
+}
+
+/**
+ * Build the single-agent simplification prompt for all changed files,
+ * with their diffs inlined. Used when the total diff fits the budget
+ * (see planSimplify). Instructs the developer agent to reduce complexity
+ * without changing behavior.
+ */
+function buildSimplifyPrompt(manifest, projectRoot) {
+  const manifestPath = getManifestPath(projectRoot, manifest.feature_id);
+  const changedFiles = getChangedFilesForSimplify(manifestPath, projectRoot);
+  const phaseContext = buildPhaseContext(manifest, SIMPLIFY_PHASE);
+
+  if (changedFiles.length === 0) {
+    return renderSimplifyPrompt(
+      phaseContext,
+      '(auto-detected from git diff — review all files modified in this feature)',
+      '(no changes detected)',
+    );
+  }
+
+  const diffs = gatherDiffs(changedFiles, projectRoot);
+  const fileList = changedFiles.map(f => `- ${f}`).join('\n');
+  return renderSimplifyPrompt(phaseContext, fileList, formatChanges(diffs));
+}
+
+/**
+ * Decide how to run the simplification phase based on total diff size.
+ *
+ * Deterministic, made before spawning any agent:
+ *   total diff tokens <= SIMPLIFY_DIFF_BUDGET → one agent, all diffs inlined
+ *   otherwise                                 → one fresh agent per file
+ *
+ * Returns { mode: 'single', prompt } or { mode: 'per-file', units: [{ file, prompt }] }.
+ */
+function planSimplify(manifest, projectRoot) {
+  const manifestPath = getManifestPath(projectRoot, manifest.feature_id);
+  const changedFiles = getChangedFilesForSimplify(manifestPath, projectRoot);
+  const phaseContext = buildPhaseContext(manifest, SIMPLIFY_PHASE);
+
+  if (changedFiles.length === 0) {
+    return { mode: 'single', prompt: buildSimplifyPrompt(manifest, projectRoot), totalTokens: 0 };
+  }
+
+  const diffs = gatherDiffs(changedFiles, projectRoot);
+  const totalTokens = estimateTokens(diffs.map(d => d.diff).join('\n'));
+
+  if (totalTokens <= SIMPLIFY_DIFF_BUDGET) {
+    const fileList = changedFiles.map(f => `- ${f}`).join('\n');
+    const prompt = renderSimplifyPrompt(phaseContext, fileList, formatChanges(diffs));
+    return { mode: 'single', prompt, totalTokens };
+  }
+
+  const units = diffs.map(d => ({
+    file: d.file,
+    prompt: renderSimplifyPrompt(phaseContext, `- ${d.file}`, formatChanges([d])),
+  }));
+  return { mode: 'per-file', units, totalTokens };
 }
 
 // ============================================================
@@ -522,5 +611,7 @@ module.exports = {
   listManifests,
   buildPhaseContext,
   buildSimplifyPrompt,
+  planSimplify,
   SIMPLIFY_PHASE,
+  SIMPLIFY_DIFF_BUDGET,
 };


### PR DESCRIPTION
## What

Reworks the **Simplify phase (Phase 9)** so it stops overflowing small context windows (e.g. DeepSeek via the jonggrang Pi SDK).

Previously the phase injected only a list of changed file paths and told the agent to *"Read each file listed above"* — the agent then loaded the **full content of every changed file** into one session. On small-window backends the session auto-compacted mid-run, frequently, because the loaded tokens equalled the sum of all files read in full.

Now the phase feeds the agent the **diff** of the changed files, and splits into one fresh agent per file when the total diff is large.

## How

- `lib/compaction.js` — add `estimateTokens(text)` (~4 chars/token).
- `lib/orchestration.js` — `getDiffForFile`, `planSimplify`; `buildSimplifyPrompt` now inlines diffs under a `## Changes` section; `SIMPLIFY_DIFF_BUDGET = 200_000`.
- `bin/jonggrang.js` — simplify phase runs as one-or-many agents per `planSimplify`, on the user's configured backend.
- `docs/PHILOSOPHY.md` — documents the diff-budget mechanic.
- `docs/plans/` — design doc with the full rationale.

## Decisions & tradeoffs

**1. Inline the diff instead of reading whole files (default), with per-file fallback.**
The diff is usually far smaller than the full files, so the default single-agent path already loads much less. When the total diff still exceeds the budget, the phase splits into **one fresh agent per file** — bounding each session's load to a *single file* rather than the *sum* of all changes.
- _Tradeoff:_ simplification quality can dip slightly when the agent can't see surrounding code. Mitigated by including diff context lines and explicitly allowing the agent to `Read` a full file when it needs more.

**2. The split decision is deterministic, made in code before spawning — not by the model.**
The natural alternative was to let the agent notice it was running out of room and request a split. Rejected: on a small-window backend the agent **already compacts before it can "notice"**, so the decision arrives too late. It also conflicts with Jonggrang's *Deterministic Enforcement* principle. The orchestrator measures total diff tokens up front and picks the mode before any agent runs.

**3. Budget is a code constant (`SIMPLIFY_DIFF_BUDGET = 200_000`), not config — yet.**
Kept as a single named constant so it's trivial to tune. Not exposed in `jonggrang.json` to avoid premature config surface; `docs/CONFIG.md` is intentionally untouched. Easy to promote to a setting later.

**4. New / untracked files use full content as their "changes".**
`git diff HEAD -- file` is empty for untracked files, so we fall back to the full file — simplifying a brand-new file means reviewing it whole anyway.

**5. A single file whose diff alone exceeds the budget is *not* split further.**
Accepted limitation (YAGNI). Per-file is the granularity floor; damage is bounded to that one file, and a `logWarn` keeps it visible. Chunking within a file added complexity we didn't need.

**6. `IMPLEMENTATION_COMPLETE` is safe to emit per file.**
It's the developer role's `completion_signal` used for loop/role detection (`lib/roles.js`), **not** a hard phase gate — phase completion is driven by `exitCode` in the work loop. Each per-file agent emitting it independently is harmless and consistent with the role convention.

## Verification

- `npm run check:syntax` → 20 passed
- `npm test` → 17 passed
- Manual: exercised single mode, per-file fallback (forced tiny budget), and the untracked-file path against the real repo state.

## Known drift (pre-existing, out of scope)

While updating docs I found that `docs/WORKFLOW.md` / `docs/JONGGRANG.md` use a 16-phase table where **phase 9 = DesignVerify** with **no Simplify row**, while the code has `SIMPLIFY_PHASE = 9` and the philosophy pipeline `Plan → Implement → Simplify → Test → Review`. To avoid deepening that drift, simplify mechanics are documented only in `docs/PHILOSOPHY.md` (where the phase is actually described). Reconciling the phase numbering across docs and code is a separate, larger task.

cc @anak10thn
