### PR TITLE
fix: prevent re-initialization from destroying existing project state

### DIFF
--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -957,15 +957,36 @@ function displayPlanBox(planFile) {
 // Ensure the project is initialized. Offers to run `jonggrang init` if not.
 // Returns true if we can proceed, false if the user declined or init failed.
 async function ensureInit() {
-  if (lib.fileExists(CONFIG_FILE)) return true;
+  const validation = lib.validateProjectState(PROJECT_ROOT);
 
+  // All 3 files valid — ready to go
+  if (validation.allValid) return true;
+
+  // Config is valid but tasks/progress are missing/corrupt — auto-regenerate them
+  if (validation.config.valid) {
+    const existingConfig = lib.readJSON(CONFIG_FILE);
+    const name = existingConfig?.name || path.basename(PROJECT_ROOT);
+
+    if (!validation.tasks.valid) {
+      lib.writeJSON(TASKS_FILE, { feature: '', branch: '', tasks: [] });
+      logWarn(`Regenerated jonggrang-tasks.json (was ${validation.tasks.reason}).`);
+    }
+    if (!validation.progress.valid) {
+      const now = new Date().toISOString().split('T')[0];
+      fs.writeFileSync(PROGRESS_FILE, `# Jonggrang Progress Log — ${name}\n# Created: ${now}\n`);
+      logWarn(`Regenerated progress.txt (was ${validation.progress.reason}).`);
+    }
+    return true;
+  }
+
+  // Config itself is invalid — need full init
   const isInteractiveTTY = process.stdin.isTTY && process.stdout.isTTY;
   if (!isInteractiveTTY) {
     logError('Project not initialized. Run "jonggrang init" first.');
     return false;
   }
 
-  logWarn('Project not initialized (.jonggrang/jonggrang.json not found).');
+  logWarn('Project not initialized (.jonggrang/jonggrang.json not found or invalid).');
   const doInit = await confirm({
     message: 'Initialize project now?',
     initialValue: true,
@@ -1659,19 +1680,46 @@ async function cmdInit() {
 
   const isInteractiveTTY = process.stdin.isTTY && process.stdout.isTTY;
 
-  if (lib.fileExists(CONFIG_FILE) && !INIT_FORCE) {
-    if (isInteractiveTTY) {
-      const overwrite = await confirm({
-        message: 'jonggrang.json already exists. Overwrite?',
-        initialValue: false,
-      });
-      if (isCancel(overwrite) || !overwrite) {
-        cancel('Init cancelled.');
-        return;
+  // ── Validate existing project state ───────────────────────────
+  const validation = lib.validateProjectState(PROJECT_ROOT);
+
+  if (validation.allValid && !INIT_FORCE) {
+    // All 3 files exist and are valid — skip re-initialization
+    const existingConfig = lib.readJSON(CONFIG_FILE);
+    const existingTasks = lib.getTasks(TASKS_FILE);
+    const taskCount = existingTasks.tasks?.length || 0;
+    const completedCount = existingTasks.tasks?.filter(t => t.status === 'completed').length || 0;
+    logSuccess(`Project "${existingConfig.name}" is already initialized.`);
+    logInfo(`  jonggrang.json       ✓ valid`);
+    logInfo(`  jonggrang-tasks.json ✓ valid (${taskCount} tasks, ${completedCount} completed)`);
+    logInfo(`  progress.txt         ✓ valid`);
+    logInfo('Use --force to re-initialize from scratch.');
+    return;
+  }
+
+  if (!validation.allValid && !INIT_FORCE) {
+    // Some files exist — warn user before overwriting
+    const hasAny = validation.config.valid || validation.tasks.valid || validation.progress.valid;
+    if (hasAny) {
+      const statusLabel = (v) => v.valid ? '✓ valid' : `✗ ${v.reason}`;
+      logWarn('Existing project state detected:');
+      logInfo(`  jonggrang.json       ${statusLabel(validation.config)}`);
+      logInfo(`  jonggrang-tasks.json ${statusLabel(validation.tasks)}`);
+      logInfo(`  progress.txt         ${statusLabel(validation.progress)}`);
+
+      if (isInteractiveTTY) {
+        const overwrite = await confirm({
+          message: 'Re-initialize? Valid files will be preserved where possible.',
+          initialValue: false,
+        });
+        if (isCancel(overwrite) || !overwrite) {
+          cancel('Init cancelled.');
+          return;
+        }
+      } else {
+        logError('Project partially initialized. Use --force to overwrite.');
+        process.exit(1);
       }
-    } else {
-      logError('jonggrang.json already exists. Use --force to overwrite.');
-      process.exit(1);
     }
   }
 
@@ -1760,7 +1808,7 @@ async function cmdInit() {
     autonomy: INIT_AUTONOMY,
     testing: INIT_TESTING,
     ci: INIT_CI,
-  }, JONGGRANG_HOME, PROJECT_ROOT);
+  }, JONGGRANG_HOME, PROJECT_ROOT, { force: !!INIT_FORCE });
 
   logSuccess('Generated .jonggrang/jonggrang.json');
   logSuccess('Generated opencode.json');

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -95,6 +95,43 @@ function checkConfig(configFile) {
   }
 }
 
+// ── State validation ─────────────────────────────────────────
+
+function validateConfigFile(configFilePath) {
+  if (!fileExists(configFilePath)) return { valid: false, reason: 'missing' };
+  const data = readJSON(configFilePath);
+  if (!data) return { valid: false, reason: 'corrupt' };
+  if (typeof data.name !== 'string' || !data.name) return { valid: false, reason: 'missing_field', field: 'name' };
+  if (typeof data.project !== 'object' || !data.project?.stack) return { valid: false, reason: 'missing_field', field: 'project.stack' };
+  return { valid: true };
+}
+
+function validateTasksFile(tasksFilePath) {
+  if (!fileExists(tasksFilePath)) return { valid: false, reason: 'missing' };
+  const data = readJSON(tasksFilePath);
+  if (!data) return { valid: false, reason: 'corrupt' };
+  if (!Array.isArray(data.tasks)) return { valid: false, reason: 'missing_field', field: 'tasks' };
+  return { valid: true };
+}
+
+function validateProgressFile(progressFilePath) {
+  if (!fileExists(progressFilePath)) return { valid: false, reason: 'missing' };
+  try {
+    const content = fs.readFileSync(progressFilePath, 'utf8');
+    if (!content.trim()) return { valid: false, reason: 'empty' };
+    return { valid: true };
+  } catch { return { valid: false, reason: 'unreadable' }; }
+}
+
+function validateProjectState(projectRoot) {
+  const paths = getProjectPaths(projectRoot);
+  const config = validateConfigFile(paths.configFile);
+  const tasks = validateTasksFile(paths.tasksFile);
+  const progress = validateProgressFile(paths.progressFile);
+  const allValid = config.valid && tasks.valid && progress.valid;
+  return { allValid, config, tasks, progress };
+}
+
 // ============================================================
 // TASK MANAGEMENT
 // ============================================================
@@ -1400,7 +1437,7 @@ function generateConfig(options) {
   };
 }
 
-function runInit(options, jonggrangHome, projectRoot) {
+function runInit(options, jonggrangHome, projectRoot, opts = {}) {
   const { name, type, stack, tool, testing, ci } = options;
   const paths = getProjectPaths(projectRoot);
   const testCmd = getTestCommand(testing);
@@ -1487,12 +1524,16 @@ function runInit(options, jonggrangHome, projectRoot) {
     }
   }
 
-  // 3. jonggrang-tasks.json
-  writeJSON(paths.tasksFile, { feature: '', branch: '', tasks: [] });
+  // 3. jonggrang-tasks.json — preserve existing valid file unless forced
+  if (opts.force || !validateTasksFile(paths.tasksFile).valid) {
+    writeJSON(paths.tasksFile, { feature: '', branch: '', tasks: [] });
+  }
 
-  // 4. progress.txt
-  const now = new Date().toISOString().split('T')[0];
-  fs.writeFileSync(paths.progressFile, `# Jonggrang Progress Log — ${name}\n# Created: ${now}\n`);
+  // 4. progress.txt — preserve existing valid file unless forced
+  if (opts.force || !validateProgressFile(paths.progressFile).valid) {
+    const now = new Date().toISOString().split('T')[0];
+    fs.writeFileSync(paths.progressFile, `# Jonggrang Progress Log — ${name}\n# Created: ${now}\n`);
+  }
 
   // 5. Copy skills into tool-specific directories
   const jonggrangSkillsDir = path.join(jonggrangHome, 'skills');
@@ -2215,6 +2256,12 @@ module.exports = {
   writeJSON,
   readConfig,
   checkConfig,
+
+  // State validation
+  validateConfigFile,
+  validateTasksFile,
+  validateProgressFile,
+  validateProjectState,
 
   // Task management
   getTasks,


### PR DESCRIPTION
## Summary

- Validate all 3 state files (`jonggrang.json`, `jonggrang-tasks.json`, `progress.txt`) during `jonggrang init` instead of only checking `jonggrang.json`
- Skip re-initialization when all files are valid — preserves existing task history and progress logs on cloned projects
- `ensureInit()` auto-regenerates only missing/corrupt non-config files instead of triggering full init
- `--force` flag still performs full reinit as before

Closes #47

## Test plan

- [x] `jonggrang init` on already-initialized project → detects valid state, skips reinit, all checksums unchanged
- [x] `jonggrang init --force` → full reinit, all files overwritten
- [x] Partial state (tasks file deleted) → shows per-file status (valid/missing), blocks in non-TTY
- [x] `ensureInit()` with missing tasks file → auto-regenerates only that file, progress.txt unchanged
- [x] Corrupt JSON detected as invalid
- [x] Existing test suite passes (`node test/backend-args.test.js`)