### PR TITLE
feat: monorepo support via git sparse-checkout

### DIFF
--- a/apis/projects/projects.js
+++ b/apis/projects/projects.js
@@ -51,6 +51,86 @@ module.exports = function(deps) {
         });
     }
 
+    function runGitTreeList(url, ref) {
+        const os = require('os');
+        const tmpDir = deps.fs.mkdtempSync(deps.path.join(os.tmpdir(), 'jg-git-tree-'));
+        return new Promise((resolve, reject) => {
+            const args = ['clone', '--filter=blob:none', '--sparse', '--no-checkout', '--depth=1'];
+            if (ref) args.push('--branch', ref);
+            args.push(url, tmpDir);
+            const child = spawn('git', args, {
+                env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+                stdio: ['pipe', 'pipe', 'pipe'],
+            });
+            child.on('error', err => { cleanup(); reject(err); });
+            child.on('close', code => {
+                if (code !== 0) { cleanup(); return reject(new Error(`git clone failed (exit ${code})`)); }
+                const ls = spawn('git', ['ls-tree', '--name-only', '-d', 'HEAD'], { cwd: tmpDir, stdio: ['pipe', 'pipe', 'pipe'] });
+                let stdout = '';
+                ls.stdout.on('data', d => { stdout += d.toString(); });
+                ls.on('error', err => { cleanup(); reject(err); });
+                ls.on('close', lsCode => {
+                    cleanup();
+                    if (lsCode !== 0) return reject(new Error('git ls-tree failed'));
+                    const dirs = stdout.trim().split('\n').filter(d => d && !d.startsWith('.'));
+                    resolve(dirs);
+                });
+            });
+            function cleanup() {
+                try { deps.fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+            }
+            // Timeout after 30s
+            setTimeout(() => { try { child.kill(); } catch {} cleanup(); reject(new Error('git-tree timed out')); }, 30000);
+        });
+    }
+
+    router.post('/projects/git-tree', async (req, res) => {
+        const { url, ref } = req.body || {};
+        if (!url) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'url required' } });
+        try {
+            const directories = await runGitTreeList(url, ref);
+            res.json({ directories });
+        } catch (err) {
+            res.status(500).json({ error: { code: 'GIT_TREE_FAILED', message: err.message } });
+        }
+    });
+
+    function runGitCloneSparse(url, ref, directories, targetPath, onProgress) {
+        return new Promise((resolve, reject) => {
+            const args = ['clone', '--filter=blob:none', '--sparse', '--progress'];
+            if (ref) args.push('--branch', ref);
+            args.push(url, targetPath);
+            const child = spawn('git', args, {
+                env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+                stdio: ['pipe', 'pipe', 'pipe'],
+            });
+            let lastStderr = '';
+            child.stderr.on('data', d => {
+                const msg = d.toString().trim();
+                if (msg) { lastStderr = msg; onProgress(msg); }
+            });
+            child.on('error', reject);
+            child.on('close', code => {
+                if (code !== 0) return reject(new Error(`git clone --sparse failed (exit ${code}): ${lastStderr}`));
+                // Init cone mode + set directories
+                onProgress('Configuring sparse checkout...');
+                const init = spawn('git', ['sparse-checkout', 'init', '--cone'], { cwd: targetPath, stdio: 'pipe' });
+                init.on('error', reject);
+                init.on('close', initCode => {
+                    if (initCode !== 0) return reject(new Error('git sparse-checkout init failed'));
+                    const setArgs = ['sparse-checkout', 'set', ...directories];
+                    const set = spawn('git', setArgs, { cwd: targetPath, stdio: 'pipe' });
+                    set.on('error', reject);
+                    set.on('close', setCode => {
+                        if (setCode !== 0) return reject(new Error('git sparse-checkout set failed'));
+                        onProgress(`Sparse checkout: ${directories.join(', ')}`);
+                        resolve();
+                    });
+                });
+            });
+        });
+    }
+
     function runGitInit(cwd) {
         return new Promise((resolve, reject) => {
             const child = spawn('git', ['init'], { cwd, stdio: 'pipe' });
@@ -116,7 +196,11 @@ module.exports = function(deps) {
                 emit('prepare', 'Preparing project...');
 
                 if (source.type === 'git') {
-                    await runGitClone(source.url, source.ref, targetPath, msg => emit('clone', msg));
+                    if (source.sparse?.enabled && Array.isArray(source.sparse.directories) && source.sparse.directories.length > 0) {
+                        await runGitCloneSparse(source.url, source.ref, source.sparse.directories, targetPath, msg => emit('clone', msg));
+                    } else {
+                        await runGitClone(source.url, source.ref, targetPath, msg => emit('clone', msg));
+                    }
                 } else if (source.type === 'fresh') {
                     fs.mkdirSync(targetPath, { recursive: true });
                     if (source.git_init !== false) await runGitInit(targetPath);

--- a/client/src/views/ImportFlowView.vue
+++ b/client/src/views/ImportFlowView.vue
@@ -34,14 +34,43 @@
           <InputText v-model="gitUrl" type="url" placeholder="https://github.com/user/repo.git" fluid />
         </div>
 
+        <div v-if="sourceType === 'git'" class="form-group">
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="isMonorepo" @change="onMonorepoToggle" />
+            Monorepo — only check out selected directories (sparse checkout)
+          </label>
+        </div>
+
+        <div v-if="sourceType === 'git' && isMonorepo" class="form-group">
+          <div v-if="loadingDirectories" class="dir-loading">
+            <i class="pi pi-spin pi-spinner" /> Fetching directory list...
+          </div>
+          <div v-else-if="dirError" class="error-text">{{ dirError }}</div>
+          <div v-else-if="availableDirectories.length > 0">
+            <label>Select directories to check out</label>
+            <div class="dir-picker">
+              <label v-for="dir in availableDirectories" :key="dir" class="dir-option">
+                <input type="checkbox" :value="dir" v-model="sparseDirectories" />
+                <i class="pi pi-folder" /> {{ dir }}
+              </label>
+            </div>
+            <div v-if="sparseDirectories.length > 0" class="dir-selected">
+              {{ sparseDirectories.length }} director{{ sparseDirectories.length === 1 ? 'y' : 'ies' }} selected
+            </div>
+          </div>
+          <div v-else-if="!gitUrl.trim()" class="dir-hint">
+            Enter a Git URL above, then check the monorepo box to fetch directories.
+          </div>
+        </div>
+
         <div v-if="sourceType === 'local'" class="form-group">
           <label>Local folder path</label>
           <InputText v-model="localPath" placeholder="/Users/you/my-project" fluid />
         </div>
 
         <div v-if="sourceType === 'fresh'" class="form-group">
-          <label style="display:flex;align-items:center;gap:8px;">
-            <input type="checkbox" v-model="freshGitInit" style="flex-shrink:0" />
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="freshGitInit" />
             Initialize git repository
           </label>
         </div>
@@ -69,6 +98,7 @@
         <div class="wizard-section-title">Initialize Jonggrang</div>
         <div class="detected-info" v-if="detected">
           <Tag :value="`Detected: ${detected.stack} · ${detected.type}`" severity="info" />
+          <Tag v-if="detected.is_monorepo" :value="`Monorepo: ${detected.workspace_type}`" severity="warn" class="mono-tag" />
         </div>
         <InitWizard :project="currentProject" :detected="detected" @done="onInitDone" @cancel="goHome" />
       </div>
@@ -103,6 +133,13 @@ const detected = ref(null);
 const currentProjectId = ref(null);
 const currentProject = computed(() => currentProjectId.value ? projects.byId[currentProjectId.value] : null);
 
+// Monorepo / sparse checkout state
+const isMonorepo = ref(false);
+const sparseDirectories = ref([]);
+const availableDirectories = ref([]);
+const loadingDirectories = ref(false);
+const dirError = ref('');
+
 const sourceOptions = [
   { type: 'git',   icon: 'pi-link',   label: 'Git Repository', desc: 'Clone from GitHub, GitLab, etc.' },
   { type: 'local', icon: 'pi-folder', label: 'Local Folder',   desc: 'Use an existing project on disk' },
@@ -112,12 +149,50 @@ const sourceOptions = [
 const canNext = computed(() => {
   if (!name.value.trim()) return false;
   if (sourceType.value === 'git' && !gitUrl.value.trim()) return false;
+  if (sourceType.value === 'git' && isMonorepo.value && sparseDirectories.value.length === 0) return false;
   if (sourceType.value === 'local' && !localPath.value.trim()) return false;
   return true;
 });
 
+async function onMonorepoToggle() {
+  dirError.value = '';
+  sparseDirectories.value = [];
+  availableDirectories.value = [];
+  if (!isMonorepo.value) return;
+  const url = gitUrl.value.trim();
+  if (!url) return;
+  loadingDirectories.value = true;
+  try {
+    const res = await window.fetch('/api/projects/git-tree', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      dirError.value = err.error?.message || 'Failed to fetch directories';
+      return;
+    }
+    const data = await res.json();
+    availableDirectories.value = data.directories || [];
+    if (availableDirectories.value.length === 0) {
+      dirError.value = 'No directories found in repository root.';
+    }
+  } catch (e) {
+    dirError.value = e.message;
+  } finally {
+    loadingDirectories.value = false;
+  }
+}
+
 function buildSource() {
-  if (sourceType.value === 'git') return { type: 'git', url: gitUrl.value.trim() };
+  if (sourceType.value === 'git') {
+    const src = { type: 'git', url: gitUrl.value.trim() };
+    if (isMonorepo.value && sparseDirectories.value.length > 0) {
+      src.sparse = { enabled: true, directories: [...sparseDirectories.value] };
+    }
+    return src;
+  }
   if (sourceType.value === 'local') return { type: 'local', path: localPath.value.trim(), link_mode: 'reference' };
   return { type: 'fresh', git_init: freshGitInit.value };
 }
@@ -199,6 +274,9 @@ function goHome() {
 .source-label { font-size: 12px; font-weight: 600; color: var(--jg-text); margin-bottom: 2px; }
 .source-desc { font-size: 11px; color: var(--jg-text-faint); }
 
+.checkbox-label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; }
+.checkbox-label input[type="checkbox"] { flex-shrink: 0; }
+
 .wizard-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--jg-border); }
 .wizard-actions :deep(.p-button) { padding-block: 9px !important; min-height: 36px; }
 
@@ -208,5 +286,22 @@ function goHome() {
   max-height: 200px; overflow-y: auto; color: var(--jg-text-muted);
 }
 .progress-line { line-height: 1.6; }
-.detected-info { margin-bottom: 16px; }
+.detected-info { margin-bottom: 16px; display: flex; gap: 6px; flex-wrap: wrap; }
+.mono-tag { margin-left: 2px; }
+
+/* Directory picker */
+.dir-picker {
+  background: var(--jg-bg); border: 1px solid var(--jg-border); border-radius: var(--radius);
+  padding: 8px; max-height: 200px; overflow-y: auto; margin-top: 6px;
+}
+.dir-option {
+  display: flex; align-items: center; gap: 6px; padding: 4px 6px; font-size: 12px;
+  color: var(--jg-text); cursor: pointer; border-radius: 3px;
+}
+.dir-option:hover { background: var(--jg-hover); }
+.dir-option input[type="checkbox"] { flex-shrink: 0; }
+.dir-option .pi-folder { color: var(--jg-text-faint); font-size: 12px; }
+.dir-selected { font-size: 11px; color: var(--jg-green); margin-top: 6px; }
+.dir-loading { font-size: 12px; color: var(--jg-text-muted); display: flex; align-items: center; gap: 6px; }
+.dir-hint { font-size: 11px; color: var(--jg-text-faint); font-style: italic; }
 </style>

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -362,3 +362,66 @@ Persistent orchestration state for a feature run. Located at:
 > They are injected as default env into every sandbox container/agent so the `gh` and
 > `glab` CLIs are pre-authenticated. The dashboard never returns the stored values — only
 > whether each is set. A per-project secret with the same name overrides the global token.
+
+---
+
+## Monorepo / Sparse Checkout
+
+When importing a project from Git via the web dashboard, you can enable **sparse checkout** to clone only selected directories from a monorepo. This saves bandwidth and disk space.
+
+### Import source schema (git + sparse)
+
+When `source.type` is `"git"`, you can optionally include a `sparse` object:
+
+```json
+{
+  "name": "my-monorepo-app",
+  "source": {
+    "type": "git",
+    "url": "https://github.com/org/monorepo.git",
+    "ref": "main",
+    "sparse": {
+      "enabled": true,
+      "directories": ["packages/my-app", "packages/shared"]
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sparse.enabled` | boolean | Enable sparse checkout mode |
+| `sparse.directories` | string[] | List of directories to check out (relative to repo root) |
+
+When `sparse` is omitted or `enabled` is false, a normal full clone is performed.
+
+### API: List remote directories
+
+```
+POST /api/projects/git-tree
+Body: { "url": "https://github.com/org/repo.git", "ref": "main" }
+Response: { "directories": ["packages", "apps", "libs", ...] }
+```
+
+Lists top-level directories from a remote git repo without performing a full checkout. Used by the web dashboard directory picker.
+
+### Monorepo detection
+
+After import, the stack detector checks for workspace configuration files:
+
+| File | Detected as |
+|------|-------------|
+| `pnpm-workspace.yaml` | `pnpm` workspace |
+| `package.json` with `workspaces` field | `npm` or `yarn` workspace |
+| `lerna.json` | `lerna` workspace |
+
+The detection result is included in `detectStack()` output: `{ is_monorepo: true, workspace_type: "pnpm" }`.
+
+### Manual sparse checkout (CLI)
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/org/monorepo.git
+cd monorepo
+git sparse-checkout init --cone
+git sparse-checkout set packages/my-app packages/shared
+```

--- a/docs/plans/2026-06-10-monorepo-sparse-checkout.md
+++ b/docs/plans/2026-06-10-monorepo-sparse-checkout.md
@@ -1,0 +1,264 @@
+---
+feature: monorepo-sparse-checkout
+branch: feat/monorepo-sparse-checkout
+work_type: MEDIUM
+description: Add monorepo support via git sparse-checkout so users can import only selected directories from a large repo, with a checkbox + directory picker in the web import flow.
+created_at: 2026-06-10
+status: implemented
+issue: https://github.com/porcupine-md/jonggrang/issues/48
+---
+
+# Plan: Monorepo Support via Git Sparse-Checkout
+
+## 1. Goal (from issue #48)
+
+When importing a project from Git in the web dashboard, users should be able to:
+1. Check a **"Monorepo (sparse checkout)"** checkbox
+2. Once checked, a **directory picker** appears — listing all top-level directories from the repo
+3. User selects one or more directories to check out
+4. Clone is performed with `--filter=blob:none --sparse` + `git sparse-checkout set <dirs>`
+5. Only the selected directories are checked out to disk — saving bandwidth and storage
+
+## 2. Current State (verified)
+
+### Backend — `apis/projects/projects.js`
+- `runGitClone()` (line 33-52): plain `git clone --progress <url> <target>`, no sparse support
+- `POST /projects/import` (line 62-138): accepts `source.type = git|local|fresh`, no monorepo fields
+- Project record stores `lanes: { main: { ... } }` — single lane only
+
+### Frontend — `client/src/views/ImportFlowView.vue`
+- Step 1: source type picker (git/local/fresh), project name, git URL
+- No monorepo checkbox, no directory picker
+- `buildSource()` (line 119-123): returns `{ type: 'git', url }` — no sparse fields
+
+### Detection — `lib/web-state.js`
+- `detectStack()` (line 234-250): checks root `package.json`, `go.mod`, etc. — no workspace detection
+
+### Worktrees — `lib/jonggrang.js`
+- Worktree creation (line 1632-1656): standard `git worktree add`
+- **Verified**: worktrees inherit sparse-checkout config from the parent repo automatically
+
+## 3. Technical Validation (tested)
+
+All steps below were tested in `/tmp/monorepo-test` against the `vercel/next.js` repo:
+
+| Test | Result |
+|------|--------|
+| `git clone --filter=blob:none --sparse <url>` | OK — fast clone, metadata only |
+| `git sparse-checkout init --cone` | OK |
+| `git sparse-checkout set packages/next` | OK — only that directory appears on disk |
+| `git sparse-checkout add packages/create-next-app` | OK — can add directories after initial set |
+| `git sparse-checkout list` | OK — returns list of checked-out directories |
+| `git config --get core.sparseCheckout` | `true` — can detect sparse mode programmatically |
+| `git ls-tree --name-only -d HEAD` | OK — lists all dirs without checking them out (for picker) |
+| `git ls-tree --name-only -d HEAD packages/` | OK — can list subdirectories too |
+| `git worktree add ...` from sparse repo | OK — worktree inherits sparse config |
+| Non-checked-out dirs (`packages/react-refresh`) | Not Found — expected behavior |
+
+## 4. Implementation Plan
+
+### Phase 1: Backend — New API endpoint to list directories
+
+**File:** `apis/projects/projects.js`
+
+Add a new endpoint `POST /api/projects/git-tree` that accepts a git URL + optional ref, performs a temporary bare/sparse clone, then returns the directory tree.
+
+```
+POST /api/projects/git-tree
+Body: { url: string, ref?: string, depth?: number }
+Response: { directories: string[] }
+```
+
+Implementation:
+1. Clone to a temp dir with `git clone --filter=blob:none --sparse --no-checkout --depth=1 <url> <tmpDir>`
+2. Run `git ls-tree --name-only -d HEAD` to list top-level dirs
+3. Optional: if `depth > 1`, also list level 2 (`git ls-tree --name-only -d HEAD <dir>/`)
+4. Return the result, clean up the temp dir
+
+### Phase 2: Backend — Extend git clone to support sparse-checkout
+
+**File:** `apis/projects/projects.js`
+
+Modify `runGitClone()` and the `POST /projects/import` handler:
+
+1. Extend the `source` schema for git type:
+   ```javascript
+   source: {
+     type: 'git',
+     url: string,
+     ref?: string,
+     sparse?: {
+       enabled: boolean,
+       directories: string[]   // e.g. ['packages/next', 'packages/shared']
+     }
+   }
+   ```
+
+2. Add a new function `runGitCloneSparse(url, ref, directories, targetPath, onProgress)`:
+   ```
+   git clone --filter=blob:none --sparse --progress <url> <target>
+   cd <target>
+   git sparse-checkout init --cone
+   git sparse-checkout set <dir1> <dir2> ...
+   ```
+
+3. In the `POST /projects/import` handler, if `source.sparse?.enabled`, call `runGitCloneSparse` instead of `runGitClone`
+
+4. Persist sparse config in the project record:
+   ```javascript
+   {
+     ...project,
+     source: { ...source, sparse: { enabled: true, directories: [...] } }
+   }
+   ```
+
+### Phase 3: Backend — Detect monorepo workspace
+
+**File:** `lib/web-state.js`
+
+Extend `detectStack()`:
+
+1. When sparse checkout is active, detect stack per checked-out directory (not root)
+2. Add a `detectMonorepo()` helper:
+   - Check `pnpm-workspace.yaml` → `workspace: { type: 'pnpm' }`
+   - Check `package.json` `.workspaces` → `workspace: { type: 'yarn'|'npm' }`
+   - Check `lerna.json` → `workspace: { type: 'lerna' }`
+   - Return `{ is_monorepo: boolean, workspace_type: string, detected_stacks: [...] }`
+
+### Phase 4: Frontend — Monorepo checkbox + directory picker
+
+**File:** `client/src/views/ImportFlowView.vue`
+
+1. Add new reactive state:
+   ```javascript
+   const isMonorepo = ref(false);
+   const sparseDirectories = ref([]);         // selected directories
+   const availableDirectories = ref([]);       // from git-tree API
+   const loadingDirectories = ref(false);
+   ```
+
+2. Below the Git URL input, add a checkbox:
+   ```html
+   <div v-if="sourceType === 'git'" class="form-group">
+     <label style="display:flex;align-items:center;gap:8px;">
+       <input type="checkbox" v-model="isMonorepo" @change="onMonorepoToggle" />
+       Monorepo — only check out selected directories (sparse checkout)
+     </label>
+   </div>
+   ```
+
+3. When the checkbox is checked and a valid URL is present, call `POST /api/projects/git-tree`:
+   ```javascript
+   async function onMonorepoToggle() {
+     if (!isMonorepo.value || !gitUrl.value.trim()) return;
+     loadingDirectories.value = true;
+     const res = await fetch('/api/projects/git-tree', {
+       method: 'POST',
+       headers: { 'Content-Type': 'application/json' },
+       body: JSON.stringify({ url: gitUrl.value.trim() }),
+     });
+     const data = await res.json();
+     availableDirectories.value = data.directories;
+     loadingDirectories.value = false;
+   }
+   ```
+
+4. Show the directory picker (checkbox list):
+   ```html
+   <div v-if="isMonorepo && availableDirectories.length" class="form-group">
+     <label>Select directories to check out</label>
+     <div class="dir-picker">
+       <label v-for="dir in availableDirectories" :key="dir" class="dir-option">
+         <input type="checkbox" :value="dir" v-model="sparseDirectories" />
+         {{ dir }}
+       </label>
+     </div>
+   </div>
+   ```
+
+5. Update `buildSource()`:
+   ```javascript
+   function buildSource() {
+     if (sourceType.value === 'git') {
+       const src = { type: 'git', url: gitUrl.value.trim() };
+       if (isMonorepo.value && sparseDirectories.value.length > 0) {
+         src.sparse = { enabled: true, directories: [...sparseDirectories.value] };
+       }
+       return src;
+     }
+     // ... rest unchanged
+   }
+   ```
+
+6. Update `canNext` computed:
+   ```javascript
+   const canNext = computed(() => {
+     if (!name.value.trim()) return false;
+     if (sourceType.value === 'git' && !gitUrl.value.trim()) return false;
+     if (sourceType.value === 'git' && isMonorepo.value && sparseDirectories.value.length === 0) return false;
+     // ... rest unchanged
+   });
+   ```
+
+### Phase 5: Documentation
+
+Per the CLAUDE.md checklist:
+
+| Changed | Update |
+|---------|--------|
+| Config schema (source.sparse field) | `docs/CONFIG.md` |
+| Import flow | `README.md` (if import section exists), `docs/QUICKSTART.md` |
+| New git clone behavior | `docs/WORKFLOW.md` if relevant |
+
+Add a section in README or docs explaining the monorepo workflow:
+```markdown
+### Monorepo Support
+
+When importing from Git, check "Monorepo" to use sparse checkout.
+Only selected directories will be cloned — saving bandwidth and disk space.
+
+Manual workaround (CLI):
+  git clone --filter=blob:none --sparse <url>
+  cd <repo>
+  git sparse-checkout init --cone
+  git sparse-checkout set packages/my-app packages/shared
+```
+
+## 5. File Change Summary
+
+| File | Change |
+|------|--------|
+| `apis/projects/projects.js` | Add `POST /git-tree` endpoint, add `runGitCloneSparse()`, extend import handler |
+| `lib/web-state.js` | Extend `detectStack()` with monorepo detection |
+| `client/src/views/ImportFlowView.vue` | Add monorepo checkbox, directory picker UI, update `buildSource()` |
+| `client/src/stores/projects.js` | No change needed — `importProject()` already passes the source object as-is |
+| `docs/CONFIG.md` | Document `source.sparse` schema |
+| `README.md` or `docs/QUICKSTART.md` | Add monorepo section |
+
+## 6. Edge Cases & Considerations
+
+1. **Private repos** — the `git-tree` endpoint must handle auth failures gracefully (return error, not hang)
+2. **Large repos with many top-level dirs** — the UI picker needs to be scrollable, possibly with search/filter
+3. **Nested monorepos** — depth=1 is sufficient for most cases (packages/X); depth=2 can be optional
+4. **Sparse + worktree compatibility** — already verified; worktrees inherit sparse config
+5. **Existing project re-checkout** — extending to add/remove directories post-import can be a follow-up issue
+6. **Timeout on git-tree** — the temporary clone for listing dirs must have a timeout (30s max)
+7. **Temp dir cleanup** — ensure the temp dir is always cleaned up even if the request aborts or errors
+
+## 7. Execution Order
+
+```
+Phase 1 (backend: git-tree API)
+    ↓
+Phase 2 (backend: sparse clone)
+    ↓
+Phase 3 (backend: monorepo detection)
+    ↓
+Phase 4 (frontend: UI)
+    ↓
+Phase 5 (docs)
+```
+
+Phases 1-3 should be done sequentially as they depend on each other.
+Phase 4 requires Phase 1 (git-tree API) to be completed first.
+Phase 5 comes after all implementation is done.

--- a/lib/web-state.js
+++ b/lib/web-state.js
@@ -231,22 +231,36 @@ function deriveState(projectPath) {
   return { state: 'tasks_pending', tasks };
 }
 
+function detectMonorepo(projectPath) {
+  if (fs.existsSync(path.join(projectPath, 'pnpm-workspace.yaml'))) return { is_monorepo: true, workspace_type: 'pnpm' };
+  if (fs.existsSync(path.join(projectPath, 'lerna.json'))) return { is_monorepo: true, workspace_type: 'lerna' };
+  const pkgPath = path.join(projectPath, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      if (pkg.workspaces) return { is_monorepo: true, workspace_type: Array.isArray(pkg.workspaces) ? 'npm' : 'yarn' };
+    } catch {}
+  }
+  return { is_monorepo: false, workspace_type: null };
+}
+
 function detectStack(projectPath) {
+  const mono = detectMonorepo(projectPath);
   const pkgPath = path.join(projectPath, 'package.json');
   if (fs.existsSync(pkgPath)) {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-    if (deps.next) return { stack: 'nextjs-typescript', type: 'web-app' };
-    if (deps.express || deps.fastify || deps.koa) return { stack: 'express-typescript', type: 'api' };
-    if (pkg.bin) return { stack: 'node-typescript', type: 'cli' };
-    return { stack: 'node-typescript', type: 'library' };
+    if (deps.next) return { stack: 'nextjs-typescript', type: 'web-app', ...mono };
+    if (deps.express || deps.fastify || deps.koa) return { stack: 'express-typescript', type: 'api', ...mono };
+    if (pkg.bin) return { stack: 'node-typescript', type: 'cli', ...mono };
+    return { stack: 'node-typescript', type: 'library', ...mono };
   }
-  if (fs.existsSync(path.join(projectPath, 'go.mod'))) return { stack: 'go', type: 'api' };
-  if (fs.existsSync(path.join(projectPath, 'Cargo.toml'))) return { stack: 'rust', type: 'cli' };
+  if (fs.existsSync(path.join(projectPath, 'go.mod'))) return { stack: 'go', type: 'api', ...mono };
+  if (fs.existsSync(path.join(projectPath, 'Cargo.toml'))) return { stack: 'rust', type: 'cli', ...mono };
   const hasPy = fs.existsSync(path.join(projectPath, 'pyproject.toml'))
     || fs.existsSync(path.join(projectPath, 'requirements.txt'));
-  if (hasPy) return { stack: 'python-fastapi', type: 'api' };
-  return { stack: 'node-typescript', type: 'library' };
+  if (hasPy) return { stack: 'python-fastapi', type: 'api', ...mono };
+  return { stack: 'node-typescript', type: 'library', ...mono };
 }
 
 function getProjectPaths(projectPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "jonggrang": "bin/jonggrang.js"
       },
       "devDependencies": {
-        "nodemon": "^3.1.0"
+        "nodemon": "^3.1.0",
+        "vite": "^8.0.16"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -604,6 +605,40 @@
         "koffi": "^2.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -818,6 +853,25 @@
         "zod-to-json-schema": "^3.25.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -829,6 +883,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -892,6 +956,270 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -1024,6 +1352,17 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -1403,6 +1742,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2210,6 +2559,267 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -2335,6 +2945,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2614,6 +3243,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -2743,6 +3401,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -2982,6 +3674,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3014,6 +3716,54 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -3126,6 +3876,97 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "vite": "^8.0.16"
   }
 }


### PR DESCRIPTION
## Summary

- Adds monorepo sparse-checkout support to the web dashboard import flow (closes #48)
- New `POST /api/projects/git-tree` endpoint lists remote repo directories without full checkout
- New `runGitCloneSparse()` backend: `git clone --filter=blob:none --sparse` + `git sparse-checkout set`
- Import handler branches to sparse clone when `source.sparse.enabled` is true
- Frontend: monorepo checkbox + scrollable directory picker in ImportFlowView.vue
- `detectStack()` now includes monorepo workspace detection (pnpm/yarn/npm/lerna)
- Documentation added to `docs/CONFIG.md` (schema, API, detection, manual CLI)

## Files changed

| File | Change |
|------|--------|
| `apis/projects/projects.js` | `runGitTreeList()`, `runGitCloneSparse()`, `POST /git-tree`, sparse branch in import handler |
| `lib/web-state.js` | `detectMonorepo()` + wired into `detectStack()` |
| `client/src/views/ImportFlowView.vue` | Monorepo checkbox, directory picker, updated `buildSource()`/`canNext` |
| `docs/CONFIG.md` | Monorepo / Sparse Checkout section |
| `docs/plans/2026-06-10-monorepo-sparse-checkout.md` | Implementation plan |

## Test plan

- [x] `POST /api/projects/git-tree` returns directory list from remote repo
- [x] Sparse clone via API: only selected directories checked out on disk
- [x] `git sparse-checkout list` confirms cone mode with correct directories
- [x] `core.sparseCheckout` config flag set to `true`
- [x] Browser E2E: checkbox → directory picker loads → select packages → import → step 3 shows "Monorepo: NPM" tag
- [x] Monorepo detection: `pnpm-workspace.yaml`, `package.json` workspaces, `lerna.json`
- [x] Normal (non-sparse) git import still works unchanged
- [ ] Test with private repo (auth error handling)
- [ ] Test with large monorepo (many top-level dirs → scrollable picker)