### PR TITLE
fix: harden base-branch handling (shell injection) + bound issues cache

### DIFF
--- a/apis/issues.js
+++ b/apis/issues.js
@@ -9,6 +9,7 @@ const { Router } = require('express');
 const providers = require('../lib/issue-providers');
 
 const CACHE_TTL = 60_000; // 60s — keep the list/detail views responsive.
+const CACHE_MAX = 200;    // bound the cache: search-as-you-type makes one key per keystroke.
 const PER_PAGE = 20;      // issues per page in the list view.
 const AGG_PER_REPO = 50;  // newest issues fetched per repo for the aggregate view.
 
@@ -24,10 +25,20 @@ module.exports = function (deps) {
     return null;
   }
 
+  // Bounded LRU: the search box drives one cache key per keystroke, so without a
+  // cap this Map grows without limit on a long-running server. Re-insert on hit
+  // to mark recency; evict the oldest key once over CACHE_MAX.
   function cached(key, fn) {
     const hit = cache.get(key);
-    if (hit && Date.now() - hit.t < CACHE_TTL) return Promise.resolve(hit.v);
-    return Promise.resolve(fn()).then((v) => { cache.set(key, { t: Date.now(), v }); return v; });
+    if (hit && Date.now() - hit.t < CACHE_TTL) {
+      cache.delete(key); cache.set(key, hit);
+      return Promise.resolve(hit.v);
+    }
+    return Promise.resolve(fn()).then((v) => {
+      cache.set(key, { t: Date.now(), v });
+      if (cache.size > CACHE_MAX) cache.delete(cache.keys().next().value);
+      return v;
+    });
   }
 
   function sendErr(res, err) {

--- a/apis/projects/orchestration-run.js
+++ b/apis/projects/orchestration-run.js
@@ -125,12 +125,25 @@ module.exports = function(deps) {
     // then HEAD, if the fetch fails (offline / no such remote branch / no base).
     function resolveStartRef(ctx, base) {
         if (!base) return 'HEAD';
+        // This is the single choke point every base value flows through (CLI
+        // --base, web API, AI-written frontmatter, committed plan.md). `base` is
+        // interpolated into a shell command below, so reject anything that isn't
+        // a plain branch name before it reaches the shell.
+        if (!lib.isSafeBranchName(base)) {
+            console.warn(`orchestration: ignoring unsafe base "${base}" — starting worktree from HEAD`);
+            return 'HEAD';
+        }
         try {
             sandboxGit.gitShell(ctx, `fetch origin "${base}"`);
             return 'FETCH_HEAD';
-        } catch {
+        } catch (fetchErr) {
             try { gitSync(ctx, ctx.root, ['rev-parse', '--verify', `refs/heads/${base}`]); return base; }
-            catch { return 'HEAD'; }
+            catch {
+                // The plan explicitly asked for this base but it's neither on
+                // origin nor local — surface it instead of silently using HEAD.
+                console.warn(`orchestration: base "${base}" not found on origin or locally (${fetchErr.message}) — starting worktree from HEAD`);
+                return 'HEAD';
+            }
         }
     }
 

--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -252,8 +252,8 @@ module.exports = function(deps) {
                 return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: `effort must be one of: ${expected}` } });
             }
         }
-        if (base && (typeof base !== 'string' || base.length > MAX_STRING_LEN || /[\s;|&$`]/.test(base))) {
-            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'base must be a plain branch name' } });
+        if (base && !lib.isSafeBranchName(base)) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'base must be a plain branch name (letters, digits, . _ / -)' } });
         }
 
         const args = ['plan', description, ...(deep ? ['--deep'] : [])];

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1027,6 +1027,14 @@ async function cmdPlan(args, opts = {}) {
     else if (!arg.startsWith('--')) description = arg;
   }
 
+  // Validate --base up front: it ends up interpolated into `git fetch` at
+  // worktree creation, so reject anything that isn't a plain branch name before
+  // we spend a plan generation on it.
+  if (baseBranch && !lib.isSafeBranchName(baseBranch)) {
+    logError(`Invalid --base "${baseBranch}": must be a plain branch name (letters, digits, . _ / -).`);
+    process.exit(1);
+  }
+
   if (!await ensureInit()) return;
 
   // ── Revise mode: AI rewrites existing plan.md ────────────────
@@ -1200,7 +1208,10 @@ async function cmdPlan(args, opts = {}) {
   // The base branch (worktree start-point) is a deterministic user choice, so
   // write it into the generated plan.md frontmatter (overriding anything the AI
   // may have put there). Covers both deep + standard generation paths above.
-  if (baseBranch && lib.fileExists(PLAN_FILE)) lib.setPlanBase(PLAN_FILE, baseBranch);
+  // Warn if it didn't take — otherwise the worktree silently cuts from HEAD.
+  if (baseBranch && lib.fileExists(PLAN_FILE) && !lib.setPlanBase(PLAN_FILE, baseBranch)) {
+    logWarn(`Could not write base "${baseBranch}" to the plan frontmatter — the worktree will start from HEAD unless you set it manually.`);
+  }
 
   if (autoApprove) {
     logInfo('Auto-approving plan (--yes)...');

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -1723,18 +1723,37 @@ function parsePlanFrontmatter(planPath) {
   }
 }
 
+// A base branch name we consider safe to interpolate into a shell command
+// (`git fetch origin "<base>"`) and into a YAML scalar. Letters, digits, dot,
+// slash, dash, underscore only; must not lead with `-` or `.` (option/relative
+// ref hazards). Intentionally stricter than git's own ref grammar — the point is
+// that a value passing this check carries NO shell metacharacters, quotes, or
+// whitespace, so every interpolation downstream (resolveStartRef, setPlanBase)
+// is injection-safe regardless of where the value came from (CLI, web API, or
+// frontmatter written by the AI / committed plan.md).
+function isSafeBranchName(name) {
+  return typeof name === 'string'
+    && name.length > 0 && name.length <= 200
+    && /^[A-Za-z0-9_][A-Za-z0-9._/-]*$/.test(name);
+}
+
 // Set (or replace) the `base:` branch field inside a plan.md's YAML frontmatter.
 // The base branch (which branch the worktree is cut from) is a deterministic
 // user choice, NOT something the AI decides — so we write it after generation.
-// Returns true if the file was updated.
+// Rejects unsafe names (see isSafeBranchName) so a malicious --base / frontmatter
+// value can never reach the fetch shell. Returns true only if the file was
+// updated; false on invalid input, missing frontmatter, or write error.
 function setPlanBase(planPath, base) {
-  if (!base) return false;
+  if (!isSafeBranchName(base)) return false;
   try {
     const raw = fs.readFileSync(planPath, 'utf8');
     const m = raw.match(/^(---\n)([\s\S]*?)(\n---)/);
     if (!m) return false;
     let body = m[2];
-    const line = `base: ${base}`;
+    // Quote the scalar so branch names that look like YAML keywords (true, no,
+    // 123, 0x1f) survive js-yaml parsing as strings. Safe to embed bare: the
+    // value passed isSafeBranchName, so it contains no `"`.
+    const line = `base: "${base}"`;
     if (/^base:.*$/m.test(body)) {
       body = body.replace(/^base:.*$/m, line);
     } else if (/^branch:.*$/m.test(body)) {
@@ -2397,6 +2416,7 @@ module.exports = {
   groupPlans,
   parsePlanFrontmatter,
   setPlanBase,
+  isSafeBranchName,
   listBranches,
   orderTaskIds,
   createWorktree,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js"
+    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/base-branch.test.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/test/base-branch.test.js
+++ b/test/base-branch.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Guards for the base-branch hardening (PR #57 review, Tier 0/2):
+// isSafeBranchName must reject every shell-injection vector, and setPlanBase
+// must persist a quoted YAML scalar and refuse unsafe input.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../lib/jonggrang');
+
+test('isSafeBranchName accepts plain branch names', () => {
+  for (const ok of ['main', 'develop', 'feat/issuespickup', 'release-1.2.0', 'a_b.c/d-e']) {
+    assert.equal(lib.isSafeBranchName(ok), true, ok);
+  }
+});
+
+test('isSafeBranchName rejects injection + non-string + leading dash/dot', () => {
+  for (const bad of [
+    'main"; rm -rf ~/.jonggrang; echo "',
+    'main && touch /tmp/x',
+    'a|b', 'a;b', 'a b', '$(id)', '`id`', 'a(b)', "a'b", 'a"b', 'a\\b',
+    '-rf', '.hidden', '', 'a'.repeat(201),
+    null, undefined, 123, {},
+  ]) {
+    assert.equal(lib.isSafeBranchName(bad), false, JSON.stringify(bad));
+  }
+});
+
+test('setPlanBase writes a quoted scalar and rejects unsafe base', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-base-'));
+  const planPath = path.join(dir, 'plan.md');
+  fs.writeFileSync(planPath, '---\nbranch: jonggrang/x\n---\n# Title\n');
+
+  assert.equal(lib.setPlanBase(planPath, 'develop'), true);
+  let raw = fs.readFileSync(planPath, 'utf8');
+  assert.match(raw, /base: "develop"/);
+  // js-yaml must parse it back as the string, not coerce.
+  assert.equal(lib.parsePlanFrontmatter(planPath).base, 'develop');
+
+  // A YAML-keyword-shaped branch name stays a string thanks to quoting.
+  fs.writeFileSync(planPath, '---\nbranch: jonggrang/x\n---\n# Title\n');
+  assert.equal(lib.setPlanBase(planPath, 'no'), true);
+  assert.strictEqual(lib.parsePlanFrontmatter(planPath).base, 'no');
+
+  // Unsafe input is refused and the file is left untouched.
+  fs.writeFileSync(planPath, '---\nbranch: jonggrang/x\n---\n# Title\n');
+  assert.equal(lib.setPlanBase(planPath, 'x"; rm -rf /; echo "'), false);
+  assert.doesNotMatch(fs.readFileSync(planPath, 'utf8'), /base:/);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Review follow-ups on #57 — addresses Tier 0–2 from the code review of `feat/issuespickup`. Targets `feat/issuespickup` so it folds into that PR before it lands on `main`.

## What changed

### Tier 0 — `base` → shell injection (security)
`resolveStartRef` interpolates `base` into `git fetch origin "<base>"` which runs through `sh -c` / `execSync`. Validation previously lived **only** at the web POST boundary (and used a loose blocklist that leaked `"`, `'`, `(`, `)`, `\`). The CLI `--base` path and any committed / AI-written `plan.md` frontmatter reached the shell unvalidated.

- New `lib.isSafeBranchName` — strict allowlist `^[A-Za-z0-9_][A-Za-z0-9._/-]*$` (no whitespace, quotes, shell metachars, leading `-`/`.`, non-string, >200 chars).
- Validate at **`resolveStartRef`** — the single choke point every base value flows through (CLI, web API, AI frontmatter, committed `plan.md`). One guard closes all paths.
- `setPlanBase` rejects unsafe input and writes a **quoted** YAML scalar, so keyword-shaped names (`true`/`no`/`123`/`0x1f`) aren't coerced by `js-yaml`.
- `plan.js` swapped to `isSafeBranchName`; CLI `--base` validated up front.

### Tier 1 — issues cache memory leak
`apis/issues.js` cache is keyed by free-text search → one key per keystroke, never evicted. Bounded to an LRU of `CACHE_MAX=200`.

### Tier 2 — silent fallback to HEAD
When a chosen base couldn't be honored, the worktree silently cut from HEAD. `resolveStartRef` now `console.warn`s (unsafe or missing base); the CLI warns if `setPlanBase` fails to persist.

## Testing
- New `test/base-branch.test.js` (wired into `npm test`): validator behavior, YAML quoting/coercion, rejection of injection payloads.
- `npm test` green; `issue-providers` suite green; syntax check on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)