### PR TITLE
feat: add 'plan ask' — agent-submitted clarifying questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Project entry points: CLI binary, Pi TUI extension, web dashboard server. Hooks 
 | Command | What it does |
 |---------|-------------|
 | `jonggrang init` | Interactive wizard — sets up `.jonggrang/`, `AGENTS.md`, hooks, skills |
-| `jonggrang plan "desc"` | AI writes a draft plan to `.jonggrang/.drafts/<session>/plan.md` — human reviews before code |
+| `jonggrang plan "desc"` | AI analyzes the goal, asks clarifying questions if anything is ambiguous, then writes a draft plan to `.jonggrang/.drafts/<session>/plan.md` — human reviews before code |
 | `jonggrang approve` | Decomposes the most-recent draft (or `--session <id>`) into `.jonggrang/.output/features/<id>/jonggrang-tasks.json` |
 | `jonggrang work` | Executes task queue with fresh context per task |
 | `jonggrang status` | Shows task board |
@@ -88,11 +88,17 @@ jonggrang plan "feature" --yes       # Skip review, auto-approve
 jonggrang work "feature" --yes       # Full pipeline in one command
 jonggrang plan "feature" --deep      # 3-phase deep analysis (risks, alternatives)
 jonggrang plan "feature" --base develop  # Cut the worktree from a chosen branch (fetched fresh from origin)
+jonggrang plan "feature" --no-ask    # Skip the agent's clarifying-questions step
 jonggrang approve --session draft-abc123  # Approve a specific pending draft
 jonggrang work --mode autonomous     # Override autonomy mode
 jonggrang work --task task-003       # Execute specific task only
 jonggrang work --feature feat-abc123 # Target a specific approved feature (multi-feature projects)
 ```
+
+> When the request is ambiguous, `plan` first asks you a few clarifying questions
+> (pick an option — each carries its rationale — or type your own answer) so the
+> agent plans from real intent instead of guessing. The Q&A is saved with the plan
+> and reused on `plan --revise`. The web dashboard shows the same questions as a form.
 
 ---
 

--- a/apis/projects/index.js
+++ b/apis/projects/index.js
@@ -80,6 +80,22 @@ module.exports = function register(app, io, ctx) {
             const lines = data.toString().split(/\r?\n/).filter(l => l.trim());
             for (const line of lines) {
                 io.to(`project:${projectId}`).emit('process.log', { project_id: projectId, stream, line, raw: line, seq: seq++ });
+                // The planning agent surfaces clarifying questions via a JSON signal
+                // line (`{"type":"plan_questions",...}`). Relay the stored questions
+                // to the client so it can render an answer form.
+                if (stream === 'stdout' && line.includes('"plan_questions"')) {
+                    try {
+                        const sig = JSON.parse(line.trim());
+                        if (sig && sig.type === 'plan_questions') {
+                            const project = webState.getProject(projectId);
+                            const qPath = project && path.join(project.path, '.jonggrang', 'plan-questions.json');
+                            if (qPath && fs.existsSync(qPath)) {
+                                const questions = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
+                                io.to(`project:${projectId}`).emit('plan.questions', { project_id: projectId, ...questions });
+                            }
+                        }
+                    } catch { /* not a signal line — ignore */ }
+                }
             }
         };
         child.stdout.on('data', logLine('stdout'));

--- a/apis/projects/index.js
+++ b/apis/projects/index.js
@@ -76,31 +76,51 @@ module.exports = function register(app, io, ctx) {
     function wireProjectProcess(projectId, child, command) {
         io.to(`project:${projectId}`).emit('process.started', { project_id: projectId, command, pid: child.pid });
         let seq = 0;
-        const logLine = (stream) => (data) => {
-            const lines = data.toString().split(/\r?\n/).filter(l => l.trim());
-            for (const line of lines) {
-                io.to(`project:${projectId}`).emit('process.log', { project_id: projectId, stream, line, raw: line, seq: seq++ });
-                // The planning agent surfaces clarifying questions via a JSON signal
-                // line (`{"type":"plan_questions",...}`). Relay the stored questions
-                // to the client so it can render an answer form.
-                if (stream === 'stdout' && line.includes('"plan_questions"')) {
-                    try {
-                        const sig = JSON.parse(line.trim());
-                        if (sig && sig.type === 'plan_questions') {
-                            const project = webState.getProject(projectId);
-                            const qPath = project && path.join(project.path, '.jonggrang', 'plan-questions.json');
-                            if (qPath && fs.existsSync(qPath)) {
-                                const questions = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
-                                io.to(`project:${projectId}`).emit('plan.questions', { project_id: projectId, ...questions });
-                            }
-                        }
-                    } catch { /* not a signal line — ignore */ }
-                }
+        // Read the stored clarifying questions and relay them to the client so it
+        // can render an answer form (feature: plan ask).
+        const emitPlanQuestions = () => {
+            const project = webState.getProject(projectId);
+            const qPath = project && path.join(project.path, '.jonggrang', 'plan-questions.json');
+            if (!qPath || !fs.existsSync(qPath)) return;
+            try {
+                const questions = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
+                io.to(`project:${projectId}`).emit('plan.questions', { project_id: projectId, ...questions });
+            } catch { /* unreadable store — ignore */ }
+        };
+
+        const handleLine = (stream, line) => {
+            if (!line.trim()) return;
+            io.to(`project:${projectId}`).emit('process.log', { project_id: projectId, stream, line, raw: line, seq: seq++ });
+            // The planning agent surfaces clarifying questions via a JSON signal
+            // line (`{"type":"plan_questions",...}`). Parse the *complete* line.
+            if (stream === 'stdout' && line.includes('"plan_questions"')) {
+                try {
+                    const sig = JSON.parse(line.trim());
+                    if (sig && sig.type === 'plan_questions') emitPlanQuestions();
+                } catch { /* not a signal line — ignore */ }
             }
         };
-        child.stdout.on('data', logLine('stdout'));
-        child.stderr.on('data', logLine('stderr'));
+
+        // `stdout`/`stderr` 'data' events do NOT guarantee whole lines — a JSON
+        // signal line can be split across chunks. Buffer per stream and only
+        // handle a line once its terminating newline has arrived.
+        const buffers = { stdout: '', stderr: '' };
+        const onData = (stream) => (data) => {
+            buffers[stream] += data.toString();
+            let nl;
+            while ((nl = buffers[stream].indexOf('\n')) !== -1) {
+                const line = buffers[stream].slice(0, nl).replace(/\r$/, '');
+                buffers[stream] = buffers[stream].slice(nl + 1);
+                handleLine(stream, line);
+            }
+        };
+        child.stdout.on('data', onData('stdout'));
+        child.stderr.on('data', onData('stderr'));
         child.on('close', (code, signal) => {
+            // Flush any trailing partial line (output not terminated by a newline).
+            for (const stream of ['stdout', 'stderr']) {
+                if (buffers[stream]) { handleLine(stream, buffers[stream].replace(/\r$/, '')); buffers[stream] = ''; }
+            }
             io.to(`project:${projectId}`).emit('process.exited', { project_id: projectId, code, signal });
             try {
                 const project = webState.getProject(projectId);

--- a/apis/projects/index.js
+++ b/apis/projects/index.js
@@ -77,14 +77,19 @@ module.exports = function register(app, io, ctx) {
         io.to(`project:${projectId}`).emit('process.started', { project_id: projectId, command, pid: child.pid });
         let seq = 0;
         // Read the stored clarifying questions and relay them to the client so it
-        // can render an answer form (feature: plan ask).
-        const emitPlanQuestions = () => {
+        // can render an answer form (feature: plan ask). Questions live per-draft
+        // under .drafts/<session>/ — resolve the session from the signal (the CLI
+        // emits it) and fall back to scanning for the newest pending draft.
+        const emitPlanQuestions = (session) => {
             const project = webState.getProject(projectId);
-            const qPath = project && path.join(project.path, '.jonggrang', 'plan-questions.json');
-            if (!qPath || !fs.existsSync(qPath)) return;
+            if (!project) return;
+            const sid = session || lib.resolveActiveQuestionDraft(project.path);
+            if (!sid) return;
+            const qPath = lib.questionsFileFor(project.path, sid);
+            if (!fs.existsSync(qPath)) return;
             try {
                 const questions = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
-                io.to(`project:${projectId}`).emit('plan.questions', { project_id: projectId, ...questions });
+                io.to(`project:${projectId}`).emit('plan.questions', { project_id: projectId, sessionId: sid, ...questions });
             } catch { /* unreadable store — ignore */ }
         };
 
@@ -96,7 +101,7 @@ module.exports = function register(app, io, ctx) {
             if (stream === 'stdout' && line.includes('"plan_questions"')) {
                 try {
                     const sig = JSON.parse(line.trim());
-                    if (sig && sig.type === 'plan_questions') emitPlanQuestions();
+                    if (sig && sig.type === 'plan_questions') emitPlanQuestions(sig.session);
                 } catch { /* not a signal line — ignore */ }
             }
         };

--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -294,6 +294,74 @@ module.exports = function(deps) {
         res.status(202).json({ job_id: project.id });
     });
 
+    // GET the clarifying questions the planning agent submitted (feature: plan ask).
+    router.get('/:id/plan/questions', (req, res) => {
+        const project = webState.getProject(req.params.id);
+        if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
+        const qPath = path.join(project.path, '.jonggrang', 'plan-questions.json');
+        if (!fs.existsSync(qPath)) return res.json({ exists: false, goal_analysis: '', questions: [] });
+        try {
+            const data = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
+            res.json({ exists: true, goal_analysis: data.goal_analysis || '', questions: data.questions || [] });
+        } catch (err) {
+            res.status(500).json({ error: { code: 'READ_ERROR', message: err.message } });
+        }
+    });
+
+    // Answer the clarifying questions → run Pass B (generate the plan with the
+    // answers). Answers are passed to the CLI inline (base64) so the same path
+    // works under the Docker sandbox without host/container fs ownership issues.
+    router.post('/:id/plan/answers', (req, res) => {
+        const project = webState.getProject(req.params.id);
+        if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
+
+        const { description, deep, tool, model, effort, base, answers } = req.body || {};
+        if (!description) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'description required' } });
+        if (!Array.isArray(answers) || answers.length === 0) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'answers must be a non-empty array' } });
+        }
+        if (answers.length > 20) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'too many answers (max 20)' } });
+        }
+        for (const a of answers) {
+            if (!a || typeof a !== 'object' || !a.id) {
+                return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'each answer needs an id' } });
+            }
+        }
+        if (tool && !VALID_PLAN_TOOL.includes(tool)) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: `tool must be one of: ${VALID_PLAN_TOOL.join(', ')}` } });
+        }
+        if (model && typeof model === 'string' && model.length > MAX_STRING_LEN) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'model must be under 100 characters' } });
+        }
+        if (effort) {
+            const allowed = tool ? (STATIC_EFFORTS[tool] || []) : ALL_EFFORTS;
+            if (!allowed.includes(effort)) {
+                const expected = allowed.length ? allowed.join(', ') : '(this backend takes no effort level)';
+                return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: `effort must be one of: ${expected}` } });
+            }
+        }
+        if (base && !lib.isSafeBranchName(base)) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'base must be a plain branch name (letters, digits, . _ / -)' } });
+        }
+
+        const goal_analysis = typeof req.body.goal_analysis === 'string' ? req.body.goal_analysis : '';
+        const payload = { goal_analysis, answers };
+        const inline = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+        if (inline.length > 200000) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'answers payload too large' } });
+        }
+
+        const args = ['plan', description, ...(deep ? ['--deep'] : []), '--answers-inline', inline];
+        if (tool)   args.push('--tool', tool);
+        if (model)  args.push('--model', model);
+        if (effort) args.push('--effort', effort);
+        if (base)   args.push('--base', base);
+        const child = spawnForProject(project, args);
+        wireProjectProcess(project.id, child, 'plan');
+        res.status(202).json({ job_id: project.id });
+    });
+
     router.put('/:id/plan', (req, res) => {
         const project = webState.getProject(req.params.id);
         if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });

--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -298,11 +298,18 @@ module.exports = function(deps) {
     router.get('/:id/plan/questions', (req, res) => {
         const project = webState.getProject(req.params.id);
         if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
-        const qPath = path.join(project.path, '.jonggrang', 'plan-questions.json');
+        // Questions live per-draft under .drafts/<session>/ — resolve the session
+        // (explicit override, else newest pending draft, else the active draft)
+        // instead of hardcoding the old root singleton.
+        const sid = requestedSession(req)
+            || lib.resolveActiveQuestionDraft(project.path)
+            || lib.resolveActiveDraft(project.path);
+        if (!sid) return res.json({ exists: false, goal_analysis: '', questions: [] });
+        const qPath = lib.questionsFileFor(project.path, sid);
         if (!fs.existsSync(qPath)) return res.json({ exists: false, goal_analysis: '', questions: [] });
         try {
             const data = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
-            res.json({ exists: true, goal_analysis: data.goal_analysis || '', questions: data.questions || [] });
+            res.json({ exists: true, sessionId: sid, goal_analysis: data.goal_analysis || '', questions: data.questions || [] });
         } catch (err) {
             res.status(500).json({ error: { code: 'READ_ERROR', message: err.message } });
         }
@@ -352,7 +359,14 @@ module.exports = function(deps) {
             return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'answers payload too large' } });
         }
 
+        // Reuse the draft that already holds the pending questions (Pass A wrote
+        // them into .drafts/<sid>/). Passing --session makes Pass B generate
+        // plan.md into that same draft instead of minting a fresh one — so the
+        // questions-only draft becomes the real plan draft (no orphan folders).
+        const sid = requestedSession(req) || lib.resolveActiveQuestionDraft(project.path);
+
         const args = ['plan', description, ...(deep ? ['--deep'] : []), '--answers-inline', inline];
+        if (sid)    args.push('--session', sid);
         if (tool)   args.push('--tool', tool);
         if (model)  args.push('--model', model);
         if (effort) args.push('--effort', effort);

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -9,7 +9,7 @@ const os = require('os');
 const path = require('path');
 const { spawn, spawnSync, execSync } = require('child_process');
 const readline = require('readline');
-const { intro, outro, select, confirm, text, isCancel, cancel, spinner } = require('@clack/prompts');
+const { intro, outro, select, multiselect, confirm, text, isCancel, cancel, spinner } = require('@clack/prompts');
 
 const lib = require('../lib/jonggrang');
 const orchestration = require('../lib/orchestration');
@@ -45,6 +45,10 @@ const paths = lib.getProjectPaths(PROJECT_ROOT);
 const CONFIG_FILE   = process.env.JONGGRANG_CONFIG || paths.configFile;
 const TASKS_FILE    = paths.tasksFile;
 const LEGACY_PLAN_FILE = paths.legacyPlanFile;
+// Clarifying-questions sidecars (feature: plan ask). Durable, root-level — one
+// plan generation runs at a time per project, and they're cleared before Pass A.
+const QUESTIONS_FILE = paths.questionsFile;
+const ANSWERS_FILE  = paths.answersFile;
 const PROGRESS_FILE = paths.progressFile;
 const AGENTS_FILE   = paths.agentsFile;
 const SKILLS_DIR    = paths.skillsDir;
@@ -1096,13 +1100,207 @@ async function ensureInit() {
 
 // ── PHASE 1: Generate draft plan.md ───────────────────────────
 // opts.fromWork = true → suppress "run jonggrang work" tail (cmdWork will continue itself)
+// ============================================================
+// PLAN CLARIFYING QUESTIONS  (jonggrang plan ask)
+// ============================================================
+
+// Agent-facing intake: the planning agent SUBMITS clarifying questions here
+// instead of guessing. Mirrors `jonggrang task import` (flag / file / stdin).
+function cmdPlanAsk(subArgs) {
+  const flags = {};
+  const positional = [];
+  for (let j = 0; j < subArgs.length; j++) {
+    if (subArgs[j] === '--input')       { flags.input = subArgs[++j]; }
+    else if (subArgs[j] === '--goal')   { flags.goal = subArgs[++j]; }
+    else if (subArgs[j] === '--pretty') { flags.pretty = true; }
+    else if (subArgs[j] === '--json')   { flags.json = true; }
+    else if (subArgs[j] === 'help' || subArgs[j] === '--help') { flags.help = true; }
+    else { positional.push(subArgs[j]); }
+  }
+
+  if (flags.help) { cmdPlanAskHelp(); return; }
+
+  const isTTY = process.stdout.isTTY;
+  const pretty = flags.pretty || (isTTY && !flags.json);
+
+  try {
+    safeCheckConfig();
+
+    let raw;
+    if (flags.input) {
+      raw = flags.input;
+    } else if (positional[0]) {
+      const filePath = path.resolve(positional[0]);
+      if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+      raw = fs.readFileSync(filePath, 'utf8');
+    } else if (!process.stdin.isTTY) {
+      raw = fs.readFileSync('/dev/stdin', 'utf8');
+    } else {
+      throw new Error("Provide questions via --input '{...}', a file path, or stdin.");
+    }
+
+    let payload;
+    try { payload = JSON.parse(raw); }
+    catch (e) { throw new Error(`Invalid JSON: ${e.message}`); }
+
+    const saved = lib.savePlanQuestions(QUESTIONS_FILE, payload, flags.goal);
+
+    if (pretty) {
+      logSuccess(`Submitted ${saved.questions.length} clarifying question(s):`);
+      if (saved.goal_analysis) console.log(`  ${DIM}Goal: ${saved.goal_analysis}${NC}`);
+      for (const q of saved.questions) console.log(`  ${q.id}: ${q.question} ${DIM}(${q.type})${NC}`);
+    } else {
+      console.log(JSON.stringify(saved));
+    }
+  } catch (err) {
+    if (pretty) logError(err.message);
+    else console.log(JSON.stringify({ error: err.message }));
+    process.exit(1);
+  }
+}
+
+function cmdPlanAskHelp() {
+  console.log(`
+${BOLD}jonggrang plan ask${NC} — submit clarifying questions (agent-facing intake)
+
+This command is used by the planning AGENT, not typically by you. During planning
+the agent calls it to ask the user questions instead of guessing.
+
+${BOLD}Usage:${NC}
+  jonggrang plan ask --input '<json>'
+  jonggrang plan ask questions.json
+  echo '<json>' | jonggrang plan ask
+
+${BOLD}Flags:${NC}
+  --input <json>   Questions JSON (object or array)
+  --goal "<text>"  Goal restatement (if not embedded in the JSON)
+  --pretty/--json  Force human / machine output
+
+${BOLD}JSON schema:${NC}
+  {
+    "goal_analysis": "what the user wants to achieve",
+    "questions": [
+      { "question": "Which X?", "rationale": "why", "type": "single_choice",
+        "options": [ {"value":"a","label":"A","rationale":"trade-off"},
+                     {"value":"b","label":"B","rationale":"trade-off"} ] },
+      { "question": "Any constraints?", "type": "text" }
+    ]
+  }
+  Types: single_choice | multi_choice | text. Max ${6} questions.
+`);
+}
+
+// Resolve pre-supplied answers (--answers <file|-> / --answers-inline <base64>).
+// Returns { goal_analysis, answers:[] } or null when none provided.
+function loadPreAnswers(answersInput, answersInline) {
+  let raw = '';
+  if (answersInline) {
+    try { raw = Buffer.from(answersInline, 'base64').toString('utf8'); }
+    catch { logError('--answers-inline must be base64-encoded JSON.'); process.exit(1); }
+  } else if (answersInput) {
+    if (answersInput === '-') {
+      raw = fs.readFileSync('/dev/stdin', 'utf8');
+    } else {
+      const fp = path.resolve(answersInput);
+      if (!fs.existsSync(fp)) { logError(`Answers file not found: ${fp}`); process.exit(1); }
+      raw = fs.readFileSync(fp, 'utf8');
+    }
+  } else {
+    return null;
+  }
+  let payload;
+  try { payload = JSON.parse(raw); }
+  catch (e) { logError(`Invalid answers JSON: ${e.message}`); process.exit(1); }
+  if (Array.isArray(payload)) return { goal_analysis: '', answers: payload };
+  if (payload && Array.isArray(payload.answers)) {
+    return { goal_analysis: payload.goal_analysis || '', answers: payload.answers };
+  }
+  logError('Answers must be a JSON array or an object with an "answers" array.');
+  process.exit(1);
+}
+
+// Present the agent's questions to the user via @clack and collect answers.
+// Returns { goal_analysis, answers:[] }, or null if the user cancels.
+async function collectAnswersInteractive(q) {
+  const FREETEXT = '__freetext__';
+  const answers = [];
+
+  if (q.goal_analysis) logInfo(`Goal: ${q.goal_analysis}`);
+  console.log(`\n${BOLD}The agent has ${q.questions.length} question(s) before planning:${NC}\n`);
+
+  for (let i = 0; i < q.questions.length; i++) {
+    const ques = q.questions[i];
+    if (ques.rationale) console.log(`  ${DIM}Why: ${ques.rationale}${NC}`);
+    const message = `(${i + 1}/${q.questions.length}) ${ques.question}`;
+
+    if (ques.type === 'single_choice' || ques.type === 'multi_choice') {
+      const options = (ques.options || []).map(o => ({
+        value: o.value, label: o.label, hint: o.rationale || undefined,
+      }));
+      if (ques.allow_freetext) options.push({ value: FREETEXT, label: '✎ Type my own answer…' });
+
+      if (ques.type === 'single_choice') {
+        const picked = await select({ message, options });
+        if (isCancel(picked)) return null;
+        if (picked === FREETEXT) {
+          const typed = await text({ message: 'Your answer:' });
+          if (isCancel(typed)) return null;
+          answers.push({ id: ques.id, question: ques.question, type: ques.type, value: FREETEXT, freetext: String(typed) });
+        } else {
+          const opt = (ques.options || []).find(o => o.value === picked);
+          answers.push({ id: ques.id, question: ques.question, type: ques.type, value: picked, label: opt ? opt.label : picked, freetext: null });
+        }
+      } else {
+        const picked = await multiselect({ message, options, required: false });
+        if (isCancel(picked)) return null;
+        const vals = Array.isArray(picked) ? picked : [];
+        let freetext = null;
+        if (vals.includes(FREETEXT)) {
+          const typed = await text({ message: 'Your additional answer:' });
+          if (isCancel(typed)) return null;
+          freetext = String(typed);
+        }
+        const chosen = vals.filter(v => v !== FREETEXT);
+        const labels = chosen.map(v => { const o = (ques.options || []).find(x => x.value === v); return o ? o.label : v; });
+        answers.push({ id: ques.id, question: ques.question, type: ques.type, value: chosen, label: labels.join(', '), freetext });
+      }
+    } else {
+      const typed = await text({ message, placeholder: ques.rationale || '' });
+      if (isCancel(typed)) return null;
+      answers.push({ id: ques.id, question: ques.question, type: 'text', value: String(typed), freetext: String(typed) });
+    }
+  }
+  return { goal_analysis: q.goal_analysis || '', answers };
+}
+
+// Append (idempotently) a human-visible Clarifications section to plan.md.
+function appendClarificationsToPlan(planFile, clarifications) {
+  const MARKER = '<!-- jonggrang:clarifications -->';
+  try {
+    let content = fs.readFileSync(planFile, 'utf8');
+    const idx = content.indexOf(MARKER);
+    if (idx !== -1) content = content.slice(0, idx);
+    content = content.replace(/\s*$/, '\n');
+    content += `\n${MARKER}\n## Clarifications\n_Captured from the planning Q&A:_\n\n${clarifications}\n`;
+    fs.writeFileSync(planFile, content);
+  } catch { /* non-fatal */ }
+}
+
 async function cmdPlan(args, opts = {}) {
+  // `plan ask` is the agent-facing question-intake command (sibling of `task
+  // import`). Intercept before positional parsing — otherwise "ask" is read as
+  // the plan description.
+  if (args[0] === 'ask') return cmdPlanAsk(args.slice(1));
+
   let description = '';
   let autoApprove = false;
   let deepMode = false;
   let reviseMode = false;
   let baseBranch = '';
   let sessionId = '';
+  let answersInput = '';   // --answers <file|-> : run Pass B directly with these answers
+  let answersInline = '';  // --answers-inline <base64-json> : same, sandbox/web-safe
+  let noAsk = false;       // --no-ask : skip the clarification step entirely
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -1111,6 +1309,9 @@ async function cmdPlan(args, opts = {}) {
     else if (arg === '--revise') reviseMode = true;
     else if (arg === '--base') baseBranch = args[++i] || '';
     else if (arg === '--session') sessionId = args[++i] || '';
+    else if (arg === '--answers') answersInput = args[++i] || '';
+    else if (arg === '--answers-inline') answersInline = args[++i] || '';
+    else if (arg === '--no-ask') noAsk = true;
     else if (!arg.startsWith('--')) description = arg;
   }
 
@@ -1147,7 +1348,10 @@ async function cmdPlan(args, opts = {}) {
     logInfo(`Session:     ${sid}`);
     logInfo(`Instruction: ${description}`);
     const currentPlan = fs.readFileSync(draftFile, 'utf8');
-    const revisePrompt = lib.buildRevisePlanPrompt(currentPlan, description, draftFile);
+    // Reuse any earlier clarifications so the revision respects prior decisions.
+    const priorAnswers = lib.getPlanAnswers(ANSWERS_FILE);
+    const clarifications = lib.formatClarifications(priorAnswers);
+    const revisePrompt = lib.buildRevisePlanPrompt(currentPlan, description, draftFile, { clarifications });
     await lib.runAgent(revisePrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG });
     const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
     if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1225,6 +1429,39 @@ async function cmdPlan(args, opts = {}) {
     logInfo(`${existingDrafts.length} pending draft(s) already exist. This creates a new session (${sid}); 'jonggrang approve' defaults to the most recent, or use 'jonggrang approve --session <id>'.`);
   }
 
+  // ── Clarification step (Pass A) ─────────────────────────────
+  // The planning agent may submit questions via `jonggrang plan ask` instead of
+  // guessing. We collect the user's answers and feed them into generation (Pass B).
+  let clarifications = '';
+  {
+    let answers = loadPreAnswers(answersInput, answersInline); // web/scripts: Pass B directly
+    if (!answers && !noAsk && !autoApprove) {
+      lib.clearPlanQuestions(QUESTIONS_FILE);
+      logInfo('Analyzing goal — the agent may ask clarifying questions first...');
+      const qPrompt = lib.buildPlanQuestionsPrompt(description, CONFIG_FILE);
+      await lib.runAgent(qPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+      const q = lib.getPlanQuestions(QUESTIONS_FILE);
+      if (q.questions && q.questions.length > 0) {
+        if (isInteractiveTTY) {
+          answers = await collectAnswersInteractive(q);
+          if (answers === null) { cancel('Cancelled — no plan generated.'); return; }
+        } else {
+          // Headless (web/script): surface the questions and stop. The caller
+          // answers, then re-runs with --answers / --answers-inline (Pass B).
+          emitSignal('plan_questions', { count: q.questions.length, file: QUESTIONS_FILE });
+          logInfo(`Agent submitted ${q.questions.length} clarifying question(s). Answer them, then re-run with --answers <file>.`);
+          return;
+        }
+      } else {
+        logInfo('No clarification needed — generating plan directly.');
+      }
+    }
+    if (answers) {
+      lib.savePlanAnswers(ANSWERS_FILE, answers);
+      clarifications = lib.formatClarifications(answers);
+    }
+  }
+
   if (deepMode) {
     // ── Deep mode: 3 sequential AI phases ──────────────────────
     // Discovery + analysis intermediates live in the draft session folder;
@@ -1244,13 +1481,13 @@ async function cmdPlan(args, opts = {}) {
 
     // Phase 1: Discovery
     logInfo(`${BOLD}[1/3]${NC} Codebase discovery...`);
-    const discoveryPrompt = lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile);
+    const discoveryPrompt = lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile, { clarifications });
     await lib.runAgent(discoveryPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
 
     if (!lib.fileExists(discoveryFile)) {
       logError(`Discovery agent did not write ${discoveryFile}`);
       logInfo('Falling back to standard plan generation...');
-      const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile);
+      const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, { clarifications });
       await lib.runAgent(fallbackPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
       const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
       if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1265,7 +1502,7 @@ async function cmdPlan(args, opts = {}) {
       if (!lib.fileExists(analysisFile)) {
         logError(`Analysis agent did not write ${analysisFile}`);
         logInfo('Falling back to standard plan generation using discovery only...');
-        const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile);
+        const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, { clarifications });
         await lib.runAgent(fallbackPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
         const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
         if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1275,7 +1512,7 @@ async function cmdPlan(args, opts = {}) {
         logInfo(`${BOLD}[3/3]${NC} Condensing into enriched plan.md...`);
         const analysisContent = fs.readFileSync(analysisFile, 'utf8');
         const condensePrompt = lib.buildDeepPlanCondensePrompt(
-          description, discoveryContent, analysisContent, CONFIG_FILE, PROJECT_ROOT, draftFile
+          description, discoveryContent, analysisContent, CONFIG_FILE, PROJECT_ROOT, draftFile, { clarifications }
         );
         await lib.runAgent(condensePrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
         const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
@@ -1302,11 +1539,17 @@ async function cmdPlan(args, opts = {}) {
     // Clear stale feedback-loop state — planning is read-only, must not be blocked.
     feedback.clearFeedbackState(PROJECT_ROOT);
 
-    const prompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile);
+    const prompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, { clarifications });
     await lib.runAgent(prompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
     const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
     if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
     if (_v === 'missing') { logError('Agent did not write the plan. Retry.'); process.exit(1); }
+  }
+
+  // Record the clarifications into plan.md so the decisions are human-visible and
+  // travel with the plan (the JSON sidecar remains the machine-readable source).
+  if (clarifications && lib.fileExists(draftFile)) {
+    appendClarificationsToPlan(draftFile, clarifications);
   }
 
   // The base branch (worktree start-point) is a deterministic user choice, so
@@ -3796,6 +4039,8 @@ Commands:
   init                    Setup project (interactive or with flags)
   plan <description>      Phase 1 — generate .jonggrang/.drafts/<session>/plan.md for review
   plan <description> --yes  Plan + auto-approve + decompose to tasks in one shot
+  plan <description> --no-ask   Skip the agent's clarifying-questions step
+  plan ask --input '<json>'     (agent-facing) submit clarifying questions, like task import
   approve                 Phase 2 — decompose the most-recent draft into tasks
   approve --session <id>  Phase 2 — decompose a specific draft session into tasks
   work [description]      Execute tasks — with description runs plan → approve → execute

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -45,10 +45,10 @@ const paths = lib.getProjectPaths(PROJECT_ROOT);
 const CONFIG_FILE   = process.env.JONGGRANG_CONFIG || paths.configFile;
 const TASKS_FILE    = paths.tasksFile;
 const LEGACY_PLAN_FILE = paths.legacyPlanFile;
-// Clarifying-questions sidecars (feature: plan ask). Durable, root-level — one
-// plan generation runs at a time per project, and they're cleared before Pass A.
-const QUESTIONS_FILE = paths.questionsFile;
-const ANSWERS_FILE  = paths.answersFile;
+// Clarifying-questions/answers sidecars (feature: plan ask) are PER-DRAFT: they
+// live in .drafts/<session>/ alongside plan.md, resolved via lib.questionsFileFor
+// / lib.answersFileFor. Per-draft placement keeps concurrent `plan` runs from
+// clobbering each other's Q&A. There is no root-level singleton anymore.
 const PROGRESS_FILE = paths.progressFile;
 const AGENTS_FILE   = paths.agentsFile;
 const SKILLS_DIR    = paths.skillsDir;
@@ -1143,7 +1143,17 @@ function cmdPlanAsk(subArgs) {
     try { payload = JSON.parse(raw); }
     catch (e) { throw new Error(`Invalid JSON: ${e.message}`); }
 
-    const saved = lib.savePlanQuestions(QUESTIONS_FILE, payload, flags.goal);
+    // `plan ask` runs as a subprocess of the planning agent, which has no
+    // session context of its own. cmdPlan exports the active draft session via
+    // JONGGRANG_DRAFT_SESSION before invoking the agent; fall back to the most
+    // recent existing draft for standalone/manual use.
+    const sid = process.env.JONGGRANG_DRAFT_SESSION || lib.resolveActiveDraft(PROJECT_ROOT);
+    if (!sid) {
+      throw new Error('No active draft session for questions. Run `jonggrang plan "<description>"` first (it sets the session).');
+    }
+    const questionsFile = lib.questionsFileFor(PROJECT_ROOT, sid);
+    fs.mkdirSync(path.dirname(questionsFile), { recursive: true });
+    const saved = lib.savePlanQuestions(questionsFile, payload, flags.goal);
 
     if (pretty) {
       logSuccess(`Submitted ${saved.questions.length} clarifying question(s):`);
@@ -1347,9 +1357,11 @@ async function cmdPlan(args, opts = {}) {
     logHeader('JONGGRANG Plan — Revise with AI');
     logInfo(`Session:     ${sid}`);
     logInfo(`Instruction: ${description}`);
+    // Any `plan ask` the revision agent runs resolves to THIS session.
+    process.env.JONGGRANG_DRAFT_SESSION = sid;
     const currentPlan = fs.readFileSync(draftFile, 'utf8');
     // Reuse any earlier clarifications so the revision respects prior decisions.
-    const priorAnswers = lib.getPlanAnswers(ANSWERS_FILE);
+    const priorAnswers = lib.getPlanAnswers(lib.answersFileFor(PROJECT_ROOT, sid));
     const clarifications = lib.formatClarifications(priorAnswers);
     const revisePrompt = lib.buildRevisePlanPrompt(currentPlan, description, draftFile, { clarifications });
     await lib.runAgent(revisePrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG });
@@ -1424,6 +1436,12 @@ async function cmdPlan(args, opts = {}) {
   const draftFile = lib.draftFileFor(PROJECT_ROOT, sid);
   fs.mkdirSync(draftDir, { recursive: true });
 
+  // Per-draft Q&A sidecars, colocated with plan.md under .drafts/<sid>/. Export
+  // the session so any `plan ask` the planning agent runs writes into THIS draft.
+  const questionsFile = lib.questionsFileFor(PROJECT_ROOT, sid);
+  const answersFile = lib.answersFileFor(PROJECT_ROOT, sid);
+  process.env.JONGGRANG_DRAFT_SESSION = sid;
+
   const existingDrafts = lib.getAllDrafts(PROJECT_ROOT).filter(d => d.sessionId !== sid);
   if (existingDrafts.length > 0 && !sessionId) {
     logInfo(`${existingDrafts.length} pending draft(s) already exist. This creates a new session (${sid}); 'jonggrang approve' defaults to the most recent, or use 'jonggrang approve --session <id>'.`);
@@ -1437,14 +1455,14 @@ async function cmdPlan(args, opts = {}) {
     // Fresh plan run: drop any stale answers from a previous plan so they can't
     // leak into this run (--no-ask / no-questions cases) or a later `--revise`.
     // Pass B (--answers/-inline) re-saves the current run's answers below.
-    lib.clearPlanAnswers(ANSWERS_FILE);
+    lib.clearPlanAnswers(answersFile);
     let answers = loadPreAnswers(answersInput, answersInline); // web/scripts: Pass B directly
     if (!answers && !noAsk && !autoApprove) {
-      lib.clearPlanQuestions(QUESTIONS_FILE);
+      lib.clearPlanQuestions(questionsFile);
       logInfo('Analyzing goal — the agent may ask clarifying questions first...');
       const qPrompt = lib.buildPlanQuestionsPrompt(description, CONFIG_FILE);
       await lib.runAgent(qPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
-      const q = lib.getPlanQuestions(QUESTIONS_FILE);
+      const q = lib.getPlanQuestions(questionsFile);
       if (q.questions && q.questions.length > 0) {
         if (isInteractiveTTY) {
           answers = await collectAnswersInteractive(q);
@@ -1452,7 +1470,8 @@ async function cmdPlan(args, opts = {}) {
         } else {
           // Headless (web/script): surface the questions and stop. The caller
           // answers, then re-runs with --answers / --answers-inline (Pass B).
-          emitSignal('plan_questions', { count: q.questions.length, file: QUESTIONS_FILE });
+          // Emit the session so the web can locate this draft's questions file.
+          emitSignal('plan_questions', { count: q.questions.length, session: sid, file: questionsFile });
           logInfo(`Agent submitted ${q.questions.length} clarifying question(s). Answer them, then re-run with --answers <file>.`);
           return;
         }
@@ -1461,7 +1480,10 @@ async function cmdPlan(args, opts = {}) {
       }
     }
     if (answers) {
-      lib.savePlanAnswers(ANSWERS_FILE, answers);
+      lib.savePlanAnswers(answersFile, answers);
+      // Questions are now answered — drop the pending-questions marker so the web
+      // (resolveActiveQuestionDraft) doesn't resurface this draft as unanswered.
+      lib.clearPlanQuestions(questionsFile);
       clarifications = lib.formatClarifications(answers);
     }
   }

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1434,6 +1434,10 @@ async function cmdPlan(args, opts = {}) {
   // guessing. We collect the user's answers and feed them into generation (Pass B).
   let clarifications = '';
   {
+    // Fresh plan run: drop any stale answers from a previous plan so they can't
+    // leak into this run (--no-ask / no-questions cases) or a later `--revise`.
+    // Pass B (--answers/-inline) re-saves the current run's answers below.
+    lib.clearPlanAnswers(ANSWERS_FILE);
     let answers = loadPreAnswers(answersInput, answersInline); // web/scripts: Pass B directly
     if (!answers && !noAsk && !autoApprove) {
       lib.clearPlanQuestions(QUESTIONS_FILE);

--- a/client/src/components/plan/PlanView.vue
+++ b/client/src/components/plan/PlanView.vue
@@ -333,6 +333,57 @@
       </div>
     </div>
   </Dialog>
+
+  <!-- Clarifying questions from the planning agent (feature: plan ask) -->
+  <Dialog v-model:visible="showQuestionForm" modal header="A few questions before planning"
+          :style="{width:'560px'}" :draggable="false" :closable="false">
+    <div v-if="pendingQuestions" class="qa-body">
+      <p v-if="pendingQuestions.goal_analysis" class="qa-goal">
+        <strong>Goal:</strong> {{ pendingQuestions.goal_analysis }}
+      </p>
+      <div v-for="(q, qi) in pendingQuestions.questions" :key="q.id" class="qa-question">
+        <div class="qa-q-title">{{ qi + 1 }}. {{ q.question }}</div>
+        <div v-if="q.rationale" class="qa-q-why">Why: {{ q.rationale }}</div>
+
+        <template v-if="q.type === 'single_choice'">
+          <label v-for="o in q.options" :key="o.value" class="qa-opt">
+            <input type="radio" :name="'q-'+q.id" :value="o.value" v-model="answerDraft[q.id].choice" />
+            <span class="qa-opt-label">{{ o.label }}</span>
+            <span v-if="o.rationale" class="qa-opt-why">— {{ o.rationale }}</span>
+          </label>
+          <label v-if="q.allow_freetext" class="qa-opt">
+            <input type="radio" :name="'q-'+q.id" value="__freetext__" v-model="answerDraft[q.id].choice" />
+            <span class="qa-opt-label">✎ Type my own</span>
+          </label>
+          <input v-if="answerDraft[q.id].choice === '__freetext__'" v-model="answerDraft[q.id].freetext"
+                 class="qa-input" placeholder="Your answer" />
+        </template>
+
+        <template v-else-if="q.type === 'multi_choice'">
+          <label v-for="o in q.options" :key="o.value" class="qa-opt">
+            <input type="checkbox" :value="o.value" v-model="answerDraft[q.id].choices" />
+            <span class="qa-opt-label">{{ o.label }}</span>
+            <span v-if="o.rationale" class="qa-opt-why">— {{ o.rationale }}</span>
+          </label>
+          <label v-if="q.allow_freetext" class="qa-opt">
+            <input type="checkbox" v-model="answerDraft[q.id].useFreetext" />
+            <span class="qa-opt-label">✎ Add my own</span>
+          </label>
+          <input v-if="answerDraft[q.id].useFreetext" v-model="answerDraft[q.id].freetext"
+                 class="qa-input" placeholder="Your answer" />
+        </template>
+
+        <template v-else>
+          <textarea v-model="answerDraft[q.id].freetext" class="qa-textarea" rows="2"
+                    :placeholder="q.rationale || 'Your answer'" />
+        </template>
+      </div>
+    </div>
+    <template #footer>
+      <Button label="Cancel" text @click="cancelQuestions" />
+      <Button label="Generate Plan" icon="pi pi-sparkles" @click="submitAnswers" />
+    </template>
+  </Dialog>
 </template>
 
 <script setup>
@@ -390,6 +441,13 @@ const showToolModal = ref(false);
 const availableModels = ref([]);
 const availableEfforts = ref([]);
 const loadingModels = ref(false);
+
+// Plan clarifying questions (feature: plan ask). When the planning agent submits
+// questions, the server relays them via the `plan.questions` socket event; we show
+// a form, collect answers, and POST them to run Pass B (plan generation).
+const pendingQuestions = ref(null);   // { goal_analysis, questions:[] } or null
+const showQuestionForm = ref(false);
+const answerDraft = reactive({});     // keyed by question id
 
 const TOOLS = [
   { label: 'OpenCode',      value: 'opencode' },
@@ -620,6 +678,8 @@ async function generatePlan() {
   genLog.value = '';
   generating.value = true;
   showNewPlanForm.value = false;
+  pendingQuestions.value = null;
+  showQuestionForm.value = false;
   try {
     const body = { description: description.value, deep: deep.value };
     if (selectedTool.value)   body.tool   = selectedTool.value;
@@ -639,6 +699,65 @@ async function generatePlan() {
     genError.value = e.message;
     generating.value = false;
   }
+}
+
+// Build the answers payload from the form draft and run Pass B (plan generation).
+async function submitAnswers() {
+  if (!pendingQuestions.value) return;
+  const FREETEXT = '__freetext__';
+  const answers = [];
+  for (const q of pendingQuestions.value.questions) {
+    const d = answerDraft[q.id] || {};
+    if (q.type === 'single_choice') {
+      if (d.choice === FREETEXT) {
+        answers.push({ id: q.id, question: q.question, type: q.type, value: FREETEXT, freetext: (d.freetext || '').trim() });
+      } else {
+        const opt = (q.options || []).find(o => o.value === d.choice);
+        answers.push({ id: q.id, question: q.question, type: q.type, value: d.choice, label: opt ? opt.label : d.choice, freetext: null });
+      }
+    } else if (q.type === 'multi_choice') {
+      const chosen = Array.isArray(d.choices) ? d.choices : [];
+      const labels = chosen.map(v => { const o = (q.options || []).find(x => x.value === v); return o ? o.label : v; });
+      answers.push({ id: q.id, question: q.question, type: q.type, value: chosen, label: labels.join(', '), freetext: d.useFreetext ? (d.freetext || '').trim() : null });
+    } else {
+      const t = (d.freetext || '').trim();
+      answers.push({ id: q.id, question: q.question, type: 'text', value: t, freetext: t });
+    }
+  }
+
+  genError.value = '';
+  genLog.value = '';
+  generating.value = true;
+  showQuestionForm.value = false;
+  const goal_analysis = pendingQuestions.value.goal_analysis || '';
+  pendingQuestions.value = null;
+
+  const body = { description: description.value, deep: deep.value, answers, goal_analysis };
+  if (selectedTool.value)   body.tool   = selectedTool.value;
+  if (selectedModel.value)  body.model  = selectedModel.value;
+  if (selectedEffort.value) body.effort = selectedEffort.value;
+  if (selectedBase.value)   body.base   = selectedBase.value;
+  try {
+    const res = await fetch(`/api/projects/${projectId.value}/plan/answers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error?.message || 'Failed');
+    }
+  } catch (e) {
+    genError.value = e.message;
+    generating.value = false;
+  }
+}
+
+function cancelQuestions() {
+  showQuestionForm.value = false;
+  pendingQuestions.value = null;
+  generating.value = false;
+  showNewPlanForm.value = true; // let the user edit the request and try again
 }
 
 async function submitRevise() {
@@ -783,6 +902,19 @@ onMounted(async () => {
     loadPlans();
   });
 
+  socket.on('plan.questions', ({ project_id, goal_analysis, questions }) => {
+    if (project_id !== projectId.value) return;
+    Object.keys(answerDraft).forEach(k => delete answerDraft[k]);
+    for (const q of (questions || [])) {
+      if (q.type === 'multi_choice') answerDraft[q.id] = { choices: [], freetext: '', useFreetext: false };
+      else if (q.type === 'single_choice') answerDraft[q.id] = { choice: (q.options && q.options[0] ? q.options[0].value : ''), freetext: '' };
+      else answerDraft[q.id] = { freetext: '' };
+    }
+    pendingQuestions.value = { goal_analysis: goal_analysis || '', questions: questions || [] };
+    showQuestionForm.value = true;
+    generating.value = false;
+  });
+
   socket.on('process.log', ({ project_id, line }) => {
     if (project_id !== projectId.value) return;
     if (generating.value || approving.value || revising.value) {
@@ -801,6 +933,9 @@ onMounted(async () => {
     if (wasApproving && code !== 0) {
       genError.value = 'Approve failed — no new tasks were created. Re-run "Approve & Decompose".';
     }
+    // When the agent surfaced questions (Pass A), keep the description and the
+    // question form — generation isn't done; we're waiting for the user's answers.
+    if (pendingQuestions.value) return;
     if (wasGenerating || wasRevising || wasApproving) {
       description.value = '';
       if (wasGenerating) selectedPlan.value = null; // select the newly-created newest draft
@@ -1061,4 +1196,20 @@ onUnmounted(() => {
   color: var(--jg-text); font-family: var(--font-mono); font-size: 12px; outline: none;
 }
 .tool-modal-input:focus { border-color: var(--jg-green); }
+
+/* Clarifying questions form (feature: plan ask) */
+.qa-body { display: flex; flex-direction: column; gap: 16px; max-height: 60vh; overflow-y: auto; }
+.qa-goal { margin: 0; font-size: 13px; color: var(--jg-text-dim); }
+.qa-question { display: flex; flex-direction: column; gap: 4px; }
+.qa-q-title { font-weight: 600; font-size: 13px; color: var(--jg-text); }
+.qa-q-why { font-size: 12px; color: var(--jg-text-dim); margin-bottom: 4px; }
+.qa-opt { display: flex; align-items: baseline; gap: 6px; font-size: 13px; cursor: pointer; padding: 2px 0; }
+.qa-opt-label { color: var(--jg-text); }
+.qa-opt-why { color: var(--jg-text-dim); font-size: 12px; }
+.qa-input, .qa-textarea {
+  width: 100%; padding: 6px 8px; border-radius: 6px; margin-top: 4px;
+  background: var(--jg-bg); border: 1px solid var(--jg-border);
+  color: var(--jg-text); font-family: var(--font-mono); font-size: 12px; outline: none;
+}
+.qa-input:focus, .qa-textarea:focus { border-color: var(--jg-green); }
 </style>

--- a/docs/JONGGRANG.md
+++ b/docs/JONGGRANG.md
@@ -101,6 +101,8 @@ project-root/
 │   ├── jonggrang.json          # Project config
 │   ├── .drafts/<session>/      # Draft plans (gitignored, per-session — concurrent-safe)
 │   │   └── plan.md            # Pending plan (exists between plan → approve)
+│   ├── plan-questions.json     # Clarifying questions the agent submitted via `plan ask`
+│   ├── plan-answers.json       # Your answers (reused on `plan --revise`)
 │   ├── .output/                # TRACKED in git — plans + manifests travel with each branch on push
 │   │   └── features/{id}/
 │   │       ├── plan.md         # Archived plan (after approve); frontmatter holds the branch name

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -376,6 +376,24 @@ The **Issues** menu (top app nav, beside `projects`) lists GitHub/GitLab issues 
 - **Detail drawer**: right-aligned overlay (reuses the Dialog/Drawer pattern in §6.7) — header `repo#number`, state badge, author/date, markdown body, comments, footer "Open original" + "Pickup → Plan".
 - **Pickup modal**: source chip + Existing/New project choice → routes to the target project's **pre-filled New Plan form** (plan-creation UX is unchanged; only the description arrives populated). Source link surfaces on the plan card as a "↗ repo#N" link.
 
+### Plan clarifying-questions form (feature: plan ask)
+
+After **Generate Plan**, if the planning agent decides the request is ambiguous it
+submits clarifying questions (relayed to the client over the `plan.questions`
+socket event). The Plan view opens a modal (Dialog §6.7) titled "A few questions
+before planning":
+
+- **Goal** line at top (the agent's restatement of intent).
+- One block per question: title + a muted "Why:" rationale line.
+- **single_choice** → radio options, each showing its label + rationale, plus a
+  "✎ Type my own" radio that reveals a text input.
+- **multi_choice** → checkboxes + an optional "✎ Add my own" text input.
+- **text** → a textarea.
+- Footer: **Cancel** (returns to the New Plan form) / **Generate Plan** (POSTs the
+  answers to `/api/projects/:id/plan/answers`, which runs plan generation with the
+  answers). The resulting plan streams back as usual and records a `## Clarifications`
+  section.
+
 ---
 
 ## 8. Pipeline Timeline

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -13,8 +13,18 @@ Before the work loop can run, a plan must exist and be approved. This is a **two
 ```
 Phase 1 — jonggrang plan "description"
     │
-    ├─ AI writes .jonggrang/.drafts/<session>/plan.md  (high-level, human-editable)
-    │   Each plan call gets its own session-id — concurrent planning is safe.
+    ├─ Pass A — Clarify: the agent analyzes the goal first. If anything is
+    │   ambiguous it SUBMITS clarifying questions via `jonggrang plan ask`
+    │   (an agent-facing intake command, the sibling of `task import`) instead of
+    │   guessing. You answer each — pick an option (every option carries its
+    │   rationale) or type your own. Skipped when the request is unambiguous, or
+    │   with `--no-ask`. Q&A is stored in .jonggrang/plan-questions.json +
+    │   plan-answers.json (durable — reused on `plan --revise`).
+    │
+    ├─ Pass B — AI writes .jonggrang/.drafts/<session>/plan.md  (high-level,
+    │   human-editable), honoring the answers and recording them in a
+    │   `## Clarifications` section. Each plan call gets its own session-id —
+    │   concurrent planning is safe.
     │   frontmatter: feature, branch, work_type, description, created_at
     │   optional `base:` (set via `--base` / the web base picker) — the branch the
     │   worktree is cut from; fetched fresh from origin at run time. Default: main/master.

--- a/docs/plans/2026-06-28-plan-ask-clarifying-questions.md
+++ b/docs/plans/2026-06-28-plan-ask-clarifying-questions.md
@@ -1,0 +1,484 @@
+---
+feature: plan-ask-clarifying-questions
+branch: feat/planner
+work_type: LARGE
+description: Give the planning agent a first-class intake command — `jonggrang plan ask` — that it uses to SUBMIT clarifying questions (instead of hallucinating assumptions), mirroring `jonggrang task import`. The user answers (pick an option with its rationale, or free text), and the agent re-plans with real answers. Covers standard + --deep planning, persistence across plan revisions, and the web UI.
+created_at: 2026-06-28
+status: implemented (P1–P5) — E2E tested with the claude backend
+---
+
+> **Implementation status (2026-06-29):** P1–P5 built and E2E-tested in `/tmp` with
+> the `claude` backend. P6 (orchestrate-mode) dropped — this is a plan-mode feature.
+> Headless CLI path (Pass A → answers → Pass B), `--deep`, `--revise` reuse, and the
+> full web round-trip (POST /plan → `plan.questions` socket → POST /plan/answers →
+> plan.md) all pass. The interactive-TTY `@clack` collection is validated by
+> contract + API checks (not auto-tested in the sandbox — no reliable PTY); smoke-test
+> manually: `jonggrang plan "something vague" --tool claude`.
+
+# Plan: `jonggrang plan ask` — Agent-Submitted Clarifying Questions
+
+> **Scope:** design only, nothing implemented yet. Build the **CLI intake command
+> first**, test in `/tmp` with the `claude` backend, then the orchestration loop,
+> then web. This doc is for review.
+>
+> **Revision note (v2):** corrected the mental model. `plan ask` is a **tool the
+> agent calls to write its questions** (like `task import`), *not* a command the
+> user runs. This removes the earlier "parse questions out of the agent's stdout
+> text" idea, which risked the agent hallucinating malformed output.
+
+---
+
+## 1. Mental Model — read this first
+
+`plan ask` is to **questions** what `jonggrang task import` is to **tasks**: an
+**agent-facing intake command**. The planning agent calls it to submit structured
+clarifying questions; the CLI validates and stores them. The user never types
+`plan ask` themselves.
+
+```
+jonggrang task import  →  agent writes TASKS into the store   (bin/jonggrang.js:3133)
+jonggrang plan ask     →  agent writes QUESTIONS into the store   (NEW, mirrors it)
+```
+
+**Why this shape:** if the agent is uncertain, we do not want it to guess and
+write a confident-but-wrong plan ("agent halu"). Instead it must *stop and ask*,
+through a strict, validated command — exactly the discipline `task import` already
+enforces for tasks.
+
+### The full loop
+
+```
+            jonggrang plan "<desc>"                 (user runs this, or the web)
+                     │
+                     ▼
+        ┌────────────────────────────┐   PASS A: agent analyzes the goal.
+        │ planning agent (runAgent)  │   If ambiguous → it CALLS
+        │  prompt: "analyze goal;    │   `jonggrang plan ask --input '<json>'`
+        │   if unsure, plan ask;     │   (writes questions store) and STOPS.
+        │   else write plan.md"      │   If clear → it writes plan.md, done.
+        └─────────────┬──────────────┘
+                      │ questions submitted?
+            ┌─────────┴──────────┐
+            │ no                 │ yes
+            ▼                    ▼
+      plan.md written     ┌──────────────────────────────┐
+      → approve menu      │ collect answers from USER      │
+                          │  • CLI (TTY): @clack prompts   │
+                          │  • Web: render a form          │
+                          │  • headless: emit + wait        │
+                          └───────────────┬───────────────┘
+                                          │ answers store
+                                          ▼
+                          ┌──────────────────────────────┐
+                          │ PASS B: re-run planning agent  │
+                          │  prompt + answers → plan.md    │
+                          └──────────────────────────────┘
+```
+
+- **`plan ask`** is only ever invoked by the agent, inside Pass A.
+- The **user-answering** and **Pass B re-run** are orchestration the CLI/web own.
+- Answers reach Pass B via `jonggrang plan "<desc>" --answers <file>` (see §5).
+
+---
+
+## 2. Implementation Phases (build order)
+
+| Phase | Deliverable | Why this order |
+|---|---|---|
+| **P1** | `plan ask` intake command (+ lib store) | The thing the user asked to build & test first. Standalone, testable by calling it directly with sample JSON. |
+| **P2** | Planning-prompt change + CLI answer loop (standard mode, TTY) | Makes the agent actually use `plan ask`, and closes the loop interactively. |
+| **P3** | Persistence + plan revision reuse | Durable Q&A sidecar; `--revise` reuses prior answers; appended to plan.md. |
+| **P4** | `--deep` mode integration | Questions before the 3-phase deep pipeline. |
+| **P5** | Web integration | Endpoints + `PlanView.vue` question form + socket events. |
+| **P6** | *(optional)* Orchestrate-mode integration | Heaviest; orchestrate is autonomous, so this has caveats (§11). Confirm before doing. |
+
+Each phase is independently shippable. P1 is the foundation everything reuses.
+
+---
+
+## 3. P1 — The `plan ask` Intake Command
+
+Mirrors `taskImport` (`bin/jonggrang.js:3133`) and `cmdTask` flag parsing
+(`bin/jonggrang.js:2988-3044`) as closely as possible.
+
+### 3.1 Invocation (3 input modes, identical to `task import`)
+
+```bash
+# by flag (what the agent uses most):
+jonggrang plan ask --input '{"goal_analysis":"...","questions":[ ... ]}'
+
+# by file:
+jonggrang plan ask questions.json
+
+# by stdin pipe:
+echo '{"questions":[ ... ]}' | jonggrang plan ask
+```
+
+Accepts **either** the canonical object form
+`{ "goal_analysis": "...", "questions": [ ... ] }` **or** a bare array of question
+objects (goal_analysis then optional, settable via `--goal "<text>"`). Object form
+is canonical; the bare array exists for symmetry with `task import`.
+
+Flags (same idiom as `cmdTask`): `--input <json>`, `--goal <text>`, `--pretty`,
+`--json`. Output is JSON when non-TTY (so the agent can read what was stored) and
+pretty when TTY — exactly like `taskImport` (`bin/jonggrang.js:3160-3165`).
+
+### 3.2 Question object schema (the agent's contract)
+
+```jsonc
+{
+  "id": "q1",                       // optional; auto-assigned (q1, q2, …) if missing
+  "question": "Which auth strategy?",          // REQUIRED
+  "rationale": "Determines token storage and revocation.",  // optional (shown as 'Why:')
+  "type": "single_choice",          // single_choice | multi_choice | text  (default: text)
+  "allow_freetext": true,           // choice types: also offer 'type my own'
+  "options": [                      // REQUIRED for choice types, ≥2 items
+    { "value": "jwt",     "label": "JWT (stateless)", "rationale": "Scales horizontally, no session store." },
+    { "value": "session", "label": "Server sessions", "rationale": "Easy revocation, needs Redis." }
+  ]
+}
+```
+
+### 3.3 Validation (in the new `lib.savePlanQuestions`, mirrors `addTasksBulk`)
+
+- Parse JSON; reject with a clear message on parse error (like `taskImport`
+  `bin/jonggrang.js:3150-3156`).
+- `questions` non-empty; cap at **6** (avoid an interrogation; log if truncated).
+- Each question: `question` required; `type` ∈ {single_choice, multi_choice, text}
+  else coerced to `text`; choice types need ≥2 `options` each with `value`+`label`
+  (`rationale` optional → rendered as hint).
+- Auto-assign missing `id`s.
+- Empty/zero questions is an **error** for `plan ask` (the agent shouldn't call it
+  with nothing) — distinct from "agent chose not to ask", which means it never
+  calls the command at all.
+
+### 3.4 Store location (durable — NOT `.ephemeral`)
+
+```
+.jonggrang/plan-questions.json     ← questions submitted by the agent
+.jonggrang/plan-answers.json       ← answers collected from the user
+```
+
+Durable siblings of `plan.md`. **Must not** live under `.jonggrang/.ephemeral/`
+because `--deep` mode deletes that directory at the end of its run
+(`bin/jonggrang.js:1184-1189`), and we need these to survive for plan revision (P3).
+
+### 3.5 New `lib/jonggrang.js` functions (export at line 2350)
+
+| Function | Mirrors | Purpose |
+|---|---|---|
+| `savePlanQuestions(file, payload)` | `addTasksBulk` | validate + normalize + write questions store; return stored object |
+| `getPlanQuestions(file)` | `getTasks` | read questions store (`{questions:[]}` if none) |
+| `clearPlanQuestions(file)` | — | delete questions store (called before Pass A) |
+| `savePlanAnswers(file, answers)` | — | validate + write answers store |
+| `getPlanAnswers(file)` | `getTasks` | read answers store |
+
+### 3.6 Routing & help
+
+- In `cmdPlan` (`bin/jonggrang.js:1014`), intercept at the top **before** the
+  positional parser (the loop at 1021-1027 would otherwise treat `ask` as a
+  description):
+  ```js
+  if (args[0] === 'ask') return cmdPlanAsk(args.slice(1));
+  ```
+- `cmdPlanAsk(subArgs)` parses flags like `cmdTask`, reads input (flag/file/stdin
+  per §3.1), calls `lib.savePlanQuestions`, prints result. Pure intake — **no
+  interactive prompts here.**
+- Help: add a `plan ask` block to `cmdHelp` (and/or a `plan ask --help`), with the
+  schema example, modeled on `cmdTaskHelp` (`bin/jonggrang.js:3267`).
+
+### 3.7 P1 acceptance (test in `/tmp`, no agent needed yet)
+
+```bash
+mkdir -p /tmp/jg-ask && cd /tmp/jg-ask
+git init -q && echo x > README.md && git add -A && git commit -qm init
+node <repo>/bin/jonggrang.js init
+
+# happy path via --input
+node <repo>/bin/jonggrang.js plan ask --input '{"goal_analysis":"add health endpoint","questions":[{"question":"Path?","type":"single_choice","options":[{"value":"/healthz","label":"/healthz","rationale":"k8s convention"},{"value":"/health","label":"/health","rationale":"shorter"}]}]}'
+cat .jonggrang/plan-questions.json     # valid, ids assigned
+
+# via stdin + file, plus error paths (bad JSON, empty array, missing question)
+echo '{"questions":[{"question":"Notes?","type":"text"}]}' | node <repo>/bin/jonggrang.js plan ask
+node <repo>/bin/jonggrang.js plan ask --input 'not json'      # clean error, exit 1
+```
+
+- [ ] Stores valid JSON, assigns ids, echoes stored object (non-TTY JSON / TTY pretty).
+- [ ] All three input modes work; bad input fails cleanly like `task import`.
+
+---
+
+## 4. P2 — Teach the Agent + Close the Loop (standard mode, TTY)
+
+### 4.1 Planning prompt change (`lib/jonggrang.js`)
+
+Extend `buildDraftPlanPrompt` (line 526) with an instruction block:
+
+> **Before planning, analyze the goal.** Restate in 1-2 sentences what the user
+> wants to achieve. If anything material is ambiguous (architecture choice, scope,
+> data model, compatibility), **do not guess.** Submit clarifying questions by
+> running:
+> `jonggrang plan ask --input '<json>'`  (schema below), then STOP — do not write
+> `.jonggrang/plan.md`. Only when the request is unambiguous (or answers are
+> already provided below) write the plan.
+
+The agent runs the command itself (claude/codex/opencode/jonggrang can all run
+shell commands). This is the same trust model as the agent calling `task import`
+during decomposition.
+
+### 4.2 CLI orchestration in `cmdPlan` (standard branch, around 1194-1205)
+
+```
+clearPlanQuestions()                      # fresh slate
+runAgent(buildDraftPlanPrompt(...))       # PASS A
+q = getPlanQuestions()
+if q.questions.length and not plan.md-just-written:
+    if TTY:   answers = interactiveAnswer(q)      # §4.3
+              savePlanAnswers(answers)
+              runAgent(buildDraftPlanPrompt(..., {clarifications}))   # PASS B
+    else:     emitSignal('plan_questions', {...}); return            # headless → web/script
+# then existing setPlanBase + showPlanOptions  (1208-1223) unchanged
+```
+
+Detection of "did the agent ask vs plan": clear the questions store before Pass A,
+then check it after. (plan.md presence is the secondary signal.)
+
+### 4.3 Interactive answering (`@clack/prompts`, imported at `bin/jonggrang.js:12`)
+
+Add `multiselect` to the import. Mapping:
+
+| `type` | clack call | notes |
+|---|---|---|
+| `single_choice` | `select({message, options})` | `options[].hint = option.rationale`; append `{value:'__freetext__', label:'✎ Type my own answer…'}` when `allow_freetext` |
+| `multi_choice` | `multiselect({message, options})` | same hint mapping + optional `__freetext__` |
+| `text` | `text({message, placeholder})` | free input |
+
+- Question-level `rationale` printed as a dim `Why: …` line before the prompt.
+- `__freetext__` selection chains into a `text()` prompt.
+- `isCancel()` → abort cleanly, write no plan (consistent with the rest of the CLI).
+
+### 4.4 Answers schema (Pass-B input)
+
+```jsonc
+{
+  "goal_analysis": "…echoed for traceability…",
+  "answers": [
+    { "id":"q1", "question":"Which auth strategy?", "type":"single_choice",
+      "value":"jwt", "label":"JWT (stateless)", "freetext":null },
+    { "id":"q2", "question":"Notes?", "type":"text",
+      "value":"reuse Postgres users table", "freetext":"reuse Postgres users table" }
+  ]
+}
+```
+"Type my own" on a choice → `value:"__freetext__"`, `freetext:"<typed>"`.
+
+### 4.5 Pass B prompt
+
+`buildDraftPlanPrompt(description, configFile, tasksFile, { clarifications })` —
+when `clarifications` present, inject a `## Clarifications from User` section
+(goal + Q/A pairs) and tell the agent: answers are authoritative, **do not** ask
+again, write `plan.md`. Backward compatible (existing caller at 1204 passes nothing).
+
+---
+
+## 5. `--answers` flag (the headless seam for web + scripting)
+
+`jonggrang plan "<desc>" --answers <file|->` runs **Pass B directly**: skip Pass A
+question-gen, load answers, generate the plan. Also `--answers-inline <base64-json>`
+to avoid any filesystem/ownership issues inside the Docker sandbox (see the known
+sandbox bind-mount EACCES gotcha — passing answers inline sidesteps it entirely).
+
+This one flag is what lets the **web** drive the exact same logic without
+duplicating it: web collects answers in a form → calls `plan --answers-inline …`.
+
+---
+
+## 6. P3 — Persistence Across Plan Revisions
+
+"Persistent buat plan revision": once answered, the clarifications stick and inform
+future revisions.
+
+- **Durable store:** `.jonggrang/plan-questions.json` + `.jonggrang/plan-answers.json`
+  (already durable per §3.4). When `plan.md` is archived to
+  `.jonggrang/.output/features/<id>/`, copy both sidecars alongside it.
+- **Human-visible:** after Pass B, the CLI deterministically appends/updates a
+  `## Clarifications` section in `plan.md` (idempotent) so the decisions are
+  visible and travel with the plan even without the sidecar.
+- **Revise reuses them:** `buildRevisePlanPrompt` (`lib/jonggrang.js:606`) gains an
+  optional `clarifications` arg; `cmdPlan` revise branch (1041-1060) loads the
+  answers store and passes it, so revisions respect prior decisions.
+- **Revise can ask again:** `jonggrang plan ask` during a revise run appends new
+  questions; their answers are **merged** into the answers store (new entries, prior
+  ones preserved). This gives the "persistent + growable" Q&A across revisions.
+
+---
+
+## 7. P4 — `--deep` Mode Integration
+
+Deep mode is the 3-phase pipeline discovery → analysis → condense
+(`bin/jonggrang.js:1135-1193`).
+
+- Insert the **same Pass-A question step at the start** of deep mode: run an
+  analyze-goal pass that may call `plan ask`; collect answers (TTY) or emit
+  (headless); persist to the durable store **before** the pipeline runs (deep mode
+  wipes `.ephemeral` at the end — the durable store is unaffected).
+- Inject answers into `buildDeepPlanDiscoveryPrompt` (line 2117) and
+  `buildDeepPlanCondensePrompt` (line 2260) via an added `opts.clarifications` arg,
+  so discovery is guided by the answers and the final plan honors them.
+- Existing fallbacks (1158-1174) untouched.
+
+---
+
+## 8. P5 — Web Integration
+
+The web spawns the CLI and streams output (`apis/projects/index.js`
+`spawnForProject`/`wireProjectProcess`; `POST /:id/plan` at `apis/projects/plan.js:235`).
+We keep that model and add a question round on top of the **durable store** + the
+**`--answers-inline`** seam — no new planning logic on the server.
+
+### 8.1 Flow
+
+```
+client: New Plan form → "Generate Plan"
+   │  POST /:id/plan  { description, deep, tool, model, effort, base }      (existing)
+   ▼
+server: spawnForProject(['plan', desc, ...])  → PASS A runs in the project
+   │  agent calls `jonggrang plan ask` → writes .jonggrang/plan-questions.json
+   │  the spawned `plan` process is non-TTY → emits plan_questions signal & exits
+   ▼
+server: on that signal (or by watching the store file) → emit socket
+        'plan.questions' { project_id, goal_analysis, questions }
+   ▼
+client: PlanView.vue renders a QUESTION FORM (radio + rationale hints,
+        'type my own', checkboxes, textareas)
+   │  POST /:id/plan/answers  { answers: [...] }
+   ▼
+server: validate answers → spawnForProject(['plan', desc, ...,
+            '--answers-inline', base64(answers)])  → PASS B → writes plan.md
+   ▼
+client: existing plan.content / process.exited events render the plan  (unchanged)
+```
+
+### 8.2 Server changes (`apis/projects/plan.js`)
+
+- **`POST /:id/plan/answers`** — new. Validate `answers` (array, bounded size, each
+  `{id,type,value/freetext}`); reuse `tool/model/effort/base` validation from the
+  existing handler (235-263). Spawn `plan … --answers-inline <b64>`; wire socket.
+- Existing `POST /:id/plan` unchanged for the no-questions path; when the agent
+  asks, the process emits `plan_questions` and the server relays `plan.questions`.
+- Add `plan_questions` to whatever stdout-signal handling `wireProjectProcess`
+  does (or have the server watch `.jonggrang/plan-questions.json`).
+
+### 8.3 Client changes (`client/src/components/plan/PlanView.vue`)
+
+- New **Questions step** between submit and result. Render each question:
+  single_choice → radio group (label + muted rationale per option) + a "Type my
+  own" radio revealing an input; multi_choice → checkboxes; text → textarea.
+- New socket listener `plan.questions` (alongside the existing `plan.content` /
+  `process.log` / `process.exited` handlers ~line 748).
+- `generatePlan` (line 607) unchanged for the direct path; add `submitAnswers()`
+  that POSTs to `/plan/answers`.
+
+### 8.4 Sandbox note
+
+Answers go in via `--answers-inline` (base64), not a host-written file, to avoid
+the container-vs-host ownership EACCES problem on bind mounts. The agent's own
+`plan ask` write lands in `.jonggrang/` inside the container, which is already
+mirrored — same path the existing flow uses.
+
+---
+
+## 9. P6 — Orchestrate-Mode (OPTIONAL — confirm before building)
+
+In orchestrate mode the Lead produces the architecture plan/tasks (Phase 7). A
+clarification gate would sit **before** the Lead finalizes tasks, using the same
+`plan ask` store + answers injection into `buildPhaseContext`.
+
+**Caveat / tension:** orchestrate mode is designed to run **autonomously** (no
+human in the loop mid-run). A blocking question round contradicts that. Options:
+(a) only ask in `supervised` autonomy; (b) ask up-front (before phase 1) and store
+answers in `MANIFEST.yaml`; (c) defer P6 entirely.
+
+→ **Recommendation:** do P1-P5 first; treat P6 as a separate follow-up. I flagged
+this because "semua out-of-scope dimasukkan" includes it — but it needs its own
+decision given the autonomy conflict. **Tell me if you want P6 in this feature or
+split out.**
+
+---
+
+## 10. Testing
+
+### CLI (`/tmp`, `claude` backend)
+- **P1:** §3.7 (call `plan ask` directly, no agent).
+- **P2:** `jonggrang plan ask`-aware run end to end:
+  ```bash
+  node <repo>/bin/jonggrang.js plan "add login to the dashboard" --tool claude
+  # expect: agent restates goal, runs `plan ask`, you answer interactively,
+  #         then plan.md appears reflecting your answers
+  ```
+- **Headless:** ambiguous request in a non-TTY → `plan_questions` signal emitted,
+  no plan.md; then `plan "<desc>" --answers answers.json` → plan.md.
+- **P3:** answer once, run `plan --revise "…"`, confirm prior answers respected and
+  `## Clarifications` present in plan.md.
+- **P4:** `plan "<desc>" --deep` triggers the question round before the 3 phases.
+
+### Web (P5)
+- New Plan → ambiguous description → question form renders with rationales and
+  "type my own" → submit → plan.md streams back. Sandbox + non-sandbox.
+
+### Acceptance checklist
+- [ ] `plan ask` works as an agent intake tool (3 input modes, validation).
+- [ ] Agent uses it instead of guessing; clear requests skip questions.
+- [ ] Each choice question shows per-option rationale + a free-text escape hatch.
+- [ ] Answers visibly shape `plan.md`.
+- [ ] `--answers` / `--answers-inline` drive Pass B without re-asking.
+- [ ] Q&A persists; `--revise` reuses it; `## Clarifications` in plan.md.
+- [ ] `--deep` asks before the pipeline; `.ephemeral` cleanup doesn't lose answers.
+- [ ] Web form round-trips; sandbox path works via `--answers-inline`.
+- [ ] Cancel/Ctrl-C writes no plan.
+
+---
+
+## 11. Resolved Decisions
+
+1. **`plan ask` is agent-facing**, mirroring `task import` (per your correction).
+2. **Subcommand name:** `jonggrang plan ask`.
+3. **Max questions:** 6 per round.
+4. **multi_choice:** included.
+5. **Store is durable** (`.jonggrang/plan-*.json`, not `.ephemeral`) so revisions persist.
+6. **Q&A is written into `plan.md`** (`## Clarifications`) *and* kept as JSON sidecar.
+7. **Free-text escape hatch** ("Type my own") on every choice question.
+
+### Still needs your call
+- **P6 orchestrate-mode**: in this feature or split out? (see §9 caveat).
+- **Default behavior**: should plain `jonggrang plan`/web "Generate" always allow
+  the agent to ask, or only behind an explicit "ask first" toggle? → *Proposed:
+  always allow asking; clear requests simply won't trigger it.*
+- **Follow-up rounds**: allow a second question round after the first answers, or
+  cap at one round per run (revise can add more)? → *Proposed: one round per run.*
+
+---
+
+## 12. Docs to Update (CLAUDE.md "Iron Rule")
+
+| Change | Update |
+|---|---|
+| New `plan ask` subcommand + `--answers`/`--answers-inline` | `README.md` (Commands at a Glance + Quick flags), `docs/QUICKSTART.md`, `docs/EXAMPLE.md` |
+| Question/answer flow in planning | `docs/WORKFLOW.md`, `docs/PHILOSOPHY.md` (planning step, "thin agent" framing) |
+| `plan-questions.json` / `plan-answers.json` store | `docs/JONGGRANG.md` (Project File Structure) |
+| Web question form + endpoints | `docs/UI.md` |
+| Orchestrate gate (if P6) | `docs/ORCHESTRATION.md`, `docs/JONGGRANG.md` (16-phase) |
+
+---
+
+## 13. Dependencies (no new npm deps)
+
+- `taskImport` / `cmdTask` pattern to mirror (`bin/jonggrang.js:2988, 3133`).
+- `addTasksBulk` to mirror for `savePlanQuestions` (`lib/jonggrang.js`).
+- `buildDraftPlanPrompt` (526) / `buildRevisePlanPrompt` (606) / deep prompts
+  (2117, 2260) — extended with `clarifications`.
+- `runAgent` (853) — unchanged.
+- `@clack/prompts` `select`/`multiselect`/`text` (`bin/jonggrang.js:12`).
+- `emitSignal` (271), `showPlanOptions` (1230) — reused.
+- Web: `spawnForProject`/`wireProjectProcess` (`apis/projects/index.js`),
+  `POST /:id/plan` (`apis/projects/plan.js:235`), `PlanView.vue` (607, ~748).

--- a/docs/plans/2026-06-28-plan-ask-clarifying-questions.md
+++ b/docs/plans/2026-06-28-plan-ask-clarifying-questions.md
@@ -144,9 +144,11 @@ pretty when TTY — exactly like `taskImport` (`bin/jonggrang.js:3160-3165`).
 - Parse JSON; reject with a clear message on parse error (like `taskImport`
   `bin/jonggrang.js:3150-3156`).
 - `questions` non-empty; cap at **6** (avoid an interrogation; log if truncated).
-- Each question: `question` required; `type` ∈ {single_choice, multi_choice, text}
-  else coerced to `text`; choice types need ≥2 `options` each with `value`+`label`
-  (`rationale` optional → rendered as hint).
+- Each question: `question` required; `type` ∈ {single_choice, multi_choice, text}.
+  An **omitted** `type` defaults to `text`; an **explicit unsupported** `type` (e.g. a
+  typo like `single-choice`) is **rejected with a clear error** — not silently coerced —
+  so the agent fixes its call instead of shipping a broken UX/contract. Choice types
+  need ≥2 `options` each with `value`+`label` (`rationale` optional → rendered as hint).
 - Auto-assign missing `id`s.
 - Empty/zero questions is an **error** for `plan ask` (the agent shouldn't call it
   with nothing) — distinct from "agent chose not to ask", which means it never

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -2738,8 +2738,13 @@ function normalizePlanQuestions(payload, goalOverride) {
     const question = String(q.question || '').trim();
     if (!question) throw new Error('Each question needs a non-empty "question".');
 
-    let type = String(q.type || 'text');
-    if (!VALID_QUESTION_TYPES.has(type)) type = 'text'; // degrade gracefully
+    // Fail fast on an explicit unsupported type — silently coercing a typo like
+    // "single-choice" to "text" would change the UX + payload contract without the
+    // agent noticing. Omitting "type" still defaults to the valid "text".
+    const type = String(q.type || 'text');
+    if (!VALID_QUESTION_TYPES.has(type)) {
+      throw new Error(`Question "${question}" has unsupported type "${type}". Use one of: ${[...VALID_QUESTION_TYPES].join(', ')} (omit "type" to default to text).`);
+    }
 
     const item = {
       id: q.id || `q${normalized.length + 1}`,
@@ -2786,6 +2791,10 @@ function getPlanQuestions(questionsFile) {
 /** Delete the questions store (called before a fresh question-generation pass). */
 function clearPlanQuestions(questionsFile) {
   try { fs.unlinkSync(questionsFile); } catch { /* already gone */ }
+}
+
+function clearPlanAnswers(answersFile) {
+  try { fs.unlinkSync(answersFile); } catch { /* already gone */ }
 }
 
 /** Validate + persist the user's answers. Accepts { goal_analysis, answers:[] } or an array. */
@@ -2946,6 +2955,7 @@ module.exports = {
   savePlanQuestions,
   getPlanQuestions,
   clearPlanQuestions,
+  clearPlanAnswers,
   savePlanAnswers,
   getPlanAnswers,
   normalizePlanQuestions,

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -34,6 +34,8 @@ function getProjectPaths(projectRoot) {
     configFile,
     tasksFile:      path.join(jonggrangDir, 'jonggrang-tasks.json'),       // legacy root location — only used by migration read in cmdInit
     legacyPlanFile: path.join(jonggrangDir, 'plan.md'),                    // legacy pending draft path — migrated to .drafts/<session>/plan.md
+    questionsFile:  path.join(jonggrangDir, 'plan-questions.json'),        // clarifying-questions sidecar (feature: plan ask)
+    answersFile:    path.join(jonggrangDir, 'plan-answers.json'),          // clarifying-answers sidecar (feature: plan ask)
     progressFile:   path.join(jonggrangDir, 'progress.txt'),               // legacy root location — only used by migration read in cmdInit
     agentsFile:   path.join(projectRoot, 'AGENTS.md'),
     skillsDir:    resolveSkillsDir(projectRoot, tool),
@@ -819,12 +821,18 @@ ${bugCmd}
  * Build a prompt for Phase 1: generate a human-readable plan.md draft.
  * The AI writes the draft to `draftPath` but does NOT touch jonggrang-tasks.json.
  */
-function buildDraftPlanPrompt(description, configFile, projectRoot, draftPath) {
+function buildDraftPlanPrompt(description, configFile, projectRoot, draftPath, opts = {}) {
   let configSection = '';
   if (configFile && fileExists(configFile)) {
     const cfg = readJSON(configFile);
     if (cfg) configSection = `## Project Config\n\`\`\`json\n${JSON.stringify(cfg, null, 2)}\n\`\`\`\n`;
   }
+
+  // When the user has already answered the agent's clarifying questions, inject
+  // them as authoritative context so the plan reflects the real intent.
+  const clarSection = opts.clarifications
+    ? `## Clarifications from User (authoritative — do NOT ask again)\n${opts.clarifications}\n\n`
+    : '';
 
   // Only embed completed tasks (across all features) — to prevent re-doing finished work
   let completedSection = '';
@@ -848,7 +856,7 @@ ${configSection}${completedSection}
 - Read AGENTS.md for project conventions
 - Check existing code structure with ls/find if needed
 
-## Your Task
+${clarSection}## Your Task
 
 Create a high-level plan for this feature. Write it to \`${draftPath}\` using EXACTLY this format:
 
@@ -899,7 +907,10 @@ Existing code, services, or patterns this builds on. Write "None" if not applica
  * Build a prompt to revise an existing draft plan based on user feedback.
  * The AI rewrites the draft at `draftFile` in-place, preserving frontmatter unless explicitly changed.
  */
-function buildRevisePlanPrompt(currentPlanContent, feedback, draftFile) {
+function buildRevisePlanPrompt(currentPlanContent, feedback, draftFile, opts = {}) {
+  const clarSection = opts.clarifications
+    ? `\n## Earlier Clarifications from User (still authoritative)\n${opts.clarifications}\n`
+    : '';
   return `# Jonggrang — Revise Draft Plan
 
 ${buildProjectContext(process.cwd(), { maxChars: 2500 })}
@@ -911,7 +922,7 @@ ${currentPlanContent}
 
 ## User Feedback
 ${feedback}
-
+${clarSection}
 ## Your Task
 
 Revise the plan above based on the user feedback.
@@ -2448,12 +2459,15 @@ Rules:
  * The agent reads existing code, dependencies, and patterns relevant to the
  * feature, then writes a discovery report to .jonggrang/.ephemeral/deep-plan-discovery.md
  */
-function buildDeepPlanDiscoveryPrompt(description, configFile, discoveryPath) {
+function buildDeepPlanDiscoveryPrompt(description, configFile, discoveryPath, opts = {}) {
   let configSection = '';
   if (configFile && fileExists(configFile)) {
     const cfg = readJSON(configFile);
     if (cfg) configSection = `## Project Config\n\`\`\`json\n${JSON.stringify(cfg, null, 2)}\n\`\`\`\n`;
   }
+  const clarSection = opts.clarifications
+    ? `\n## Clarifications from User (authoritative — let these guide discovery)\n${opts.clarifications}\n`
+    : '';
 
   return `# Jonggrang Deep Plan — Phase 1: Codebase Discovery
 
@@ -2461,7 +2475,7 @@ ${buildProjectContext(configFile, { maxChars: 3500 })}
 
 ## Feature Request
 ${description}
-
+${clarSection}
 ## Project Context
 ${configSection}- Read AGENTS.md for project conventions and patterns
 - Explore the codebase to understand existing structure
@@ -2595,13 +2609,17 @@ After writing the file, output exactly: "Analysis complete: ${analysisPath}"`;
  * Phase 3 of --deep: Condense discovery + analysis into enriched plan.md
  * Reads both ephemeral files and writes a richer plan.md than the standard one.
  */
-function buildDeepPlanCondensePrompt(description, discoveryContent, analysisContent, configFile, projectRoot, draftPath) {
+function buildDeepPlanCondensePrompt(description, discoveryContent, analysisContent, configFile, projectRoot, draftPath, opts = {}) {
   let completedSection = '';
   const allTasks = getAllTasks(projectRoot);
   const done = allTasks.tasks.filter(t => t.status === 'completed');
   if (done.length > 0) {
     completedSection = `## Already Completed Work\nDo NOT plan to redo these:\n${done.map(t => `- ${t.id}: ${t.title}`).join('\n')}\n`;
   }
+
+  const clarSection = opts.clarifications
+    ? `## Clarifications from User (authoritative — the plan MUST honor these)\n${opts.clarifications}\n\n`
+    : '';
 
   const now = new Date().toISOString();
 
@@ -2612,7 +2630,7 @@ ${buildProjectContext(configFile, { maxChars: 3000 })}
 ## Feature Request
 ${description}
 
-## Discovery Report
+${clarSection}## Discovery Report
 \`\`\`markdown
 ${discoveryContent}
 \`\`\`
@@ -2682,6 +2700,204 @@ Rules:
 }
 
 // ============================================================
+// PLAN CLARIFYING QUESTIONS  (jonggrang plan ask)
+// ============================================================
+//
+// `plan ask` is an AGENT-facing intake command (the sibling of `task import`):
+// during planning the agent SUBMITS structured clarifying questions instead of
+// guessing. The questions/answers are stored as durable siblings of plan.md
+// (NOT under .ephemeral, which --deep wipes) so they survive into plan revision.
+
+const MAX_PLAN_QUESTIONS = 6;
+const VALID_QUESTION_TYPES = new Set(['single_choice', 'multi_choice', 'text']);
+
+/**
+ * Normalize + validate a questions payload submitted by the agent.
+ * Accepts an object { goal_analysis, questions:[...] } or a bare array of
+ * question objects. Throws on malformed input (mirrors taskImport strictness).
+ */
+function normalizePlanQuestions(payload, goalOverride) {
+  let goal_analysis = '';
+  let questions;
+  if (Array.isArray(payload)) {
+    questions = payload;
+  } else if (payload && typeof payload === 'object') {
+    questions = payload.questions;
+    goal_analysis = payload.goal_analysis || '';
+  } else {
+    throw new Error('Input must be a questions object or a JSON array of questions.');
+  }
+  if (goalOverride) goal_analysis = goalOverride;
+  if (!Array.isArray(questions)) throw new Error('Input must contain a "questions" array.');
+  if (questions.length === 0) throw new Error('Questions array is empty.');
+
+  const normalized = [];
+  for (const q of questions) {
+    if (normalized.length >= MAX_PLAN_QUESTIONS) break; // cap — avoid an interrogation
+    if (!q || typeof q !== 'object') throw new Error('Each question must be an object.');
+    const question = String(q.question || '').trim();
+    if (!question) throw new Error('Each question needs a non-empty "question".');
+
+    let type = String(q.type || 'text');
+    if (!VALID_QUESTION_TYPES.has(type)) type = 'text'; // degrade gracefully
+
+    const item = {
+      id: q.id || `q${normalized.length + 1}`,
+      question,
+      rationale: String(q.rationale || ''),
+      type,
+    };
+
+    if (type === 'single_choice' || type === 'multi_choice') {
+      const opts = Array.isArray(q.options) ? q.options : [];
+      const options = opts
+        .filter(o => o && (o.value != null || o.label != null))
+        .map(o => ({
+          value: String(o.value != null ? o.value : o.label),
+          label: String(o.label != null ? o.label : o.value),
+          rationale: String(o.rationale || ''),
+        }));
+      if (options.length < 2) {
+        throw new Error(`Question "${question}" (${type}) needs at least 2 options.`);
+      }
+      item.options = options;
+      item.allow_freetext = q.allow_freetext !== false; // default true
+    }
+    normalized.push(item);
+  }
+
+  return { goal_analysis, questions: normalized };
+}
+
+/** Validate + persist questions submitted by the agent. Returns the stored object. */
+function savePlanQuestions(questionsFile, payload, goalOverride) {
+  const data = normalizePlanQuestions(payload, goalOverride);
+  writeJSON(questionsFile, data);
+  return data;
+}
+
+/** Read the questions store. Returns { goal_analysis, questions:[] } when absent. */
+function getPlanQuestions(questionsFile) {
+  const data = readJSON(questionsFile);
+  if (!data || !Array.isArray(data.questions)) return { goal_analysis: '', questions: [] };
+  return data;
+}
+
+/** Delete the questions store (called before a fresh question-generation pass). */
+function clearPlanQuestions(questionsFile) {
+  try { fs.unlinkSync(questionsFile); } catch { /* already gone */ }
+}
+
+/** Validate + persist the user's answers. Accepts { goal_analysis, answers:[] } or an array. */
+function savePlanAnswers(answersFile, payload) {
+  let goal_analysis = '';
+  let answers;
+  if (Array.isArray(payload)) {
+    answers = payload;
+  } else if (payload && typeof payload === 'object') {
+    answers = payload.answers;
+    goal_analysis = payload.goal_analysis || '';
+  } else {
+    throw new Error('Answers must be an object or array.');
+  }
+  if (!Array.isArray(answers)) throw new Error('Answers must contain an "answers" array.');
+  const data = { goal_analysis, answers };
+  writeJSON(answersFile, data);
+  return data;
+}
+
+/** Read the answers store. Returns null when absent. */
+function getPlanAnswers(answersFile) {
+  const data = readJSON(answersFile);
+  if (!data || !Array.isArray(data.answers)) return null;
+  return data;
+}
+
+/**
+ * Render collected answers into a markdown block for injection into plan prompts
+ * and for the human-visible "## Clarifications" section of plan.md. Returns '' when empty.
+ */
+function formatClarifications(answers) {
+  if (!answers || !Array.isArray(answers.answers) || answers.answers.length === 0) return '';
+  const lines = [];
+  if (answers.goal_analysis) { lines.push(`Goal: ${answers.goal_analysis}`, ''); }
+  for (const a of answers.answers) {
+    const resolved = (a.freetext != null && a.freetext !== '')
+      ? a.freetext
+      : (a.label != null && a.label !== '' ? a.label
+        : (a.value != null ? String(a.value) : '(no answer)'));
+    lines.push(`- **${a.question || a.id}** → ${resolved}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the "questions-only" Pass-A prompt: the agent analyzes the goal and, if
+ * anything is ambiguous, SUBMITS clarifying questions via `jonggrang plan ask`
+ * (it never writes plan.md here). If the request is unambiguous it outputs
+ * NO_QUESTIONS and stops.
+ */
+function buildPlanQuestionsPrompt(description, configFile) {
+  let configSection = '';
+  if (configFile && fileExists(configFile)) {
+    const cfg = readJSON(configFile);
+    if (cfg) configSection = `## Project Config\n\`\`\`json\n${JSON.stringify(cfg, null, 2)}\n\`\`\`\n`;
+  }
+
+  return `# Jonggrang — Clarify Before Planning
+
+## Feature Request
+${description}
+
+## Project Context
+${configSection}- Read AGENTS.md for project conventions
+- Skim the codebase (ls/find/read) only as much as needed to judge what is ambiguous
+
+## Your Task
+1. **Analyze the goal.** In 1-2 sentences, restate what the user wants to achieve.
+2. **Decide if you can plan confidently.** If anything MATERIAL is ambiguous —
+   architecture choice, scope boundaries, data model, backwards-compatibility,
+   UX, or a decision with real trade-offs — DO NOT guess.
+3. **If ambiguous, submit clarifying questions** by running the intake command
+   below, then STOP (do not write any plan). The user will answer and you will be
+   re-invoked with the answers.
+4. **If the request is already unambiguous**, output exactly \`NO_QUESTIONS\` and stop.
+
+## How to submit questions (preferred: write a file, then pass its path)
+Write the questions JSON to a temp file (avoids shell-escaping issues), then run:
+
+\`\`\`bash
+jonggrang plan ask /tmp/jonggrang-questions.json
+\`\`\`
+
+The JSON must match this schema (object with goal_analysis + questions array):
+
+\`\`\`json
+{
+  "goal_analysis": "one or two sentences restating the user's goal",
+  "questions": [
+    {
+      "question": "Which X do you want?",
+      "rationale": "why this matters for the plan",
+      "type": "single_choice",
+      "options": [
+        { "value": "a", "label": "Option A", "rationale": "trade-off of A" },
+        { "value": "b", "label": "Option B", "rationale": "trade-off of B" }
+      ]
+    },
+    { "question": "Any open constraints?", "rationale": "affects scope", "type": "text" }
+  ]
+}
+\`\`\`
+
+Rules:
+- Ask ONLY what genuinely blocks a correct plan. At most ${MAX_PLAN_QUESTIONS} questions.
+- Every option must carry a short \`rationale\` (the trade-off it implies).
+- Use \`"type":"text"\` for open-ended questions; \`"single_choice"\`/\`"multi_choice"\` need ≥2 options.
+- After the command succeeds, STOP. Do NOT write .jonggrang/plan.md.`;
+}
+
+// ============================================================
 // EXPORTS
 // ============================================================
 
@@ -2725,6 +2941,16 @@ module.exports = {
   detectCI,
   stackToType,
   getTestCommand,
+
+  // Plan clarifying questions (plan ask)
+  savePlanQuestions,
+  getPlanQuestions,
+  clearPlanQuestions,
+  savePlanAnswers,
+  getPlanAnswers,
+  normalizePlanQuestions,
+  formatClarifications,
+  buildPlanQuestionsPrompt,
 
   // Prompt builders
   buildProjectContext,

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -34,8 +34,8 @@ function getProjectPaths(projectRoot) {
     configFile,
     tasksFile:      path.join(jonggrangDir, 'jonggrang-tasks.json'),       // legacy root location — only used by migration read in cmdInit
     legacyPlanFile: path.join(jonggrangDir, 'plan.md'),                    // legacy pending draft path — migrated to .drafts/<session>/plan.md
-    questionsFile:  path.join(jonggrangDir, 'plan-questions.json'),        // clarifying-questions sidecar (feature: plan ask)
-    answersFile:    path.join(jonggrangDir, 'plan-answers.json'),          // clarifying-answers sidecar (feature: plan ask)
+    questionsFile:  path.join(jonggrangDir, 'plan-questions.json'),        // legacy root sidecar — superseded by per-draft questionsFileFor()
+    answersFile:    path.join(jonggrangDir, 'plan-answers.json'),          // legacy root sidecar — superseded by per-draft answersFileFor()
     progressFile:   path.join(jonggrangDir, 'progress.txt'),               // legacy root location — only used by migration read in cmdInit
     agentsFile:   path.join(projectRoot, 'AGENTS.md'),
     skillsDir:    resolveSkillsDir(projectRoot, tool),
@@ -130,6 +130,41 @@ function draftFileFor(projectRoot, sessionId) {
 function draftDirFor(projectRoot, sessionId) {
   if (!sessionId) throw new Error('draftDirFor: sessionId is required');
   return path.join(draftsDir(projectRoot), sessionId);
+}
+
+// Clarifying-questions/answers sidecars live PER-DRAFT, colocated with plan.md
+// under .drafts/<session>/. Q&A exists before a feature_id does (that's minted
+// at approve), so the draft session-id is the natural key. Per-draft placement
+// makes concurrent planning safe — two `plan` runs no longer clobber a shared
+// root singleton — and lets `--revise`/delete clean up the Q&A with the draft.
+function questionsFileFor(projectRoot, sessionId) {
+  if (!sessionId) throw new Error('questionsFileFor: sessionId is required');
+  return path.join(draftDirFor(projectRoot, sessionId), 'plan-questions.json');
+}
+
+function answersFileFor(projectRoot, sessionId) {
+  if (!sessionId) throw new Error('answersFileFor: sessionId is required');
+  return path.join(draftDirFor(projectRoot, sessionId), 'plan-answers.json');
+}
+
+// Resolve the newest draft session carrying a pending plan-questions.json.
+// A draft mid Pass-A has questions but no plan.md yet, so resolveActiveDraft()
+// (which requires plan.md) can't see it — this scans by questions-file mtime.
+// Used by the web to relay/read questions before the plan itself is generated.
+function resolveActiveQuestionDraft(projectRoot) {
+  const dir = draftsDir(projectRoot);
+  if (!fileExists(dir)) return null;
+  let names = [];
+  try { names = fs.readdirSync(dir); } catch { return null; }
+  let best = null;
+  for (const name of names) {
+    const qf = path.join(dir, name, 'plan-questions.json');
+    let st;
+    try { st = fs.statSync(qf); } catch { continue; }
+    if (!st.isFile()) continue;
+    if (!best || st.mtimeMs > best.mtime) best = { sessionId: name, mtime: st.mtimeMs };
+  }
+  return best ? best.sessionId : null;
 }
 
 /**
@@ -3023,9 +3058,12 @@ module.exports = {
   draftsDir,
   draftFileFor,
   draftDirFor,
+  questionsFileFor,
+  answersFileFor,
   generateDraftId,
   getAllDrafts,
   resolveActiveDraft,
+  resolveActiveQuestionDraft,
   verifyDraftWritten,
 
   // Orchestration extensions

--- a/scripts/plan-ask-smoke.sh
+++ b/scripts/plan-ask-smoke.sh
@@ -22,6 +22,14 @@ TEST_REPO="${TEST_REPO:-$(mktemp -d /tmp/jg-plan-ask-smoke.XXXXXX)}"
 rm -rf "$JONGGRANG_HOME"
 mkdir -p "$TEST_REPO"
 
+# `plan ask` now persists Q&A PER-DRAFT under .drafts/<session>/ (not a root
+# singleton). In production cmdPlan exports JONGGRANG_DRAFT_SESSION before running
+# the planning agent; emulate that here so standalone `plan ask` targets a draft.
+export JONGGRANG_DRAFT_SESSION="draft-plan-ask-smoke"
+DRAFT_REL=".jonggrang/.drafts/$JONGGRANG_DRAFT_SESSION"
+export QFILE="$DRAFT_REL/plan-questions.json"
+export AFILE="$DRAFT_REL/plan-answers.json"
+
 pass() { printf '\033[0;32mPASS\033[0m %s\n' "$*"; }
 fail() { printf '\033[0;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
 step() { printf '\n\033[0;36m==> %s\033[0m\n' "$*"; }
@@ -66,7 +74,7 @@ git commit -m "chore: setup plan ask smoke repo" >/dev/null
 pass "repo initialized"
 
 clean_plan() {
-  rm -f .jonggrang/plan.md .jonggrang/plan-questions.json .jonggrang/plan-answers.json
+  rm -f .jonggrang/plan.md "$QFILE" "$AFILE"
   rm -rf .jonggrang/.ephemeral
 }
 
@@ -87,10 +95,10 @@ clean_plan
   ]
 }' >/tmp/jg-plan-ask-smoke-valid.json
 
-test -f .jonggrang/plan-questions.json || fail "plan-questions.json missing"
+test -f "$QFILE" || fail "plan-questions.json missing (expected at $QFILE)"
 node - <<'NODE'
 const fs = require('fs');
-const q = JSON.parse(fs.readFileSync('.jonggrang/plan-questions.json', 'utf8'));
+const q = JSON.parse(fs.readFileSync(process.env.QFILE, 'utf8'));
 if (q.goal_analysis !== 'Need clarify') throw new Error('goal_analysis mismatch');
 if (!Array.isArray(q.questions) || q.questions.length !== 2) throw new Error('questions length mismatch');
 if (q.questions[0].id !== 'q1' || q.questions[1].id !== 'q2') throw new Error('auto ids missing');
@@ -104,7 +112,7 @@ printf '%s' '[{"question":"Pick one","type":"single_choice","options":[{"value":
   | "${JG[@]}" plan ask --json --goal "Override goal" >/tmp/jg-plan-ask-smoke-stdin.json
 node - <<'NODE'
 const fs = require('fs');
-const q = JSON.parse(fs.readFileSync('.jonggrang/plan-questions.json', 'utf8'));
+const q = JSON.parse(fs.readFileSync(process.env.QFILE, 'utf8'));
 if (q.goal_analysis !== 'Override goal') throw new Error('goal override failed');
 if (q.questions[0].question !== 'Pick one') throw new Error('stdin question not saved');
 NODE
@@ -125,7 +133,8 @@ const path = require('path');
 const fs = require('fs');
 const repo = process.argv[2];
 const lib = require(path.join(repo, 'lib/jonggrang'));
-const answersFile = path.join(process.cwd(), '.jonggrang', 'plan-answers.json');
+const answersFile = path.resolve(process.env.AFILE);
+fs.mkdirSync(path.dirname(answersFile), { recursive: true });
 lib.savePlanAnswers(answersFile, {
   goal_analysis: 'Goal',
   answers: [
@@ -140,7 +149,7 @@ if (!md.includes('**Which UI?** → Modal')) throw new Error('choice missing fro
 if (!md.includes('**Constraints?** → Keep MVP')) throw new Error('text missing from clarifications');
 fs.writeFileSync('/tmp/jg-plan-ask-smoke-clarifications.md', md);
 NODE
-test -f .jonggrang/plan-answers.json || fail "plan-answers.json missing"
+test -f "$AFILE" || fail "plan-answers.json missing (expected at $AFILE)"
 pass "answers persisted and formatted"
 
 step "Test 5: prompt builders include clarifications"

--- a/scripts/plan-ask-smoke.sh
+++ b/scripts/plan-ask-smoke.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic smoke tests for `jonggrang plan ask`.
+#
+# This intentionally avoids live LLM calls. It validates the CLI intake contract,
+# persisted sidecar files, answer formatting, and prompt injection by creating a
+# disposable project in /tmp and running the repo-local Jonggrang binary.
+#
+# Usage:
+#   bash scripts/plan-ask-smoke.sh
+#
+# Optional env:
+#   TEST_REPO=/tmp/my-repo                 # default: mktemp -d /tmp/jg-plan-ask-smoke.XXXXXX
+#   JONGGRANG_HOME=/tmp/my-jonggrang-home  # default: /tmp/jg-plan-ask-smoke-home
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JG=(node "$ROOT_DIR/bin/jonggrang.js")
+export JONGGRANG_HOME="${JONGGRANG_HOME:-/tmp/jg-plan-ask-smoke-home}"
+
+TEST_REPO="${TEST_REPO:-$(mktemp -d /tmp/jg-plan-ask-smoke.XXXXXX)}"
+rm -rf "$JONGGRANG_HOME"
+mkdir -p "$TEST_REPO"
+
+pass() { printf '\033[0;32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '\033[0;31mFAIL\033[0m %s\n' "$*" >&2; exit 1; }
+step() { printf '\n\033[0;36m==> %s\033[0m\n' "$*"; }
+
+step "Using repo-local Jonggrang binary"
+"${JG[@]}" version
+
+step "Initialize disposable repo: $TEST_REPO"
+cd "$TEST_REPO"
+git init -b main >/dev/null
+git config user.email "manual-test@example.com"
+git config user.name "Manual Test"
+
+"${JG[@]}" init \
+  --name plan-ask-smoke \
+  --type cli \
+  --work-mode work-loop \
+  --team-size solo \
+  --state existing \
+  --stack node \
+  --autonomy autonomous \
+  --ci none \
+  --testing npm \
+  --tool claude \
+  --force >/tmp/jg-plan-ask-smoke-init.log
+
+cat > package.json <<'JSON'
+{"name":"plan-ask-smoke","version":"1.0.0","type":"commonjs","scripts":{"test":"node test/smoke.test.js"}}
+JSON
+cat > index.js <<'JS'
+function greet(name) { return `hello ${name}`; }
+module.exports = { greet };
+JS
+mkdir -p test
+cat > test/smoke.test.js <<'JS'
+const { greet } = require('../index');
+if (greet('jonggrang') !== 'hello jonggrang') throw new Error('greet failed');
+console.log('ok');
+JS
+git add . >/dev/null
+git commit -m "chore: setup plan ask smoke repo" >/dev/null
+pass "repo initialized"
+
+clean_plan() {
+  rm -f .jonggrang/plan.md .jonggrang/plan-questions.json .jonggrang/plan-answers.json
+  rm -rf .jonggrang/.ephemeral
+}
+
+step "Test 1: plan ask saves normalized questions"
+clean_plan
+"${JG[@]}" plan ask --json --input '{
+  "goal_analysis": "Need clarify",
+  "questions": [
+    {
+      "question": "UI-nya mau seperti apa?",
+      "type": "single_choice",
+      "options": [
+        {"value":"modal","label":"Modal","rationale":"lebih cepat"},
+        {"value":"page","label":"Page","rationale":"lebih fleksibel"}
+      ]
+    },
+    {"question":"Ada constraint khusus?","type":"text"}
+  ]
+}' >/tmp/jg-plan-ask-smoke-valid.json
+
+test -f .jonggrang/plan-questions.json || fail "plan-questions.json missing"
+node - <<'NODE'
+const fs = require('fs');
+const q = JSON.parse(fs.readFileSync('.jonggrang/plan-questions.json', 'utf8'));
+if (q.goal_analysis !== 'Need clarify') throw new Error('goal_analysis mismatch');
+if (!Array.isArray(q.questions) || q.questions.length !== 2) throw new Error('questions length mismatch');
+if (q.questions[0].id !== 'q1' || q.questions[1].id !== 'q2') throw new Error('auto ids missing');
+if (q.questions[0].allow_freetext !== true) throw new Error('allow_freetext default missing');
+if (q.questions[0].options.length !== 2) throw new Error('options mismatch');
+NODE
+pass "questions normalized and persisted"
+
+step "Test 2: plan ask accepts stdin and --goal override"
+printf '%s' '[{"question":"Pick one","type":"single_choice","options":[{"value":"a"},{"value":"b"}]}]' \
+  | "${JG[@]}" plan ask --json --goal "Override goal" >/tmp/jg-plan-ask-smoke-stdin.json
+node - <<'NODE'
+const fs = require('fs');
+const q = JSON.parse(fs.readFileSync('.jonggrang/plan-questions.json', 'utf8'));
+if (q.goal_analysis !== 'Override goal') throw new Error('goal override failed');
+if (q.questions[0].question !== 'Pick one') throw new Error('stdin question not saved');
+NODE
+pass "stdin + goal override works"
+
+step "Test 3: invalid single_choice is rejected"
+set +e
+bad_out=$("${JG[@]}" plan ask --json --input '{"questions":[{"question":"Bad","type":"single_choice","options":[{"value":"only"}]}]}' 2>&1)
+bad_code=$?
+set -e
+[[ $bad_code -ne 0 ]] || fail "invalid schema unexpectedly succeeded"
+grep -q "needs at least 2 options" <<<"$bad_out" || fail "invalid schema error message mismatch: $bad_out"
+pass "invalid schema rejected"
+
+step "Test 4: library answer persistence + clarification formatting"
+node - "$ROOT_DIR" <<'NODE'
+const path = require('path');
+const fs = require('fs');
+const repo = process.argv[2];
+const lib = require(path.join(repo, 'lib/jonggrang'));
+const answersFile = path.join(process.cwd(), '.jonggrang', 'plan-answers.json');
+lib.savePlanAnswers(answersFile, {
+  goal_analysis: 'Goal',
+  answers: [
+    { id: 'q1', question: 'Which UI?', type: 'single_choice', value: 'modal', label: 'Modal' },
+    { id: 'q2', question: 'Constraints?', type: 'text', value: 'Keep MVP', freetext: 'Keep MVP' }
+  ]
+});
+const data = lib.getPlanAnswers(answersFile);
+const md = lib.formatClarifications(data);
+if (!md.includes('Goal: Goal')) throw new Error('goal missing from clarifications');
+if (!md.includes('**Which UI?** → Modal')) throw new Error('choice missing from clarifications');
+if (!md.includes('**Constraints?** → Keep MVP')) throw new Error('text missing from clarifications');
+fs.writeFileSync('/tmp/jg-plan-ask-smoke-clarifications.md', md);
+NODE
+test -f .jonggrang/plan-answers.json || fail "plan-answers.json missing"
+pass "answers persisted and formatted"
+
+step "Test 5: prompt builders include clarifications"
+node - "$ROOT_DIR" <<'NODE'
+const path = require('path');
+const repo = process.argv[2];
+const lib = require(path.join(repo, 'lib/jonggrang'));
+const clarifications = '- **Which UI?** → Modal';
+const draftPath = '.jonggrang/.drafts/smoke/plan.md';
+const draft = lib.buildDraftPlanPrompt('feature', '.jonggrang/jonggrang.json', process.cwd(), draftPath, { clarifications });
+const revise = lib.buildRevisePlanPrompt('# Plan', 'revise', draftPath, { clarifications });
+const deep1 = lib.buildDeepPlanDiscoveryPrompt('feature', '.jonggrang/jonggrang.json', '.jonggrang/.drafts/smoke/discovery.md', { clarifications });
+const deep3 = lib.buildDeepPlanCondensePrompt('feature', 'discovery', 'analysis', '.jonggrang/jonggrang.json', process.cwd(), draftPath, { clarifications });
+for (const [name, text] of Object.entries({ draft, revise, deep1, deep3 })) {
+  if (!text.includes(clarifications)) throw new Error(`${name} missing clarifications`);
+}
+NODE
+pass "prompt builders inject clarifications"
+
+step "Summary"
+echo "Disposable repo: $TEST_REPO"
+echo "JONGGRANG_HOME: $JONGGRANG_HOME"
+echo "Init log: /tmp/jg-plan-ask-smoke-init.log"
+echo "Clarifications sample: /tmp/jg-plan-ask-smoke-clarifications.md"
+echo
+pass "All deterministic plan ask smoke tests passed"

--- a/test/project-drafts-api.test.js
+++ b/test/project-drafts-api.test.js
@@ -21,6 +21,13 @@ function writeDraft(root, sid, content) {
   fs.writeFileSync(lib.draftFileFor(root, sid), content);
 }
 
+// A draft mid Pass-A: plan-questions.json present, plan.md not yet written.
+function writeQuestions(root, sid, payload) {
+  const dir = lib.draftDirFor(root, sid);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(lib.questionsFileFor(root, sid), JSON.stringify(payload));
+}
+
 async function withServer(root, fn) {
   const project = { id: 'p1', path: root };
   const spawned = [];
@@ -86,6 +93,92 @@ test('project API edits only the requested draft session', async () => {
       assert.equal(fs.readFileSync(lib.draftFileFor(root, 'draft-two'), 'utf8'), '# Two');
       assert.ok(!fs.existsSync(path.join(root, '.jonggrang', 'plan.md')),
         'editing a draft must not recreate the legacy root plan.md');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('plan questions endpoint resolves the pending-questions draft (no plan.md yet)', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jong-project-api-'));
+  try {
+    // Mid Pass-A: questions written into the draft folder, no plan.md.
+    writeQuestions(root, 'draft-pending', {
+      goal_analysis: 'clarify me',
+      questions: [{ id: 'q1', question: 'Which UI?', type: 'text' }],
+    });
+
+    await withServer(root, async (base) => {
+      const res = await fetch(`${base}/api/projects/p1/plan/questions`);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.exists, true);
+      assert.equal(body.sessionId, 'draft-pending');
+      assert.equal(body.goal_analysis, 'clarify me');
+      assert.equal(body.questions.length, 1);
+      assert.ok(!fs.existsSync(path.join(root, '.jonggrang', 'plan-questions.json')),
+        'must not read the legacy root singleton');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('plan questions endpoint honors an explicit ?session override', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jong-project-api-'));
+  try {
+    writeQuestions(root, 'draft-a', { goal_analysis: 'A', questions: [{ id: 'q1', question: 'A?', type: 'text' }] });
+    writeQuestions(root, 'draft-b', { goal_analysis: 'B', questions: [{ id: 'q1', question: 'B?', type: 'text' }] });
+
+    await withServer(root, async (base) => {
+      const res = await fetch(`${base}/api/projects/p1/plan/questions?session=draft-a`);
+      const body = await res.json();
+      assert.equal(body.sessionId, 'draft-a');
+      assert.equal(body.goal_analysis, 'A');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('plan questions endpoint returns exists:false when there are no questions', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jong-project-api-'));
+  try {
+    writeDraft(root, 'draft-plain', '# Plan, no questions');
+    await withServer(root, async (base) => {
+      const res = await fetch(`${base}/api/projects/p1/plan/questions`);
+      const body = await res.json();
+      assert.equal(body.exists, false);
+      assert.deepEqual(body.questions, []);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('plan answers endpoint reuses the pending-questions draft via --session', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jong-project-api-'));
+  try {
+    writeQuestions(root, 'draft-pending', {
+      goal_analysis: 'g', questions: [{ id: 'q1', question: 'Q?', type: 'text' }],
+    });
+
+    await withServer(root, async (base, spawned) => {
+      const res = await fetch(`${base}/api/projects/p1/plan/answers`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: 'build a thing',
+          answers: [{ id: 'q1', value: 'modal' }],
+        }),
+      });
+      assert.equal(res.status, 202);
+      const args = spawned[0];
+      // Reuses the pending draft rather than minting a new session → no orphans.
+      const si = args.indexOf('--session');
+      assert.ok(si !== -1, '--session must be passed');
+      assert.equal(args[si + 1], 'draft-pending');
+      assert.ok(args.includes('--answers-inline'), 'answers still passed inline');
     });
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What

Two-pass planning flow: before generating `plan.md`, the planning agent can **SUBMIT structured clarifying questions** via `jonggrang plan ask` — an agent-facing intake command, the sibling of `task import` — instead of guessing. The user answers (pick an option with its rationale, or type their own), and the agent re-plans from real intent.

Skipped automatically when the request is unambiguous, or with `--no-ask`. Q&A is stored durably (siblings of `plan.md`, not under `.ephemeral`) and **reused on `plan --revise`**.

## Why

The planning agent too often hallucinated assumptions for ambiguous requests. `task import` already proved the agent-facing intake pattern works cleanly for `task`; planning had the same gap. This makes the clarify→answer loop first-class instead of ad-hoc stdout parsing.

## Changes

- **CLI** (`bin/jonggrang.js`)
  - `jonggrang plan ask` subcommand (flag / file / stdin intake — mirrors `task import`)
  - `plan` flags: `--answers <file|->`, `--answers-inline <base64>` (sandbox/web-safe), `--no-ask`
  - Interactive `@clack` collection on TTY (`select` / `multiselect` / `text`, with "type my own" fallback)
  - Headless path: emits a `plan_questions` signal + stops; web/scripts re-run Pass B with answers
  - Honored by standard, `--deep`, and `--revise` paths
- **Lib** (`lib/jonggrang.js`)
  - `normalizePlanQuestions` / `savePlanQuestions` / `getPlanQuestions` / `clearPlanQuestions`
  - `savePlanAnswers` / `getPlanAnswers` / `formatClarifications`
  - `buildPlanQuestionsPrompt` (Pass A) + clarifications injected into `buildDraftPlanPrompt`, `buildRevisePlanPrompt`, `buildDeepPlanDiscoveryPrompt`, `buildDeepPlanCondensePrompt`
  - New paths `questionsFile` / `answersFile` (durable, not under `.ephemeral`)
- **Web** (`apis/projects/`, `client/.../PlanView.vue`)
  - `GET /api/projects/:id/plan/questions`
  - `POST /api/projects/:id/plan/answers` (answers passed inline base64 — works under the Docker sandbox without host/container fs ownership issues)
  - `plan.questions` socket relay from the stdout `plan_questions` signal line
  - `PlanView` clarifying-questions modal form (single_choice / multi_choice / text)
- **Docs** — README, `JONGGRANG.md`, `WORKFLOW.md`, `UI.md`, and the design doc `docs/plans/2026-06-28-plan-ask-clarifying-questions.md`

## Testing

E2E-tested in \`/tmp\` with the \`claude\` backend — headless CLI path (Pass A → answers → Pass B), \`--deep\`, \`--revise\` reuse, and the full web round-trip (POST /plan → \`plan.questions\` socket → POST /plan/answers → plan.md) all pass. The interactive-TTY \`@clack\` collection is validated by contract + API checks (not auto-tested in the sandbox — no reliable PTY); smoke-test manually: \`jonggrang plan "something vague" --tool claude\`.

## Notes

- P6 (orchestrate-mode) intentionally dropped — this is a plan-mode feature.
- No breaking changes to existing `plan` usage; the clarify step is a no-op when the agent decides the request is unambiguous.