### PR TITLE
feat: extend existing plans + per-plan task numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Project entry points: CLI binary, Pi TUI extension, web dashboard server. Hooks 
 |---------|-------------|
 | `jonggrang init` | Interactive wizard — sets up `.jonggrang/`, `AGENTS.md`, hooks, skills |
 | `jonggrang plan "desc"` | AI analyzes the goal, asks clarifying questions if anything is ambiguous, then writes a draft plan to `.jonggrang/.drafts/<session>/plan.md` — human reviews before code |
-| `jonggrang approve` | Decomposes the most-recent draft (or `--session <id>`) into `.jonggrang/.output/features/<id>/jonggrang-tasks.json` |
+| `jonggrang plan --append <id> "desc"` | Extend an **existing approved plan**: generate a delta draft for the additional scope only; on `approve` the new tasks are appended to that feature (numbering continues, completed tasks untouched) |
+| `jonggrang approve` | Decomposes the most-recent draft (or `--session <id>`) into `.jonggrang/.output/features/<id>/jonggrang-tasks.json`. With `--feature <id>` (or a draft carrying `append_to:`) it decomposes into an **existing** feature instead of minting a new one |
 | `jonggrang work` | Executes task queue with fresh context per task |
 | `jonggrang status` | Shows task board |
 | `jonggrang review` | Comprehensive code review → markdown report |
@@ -90,7 +91,10 @@ jonggrang plan "feature" --src docs/brd.md  # Reference source document for the 
 jonggrang plan "feature" --deep      # 3-phase deep analysis (risks, alternatives)
 jonggrang plan "feature" --base develop  # Cut the worktree from a chosen branch (fetched fresh from origin)
 jonggrang plan "feature" --no-ask    # Skip the agent's clarifying-questions step
+jonggrang plan --append feat-abc123 "also add rate limiting"  # Extend an approved plan (tasks appended, numbering continues)
+jonggrang plan --append feat-abc123 "..." --deep  # Deep analysis on the added scope (Affected Areas / Risks)
 jonggrang approve --session draft-abc123  # Approve a specific pending draft
+jonggrang approve --feature feat-abc123    # Decompose the draft into an EXISTING feature (append)
 jonggrang work --mode autonomous     # Override autonomy mode
 jonggrang work --task task-003       # Execute specific task only
 jonggrang work --feature feat-abc123 # Target a specific approved feature (multi-feature projects)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ jonggrang work --feature feat-abc123 # Target a specific approved feature (multi
 {
   "tool": "opencode",          // opencode | claude | jonggrang | codex
   "mode": { "autonomy": "balanced" },
-  "work": { "max_iterations": 10 }
+  "work": { "max_iterations": 0 }   // 0 = unlimited (run until all tasks complete)
 }
 ```
 

--- a/apis/projects/orchestration-run.js
+++ b/apis/projects/orchestration-run.js
@@ -481,14 +481,14 @@ module.exports = function(deps) {
         if (group.logTail.length > LOG_TAIL_MAX) group.logTail.shift();
     }
 
-    function applySignal(project, signal, groupFeatureId) {
+    function applySignal(project, signal, group) {
         if (signal.type !== 'task_status' || !signal.taskId) return;
         try {
             // Scope resolution to the emitting group's feature. Per-feature numbering
             // means a bare id (task-001) recurs across features, so without this hint
             // findTaskFeature could resolve to the wrong feature (active/first-match)
             // and mark done a task in a different plan.
-            const featureId = lib.findTaskFeature(project.path, signal.taskId, { featureId: groupFeatureId });
+            const featureId = lib.findTaskFeature(project.path, signal.taskId, { featureId: group?.featureId });
             if (!featureId) {
                 console.error('orchestration applySignal error: task feature not found', signal.taskId);
                 return;
@@ -496,7 +496,16 @@ module.exports = function(deps) {
             const tasksFile = lib.tasksFileFor(project.path, featureId);
             if (signal.status === 'completed') lib.markTaskDone(tasksFile, signal.taskId);
             else lib.updateTaskStatus(tasksFile, signal.taskId, signal.status);
+            // The host write succeeded, so applySignal is the LIVE writer of main
+            // tasks.json for this group. Tell the periodic mirror to leave tasks.json
+            // alone — otherwise it copies the worktree's stale copy (the worker emits
+            // signals but never updates its own tasks.json mid-task) back over these
+            // updates, reverting in_progress/completed → pending during the run.
+            if (group) group._tasksLiveWritten = true;
         } catch (err) {
+            // Host write failed (e.g. sandbox-Linux root-owned main → EACCES). Leave
+            // _tasksLiveWritten unset so syncTasks mirrors the worktree copy as the
+            // fallback path. Single writer either way — never both at once.
             console.error('orchestration applySignal error:', err.message);
         }
     }
@@ -553,6 +562,11 @@ module.exports = function(deps) {
     // applySignal write fails under sandbox (main tasks.json is root-owned by the
     // in-container approve → host EACCES), so mirror the file via the container.
     function syncTasks(project, ctx, group) {
+        // If applySignal is successfully writing main tasks.json (host / macOS bind
+        // mount), it is the single live writer — mirroring the worktree's stale copy
+        // here would revert its in_progress/completed updates back to pending. Only
+        // mirror when applySignal's host write can't land (sandbox-Linux root-owned).
+        if (group._tasksLiveWritten) return;
         mirrorFromWorktree(project, ctx, group,
             path.join('.jonggrang', '.output', 'features', group.featureId, 'jonggrang-tasks.json'), 'syncTasks');
     }
@@ -580,7 +594,7 @@ module.exports = function(deps) {
                     try { signal = JSON.parse(trimmed); } catch { /* not JSON */ }
                 }
                 if (signal && signal.type === 'task_status') {
-                    applySignal(project, signal, group.featureId);
+                    applySignal(project, signal, group);
                     continue;
                 }
                 pushLog(group, trimmed);

--- a/apis/projects/orchestration-run.js
+++ b/apis/projects/orchestration-run.js
@@ -435,8 +435,11 @@ module.exports = function(deps) {
     // pipeline (`--resume`) instead of the default all-group-tasks run.
     function spawnGroupWorker(project, ctx, group) {
         const secretVars = webState.getProjectSecretVars(project.id);
+        // Pass the group's featureId explicitly so the worker resolves its feature
+        // deterministically instead of guessing from a bare task id (per-feature
+        // numbering makes task-001 recur across features).
         const workerArgs = group.workerArgs
-            || ['work', '--worktree', '--group-tasks', group.taskIds.join(','), '--branch', group.branch];
+            || ['work', '--worktree', '--group-tasks', group.taskIds.join(','), '--branch', group.branch, '--feature', group.featureId];
 
         if (ctx.mode === 'container') {
             const envFlags = [];
@@ -478,10 +481,14 @@ module.exports = function(deps) {
         if (group.logTail.length > LOG_TAIL_MAX) group.logTail.shift();
     }
 
-    function applySignal(project, signal) {
+    function applySignal(project, signal, groupFeatureId) {
         if (signal.type !== 'task_status' || !signal.taskId) return;
         try {
-            const featureId = lib.findTaskFeature(project.path, signal.taskId);
+            // Scope resolution to the emitting group's feature. Per-feature numbering
+            // means a bare id (task-001) recurs across features, so without this hint
+            // findTaskFeature could resolve to the wrong feature (active/first-match)
+            // and mark done a task in a different plan.
+            const featureId = lib.findTaskFeature(project.path, signal.taskId, { featureId: groupFeatureId });
             if (!featureId) {
                 console.error('orchestration applySignal error: task feature not found', signal.taskId);
                 return;
@@ -573,7 +580,7 @@ module.exports = function(deps) {
                     try { signal = JSON.parse(trimmed); } catch { /* not JSON */ }
                 }
                 if (signal && signal.type === 'task_status') {
-                    applySignal(project, signal);
+                    applySignal(project, signal, group.featureId);
                     continue;
                 }
                 pushLog(group, trimmed);

--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -294,6 +294,48 @@ module.exports = function(deps) {
         res.status(202).json({ job_id: project.id });
     });
 
+    // Extend an EXISTING approved plan with additional scope. Generates an
+    // extension draft (frontmatter `append_to: <featureId>`); the existing
+    // `POST /:id/approve` then decomposes it as ADDITIONAL tasks appended to the
+    // feature (numbering continues, completed tasks preserved).
+    router.post('/:id/plans/:featureId/extend', (req, res) => {
+        const project = webState.getProject(req.params.id);
+        if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
+
+        const featureId = req.params.featureId;
+        if (!lib.isSafeBranchName(featureId)) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'invalid featureId' } });
+        }
+        const featurePlan = path.join(project.path, '.jonggrang', '.output', 'features', featureId, 'plan.md');
+        if (!fs.existsSync(featurePlan)) {
+            return res.status(404).json({ error: { code: 'FEATURE_NOT_FOUND', message: `Feature "${featureId}" has no approved plan.` } });
+        }
+
+        const { description, tool, model, effort, deep } = req.body || {};
+        if (!description) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'description required' } });
+        if (tool && !VALID_PLAN_TOOL.includes(tool)) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: `tool must be one of: ${VALID_PLAN_TOOL.join(', ')}` } });
+        }
+        if (model && typeof model === 'string' && model.length > MAX_STRING_LEN) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'model must be under 100 characters' } });
+        }
+        if (effort) {
+            const allowed = tool ? (STATIC_EFFORTS[tool] || []) : ALL_EFFORTS;
+            if (!allowed.includes(effort)) {
+                const expected = allowed.length ? allowed.join(', ') : '(this backend takes no effort level)';
+                return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: `effort must be one of: ${expected}` } });
+            }
+        }
+
+        const args = ['plan', '--append', featureId, description, ...(deep ? ['--deep'] : [])];
+        if (tool)   args.push('--tool', tool);
+        if (model)  args.push('--model', model);
+        if (effort) args.push('--effort', effort);
+        const child = spawnForProject(project, args);
+        wireProjectProcess(project.id, child, 'plan-extend');
+        res.status(202).json({ job_id: project.id });
+    });
+
     router.put('/:id/plan', (req, res) => {
         const project = webState.getProject(req.params.id);
         if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -816,6 +816,16 @@ async function cmdWork(descriptionParts = []) {
     dryRun: DRY_RUN,
   });
 
+  // Boundary guard: when the loop exhausts max_iterations at the exact moment the
+  // last task completes, it returns reason:'max_iterations' (completed:false) even
+  // though every task is actually done. Treat that as done so the MANIFEST gets
+  // finalized (phase 8 + post-work gates → status:completed) in this run, instead
+  // of staying 'running' until the user invokes `jonggrang work` again.
+  if (!result.completed && lib.countTotal(WORK_TASKS_FILE) > 0 &&
+      lib.countCompleted(WORK_TASKS_FILE) === lib.countTotal(WORK_TASKS_FILE)) {
+    result.completed = true;
+  }
+
   if (result.completed) {
     // Complete phase 8 (Implement) now that all tasks are done
     if (workManifestPath && workManifest?.active_phases?.includes(8)) {

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -995,13 +995,19 @@ async function cmdReview() {
 
 /** Parse key: value pairs from YAML frontmatter of a plan.md */
 function parsePlanFrontmatter(content) {
-  const get = (key) => { const m = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm')); return m ? m[1].trim() : ''; };
+  // Strip surrounding matched quotes — platform-written scalars (base:, append_to:)
+  // are quoted so YAML-keyword-like values survive; the agent writes them bare.
+  const get = (key) => {
+    const m = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return m ? m[1].trim().replace(/^(["'])([\s\S]*)\1$/, '$2') : '';
+  };
   return {
     feature:     get('feature'),
     branch:      get('branch'),
     work_type:   get('work_type'),
     description: get('description'),
     created_at:  get('created_at'),
+    append_to:   get('append_to'),
   };
 }
 
@@ -1103,6 +1109,7 @@ async function cmdPlan(args, opts = {}) {
   let reviseMode = false;
   let baseBranch = '';
   let sessionId = '';
+  let appendTo = '';   // --append <featureId> : extend an existing approved plan
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -1111,6 +1118,7 @@ async function cmdPlan(args, opts = {}) {
     else if (arg === '--revise') reviseMode = true;
     else if (arg === '--base') baseBranch = args[++i] || '';
     else if (arg === '--session') sessionId = args[++i] || '';
+    else if (arg === '--append') appendTo = args[++i] || '';
     else if (!arg.startsWith('--')) description = arg;
   }
 
@@ -1120,6 +1128,25 @@ async function cmdPlan(args, opts = {}) {
   if (baseBranch && !lib.isSafeBranchName(baseBranch)) {
     logError(`Invalid --base "${baseBranch}": must be a plain branch name (letters, digits, . _ / -).`);
     process.exit(1);
+  }
+
+  // --append <featureId>: extend an existing approved plan. Validate the target
+  // exists before spending a generation; extension plans use standard (non-deep)
+  // generation and require a scope description.
+  let appendPlanPath = '';
+  if (appendTo) {
+    if (!lib.isSafeBranchName(appendTo)) {
+      logError(`Invalid --append feature id "${appendTo}".`);
+      process.exit(1);
+    }
+    appendPlanPath = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', appendTo, 'plan.md');
+    if (!fs.existsSync(appendPlanPath)) {
+      logError(`--append: feature "${appendTo}" not found (no approved plan at ${appendPlanPath}).`);
+      logInfo('Use "jonggrang status" to list features, or run "jonggrang plan <desc>" for a new one.');
+      process.exit(1);
+    }
+    // --append + --deep is supported: a deep discovery+analysis pre-pass enriches
+    // the extension plan (Affected Areas / Risks / Alternatives) before synthesis.
   }
 
   if (!await ensureInit()) return;
@@ -1225,7 +1252,54 @@ async function cmdPlan(args, opts = {}) {
     logInfo(`${existingDrafts.length} pending draft(s) already exist. This creates a new session (${sid}); 'jonggrang approve' defaults to the most recent, or use 'jonggrang approve --session <id>'.`);
   }
 
-  if (deepMode) {
+  if (appendTo) {
+    // ── Append mode: extend an existing approved plan ──────────
+    logHeader(deepMode ? 'JONGGRANG Plan — Extend Existing Plan (Deep)' : 'JONGGRANG Plan — Extend Existing Plan');
+    logInfo(`Feature:   ${appendTo}`);
+    logInfo(`Tool:      ${TOOL}`);
+    logInfo(`Session:   ${sid}`);
+    feedback.clearFeedbackState(PROJECT_ROOT);
+
+    const existingPlan = fs.readFileSync(appendPlanPath, 'utf8');
+    const existingTasks = (lib.getAllTasks(PROJECT_ROOT)?.tasks || []).filter(t => t.feature_id === appendTo);
+
+    // Deep pre-pass: discovery + analysis on the ADDITIONAL scope enrich the
+    // extension plan. Best-effort — if either step is skipped, synthesis still runs.
+    let deepCtx = null;
+    if (deepMode) {
+      const discoveryFile = path.join(draftDir, 'deep-plan-discovery.md');
+      const analysisFile = path.join(draftDir, 'deep-plan-analysis.md');
+      logInfo(`${BOLD}[1/3]${NC} Codebase discovery (for the additional scope)...`);
+      await lib.runAgent(lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile), TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+      if (lib.fileExists(discoveryFile)) {
+        const discoveryContent = fs.readFileSync(discoveryFile, 'utf8');
+        logInfo(`${BOLD}[2/3]${NC} Complexity analysis & brainstorm...`);
+        await lib.runAgent(lib.buildDeepPlanAnalysisPrompt(description, discoveryContent, analysisFile), TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+        deepCtx = { discovery: discoveryContent, analysis: lib.fileExists(analysisFile) ? fs.readFileSync(analysisFile, 'utf8') : '' };
+      } else {
+        logWarn('Discovery step produced no output — falling back to standard extension synthesis.');
+      }
+      logInfo(`${BOLD}[3/3]${NC} Synthesizing enriched extension plan...`);
+    } else {
+      logInfo('Generating extension plan...');
+    }
+
+    const prompt = lib.buildAppendPlanPrompt(description, existingPlan, existingTasks, CONFIG_FILE, PROJECT_ROOT, draftFile, appendTo, { deep: deepCtx });
+    await lib.runAgent(prompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+    const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
+    if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
+    if (_v === 'missing') { logError('Agent did not write the plan. Retry.'); process.exit(1); }
+    // Clean up deep intermediates (plan.md stays in the draft folder).
+    if (deepMode) {
+      try { fs.unlinkSync(path.join(draftDir, 'deep-plan-discovery.md')); } catch {}
+      try { fs.unlinkSync(path.join(draftDir, 'deep-plan-analysis.md')); } catch {}
+    }
+    // Stamp append_to deterministically (belt + suspenders vs the prompt) so
+    // approve routes this draft to the existing feature.
+    if (!lib.setPlanFrontmatterField(draftFile, 'append_to', appendTo)) {
+      logWarn(`Could not stamp append_to into the draft frontmatter — approve may treat this as a new feature.`);
+    }
+  } else if (deepMode) {
     // ── Deep mode: 3 sequential AI phases ──────────────────────
     // Discovery + analysis intermediates live in the draft session folder;
     // only plan.md promotes to features/<id>/ at approve.
@@ -1429,9 +1503,11 @@ async function showPlanOptions(isInteractiveTTY, autoApprove, opts, sessionId) {
 async function cmdApprove(args, opts = {}) {
   // Resolve the draft to approve: --session override, else most-recent draft.
   let sessionId = opts.session || '';
-  // Allow --session as a CLI flag too
+  let featureFlag = opts.feature || '';   // --feature <id>: decompose into an existing feature (append)
+  // Allow --session / --feature as CLI flags too
   for (let i = 0; i < (args || []).length; i++) {
     if (args[i] === '--session') sessionId = args[++i] || '';
+    else if (args[i] === '--feature') featureFlag = args[++i] || '';
   }
   if (!sessionId) sessionId = lib.resolveActiveDraft(PROJECT_ROOT);
   if (!sessionId) {
@@ -1459,68 +1535,111 @@ async function cmdApprove(args, opts = {}) {
 
   // Parse YAML frontmatter fields
   const fm = parsePlanFrontmatter(planContent);
-  const featureName = fm.feature || 'work-session';
-  const workType    = fm.work_type || 'MEDIUM';
 
-  // Generate featureId BEFORE running the agent so we can create the feature
-  // directory + MANIFEST first. The decompose agent writes tasks via
-  // `jonggrang task import --feature <id>`, which needs the feature folder to
-  // exist (resolveActiveFeature won't find this feature until its MANIFEST exists).
-  const featureId = orchestration.generateFeatureId(featureName);
+  // Append target: explicit --feature wins, else the draft's `append_to` (written
+  // by `plan --append`). When set, we decompose ADDITIONAL tasks into an existing
+  // feature (numbering continues, completed tasks untouched) instead of minting one.
+  const appendTo = featureFlag || fm.append_to || '';
+  const isAppend = !!appendTo;
 
-  // Create the feature output directory + MANIFEST up front (before decompose).
-  // The plan.md is archived after the agent succeeds; only the folder + MANIFEST
-  // are created now so `task import --feature` has a home to write to.
-  const outputDir = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', featureId);
-  fs.mkdirSync(outputDir, { recursive: true });
-  const manifestPath = path.join(outputDir, 'MANIFEST.yaml');
-  if (!fs.existsSync(manifestPath)) {
-    orchestration.createManifest(PROJECT_ROOT, featureId, featureName, workType);
+  let featureId, featureName, workType;
+  if (isAppend) {
+    featureId = appendTo;
   }
 
-  // Snapshot existing task IDs globally (across all features) so we can detect
-  // which tasks the agent created. With per-feature files there are no orphan
-  // `feature_id: null` tasks to purge — the feature file starts empty.
+  if (isAppend) {
+    const featurePlanPath = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', featureId, 'plan.md');
+    if (!fs.existsSync(featurePlanPath)) {
+      logError(`Cannot append: feature "${featureId}" not found (no plan at ${featurePlanPath}).`);
+      process.exit(1);
+    }
+    const existingFm = parsePlanFrontmatter(fs.readFileSync(featurePlanPath, 'utf8'));
+    featureName = existingFm.feature || featureId;
+    workType    = existingFm.work_type || fm.work_type || 'MEDIUM';
+  } else {
+    featureName = fm.feature || 'work-session';
+    workType    = fm.work_type || 'MEDIUM';
+    // Generate featureId BEFORE running the agent so we can create the feature
+    // directory + MANIFEST first (the decompose agent writes via `task import --feature`).
+    featureId = orchestration.generateFeatureId(featureName);
+  }
+
+  const featureDir = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', featureId);
+  const manifestPath = path.join(featureDir, 'MANIFEST.yaml');
+  if (!isAppend) {
+    fs.mkdirSync(featureDir, { recursive: true });
+    if (!fs.existsSync(manifestPath)) {
+      orchestration.createManifest(PROJECT_ROOT, featureId, featureName, workType);
+    }
+  }
+
+  // Snapshot existing task IDs IN THIS FEATURE so we can detect what the agent
+  // added (append continues this feature's own numbering; a new feature is empty).
   const existingTaskIds = new Set(
-    (lib.getAllTasks(PROJECT_ROOT)?.tasks || []).map(t => t.id)
+    (lib.getAllTasks(PROJECT_ROOT)?.tasks || [])
+      .filter(t => t.feature_id === featureId)
+      .map(t => t.id)
   );
 
   logInfo(`Feature:    ${featureName}`);
-  logInfo(`Feature ID: ${featureId}`);
+  logInfo(`Feature ID: ${featureId}${isAppend ? ' (append)' : ''}`);
   logInfo(`Work type:  ${workType}`);
-  logInfo('Decomposing plan into tasks...');
+  logInfo(isAppend ? 'Decomposing additional tasks into the existing plan...' : 'Decomposing plan into tasks...');
 
   const prompt = lib.buildTasksFromPlanPrompt(planContent, CONFIG_FILE, PROJECT_ROOT, featureId, SKILLS_DIR);
   await lib.runAgent(prompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
 
-  // No feature_id stamping needed — the agent wrote via `task import --feature`,
-  // which stamps feature_id and enforces global ID uniqueness in the lib layer.
-
-  // Only archive if the agent actually created new tasks
-  const newTasks = (lib.getAllTasks(PROJECT_ROOT)?.tasks || []).filter(t => !existingTaskIds.has(t.id));
+  // New tasks = tasks in THIS feature that weren't there before the decompose.
+  const newTasks = (lib.getAllTasks(PROJECT_ROOT)?.tasks || [])
+    .filter(t => t.feature_id === featureId && !existingTaskIds.has(t.id));
   if (newTasks.length === 0) {
     logError('Agent did not create any tasks. plan.md has been preserved — re-run "jonggrang approve" after fixing the issue.');
     process.exit(1);
   }
 
-  // Promote the draft plan into the feature folder (move, not copy). The draft
-  // session folder is discarded after — only plan.md persists in features/<id>/.
-  fs.copyFileSync(draftFile, path.join(outputDir, 'plan.md'));
+  const featurePlanPath = path.join(featureDir, 'plan.md');
+  if (isAppend) {
+    // Merge the extension into the existing plan.md as a dated section (single
+    // source of truth) — never overwrite the original plan or its history.
+    const stamp = new Date().toISOString();
+    const deltaBody = planContent.replace(/^---\n[\s\S]*?\n---\n?/, '').trim();
+    fs.appendFileSync(featurePlanPath, `\n\n<!-- jonggrang:appended ${stamp} -->\n## Appended ${stamp}\n\n${deltaBody}\n`);
+  } else {
+    // Promote the draft plan into the feature folder.
+    fs.copyFileSync(draftFile, featurePlanPath);
+  }
   try { fs.rmSync(lib.draftDirFor(PROJECT_ROOT, sessionId), { recursive: true, force: true }); } catch {}
 
-  // Mark all planning phases as done — they were completed by plan+approve.
-  // (MANIFEST was created above; here we just complete phases 1-7.)
+  // MANIFEST: new feature → complete planning phases 1-7. Append → planning is
+  // already done; re-open the EXECUTION phases (8 Implement + post-work gates) so
+  // `work` re-runs implementation for the newly appended tasks instead of seeing
+  // phase 8 "completed" and skipping straight to post-work. Planning phases stay done.
   if (fs.existsSync(manifestPath)) {
     const manifest = orchestration.readManifest(manifestPath);
     if (manifest) {
-      [1, 2, 3, 4, 5, 6, 7].forEach(n => {
-        if (manifest.active_phases.includes(n))
-          orchestration.completePhase(manifestPath, n, { source: 'approve' });
-      });
+      if (!isAppend) {
+        [1, 2, 3, 4, 5, 6, 7].forEach(n => {
+          if (manifest.active_phases.includes(n))
+            orchestration.completePhase(manifestPath, n, { source: 'approve' });
+        });
+      } else {
+        let changed = false;
+        for (const n of (manifest.active_phases || [])) {
+          if (n >= 8 && manifest.phases?.[n]?.status === 'completed') {
+            manifest.phases[n].status = 'pending';
+            changed = true;
+          }
+        }
+        if (changed || manifest.status === 'completed') {
+          manifest.status = 'in_progress';
+          manifest.updated_at = new Date().toISOString();
+          orchestration.writeManifest(manifestPath, manifest);
+        }
+      }
     }
   }
 
-  logSuccess('Plan approved.');
+  logSuccess(isAppend ? `Appended ${newTasks.length} task(s) to ${featureId}.` : 'Plan approved.');
   logInfo(`Feature ID:    ${featureId}`);
   logInfo(`Plan archived: .jonggrang/.output/features/${featureId}/plan.md`);
 
@@ -3197,7 +3316,14 @@ function resolveTasksFile(flags, taskId) {
 }
 function resolveFeatureId(flags, taskId) {
   let fid = flags.feature;
-  if (!fid && taskId) fid = lib.findTaskFeature(PROJECT_ROOT, taskId);
+  if (!fid && taskId) {
+    try {
+      fid = lib.findTaskFeature(PROJECT_ROOT, taskId, { featureId: flags.feature, throwOnAmbiguous: true });
+    } catch (e) {
+      if (e.code === 'AMBIGUOUS_TASK_ID') { logError(e.message); process.exit(1); }
+      throw e;
+    }
+  }
   if (!fid) fid = lib.resolveActiveFeature(PROJECT_ROOT);
   if (!fid) throw new Error('No active feature found. Run `jonggrang plan` + `jonggrang approve` first, or pass --feature <id>.');
   return fid;
@@ -3796,8 +3922,10 @@ Commands:
   init                    Setup project (interactive or with flags)
   plan <description>      Phase 1 — generate .jonggrang/.drafts/<session>/plan.md for review
   plan <description> --yes  Plan + auto-approve + decompose to tasks in one shot
+  plan --append <id> "x"  Extend an existing approved plan; appends tasks (numbering continues)
   approve                 Phase 2 — decompose the most-recent draft into tasks
   approve --session <id>  Phase 2 — decompose a specific draft session into tasks
+  approve --feature <id>  Phase 2 — decompose the draft into an EXISTING feature (append)
   work [description]      Execute tasks — with description runs plan → approve → execute
   work --resume           Resume incomplete pipeline from last phase
   plan --update <desc>    Update existing plan (preserves completed tasks)

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -676,11 +676,14 @@ async function cmdWork(descriptionParts = []) {
     // this worktree. Tracking the manifest here is what lets the post-work
     // phases (Simplify → … → Complete) run in worktree mode instead of the
     // pipeline stalling at Implement.
-    const firstGroupId = GROUP_TASK_IDS.find(id => lib.findTaskFeature(PROJECT_ROOT, id));
-    const fid = firstGroupId ? lib.findTaskFeature(PROJECT_ROOT, firstGroupId) : null;
+    // Prefer the featureId the pipeline passed via --feature (deterministic).
+    // Fall back to resolving from a group task id — scoped to WORK_FEATURE_ID
+    // when present so per-feature task-001 collisions can't pick the wrong plan.
+    const fid = WORK_FEATURE_ID
+      || GROUP_TASK_IDS.map(id => lib.findTaskFeature(PROJECT_ROOT, id, { featureId: WORK_FEATURE_ID })).find(Boolean)
+      || null;
     if (fid) {
       WORK_TASKS_FILE = lib.tasksFileFor(PROJECT_ROOT, fid);
-      const firstTask = lib.getTask(WORK_TASKS_FILE, firstGroupId);
       const mPath = orchestration.getManifestPath(PROJECT_ROOT, fid);
       const m = orchestration.readManifest(mPath);
       if (m) {
@@ -1838,9 +1841,6 @@ async function cmdApprove(args, opts = {}) {
   let featureId, featureName, workType;
   if (isAppend) {
     featureId = appendTo;
-  }
-
-  if (isAppend) {
     const featurePlanPath = path.join(PROJECT_ROOT, '.jonggrang', '.output', 'features', featureId, 'plan.md');
     if (!fs.existsSync(featurePlanPath)) {
       logError(`Cannot append: feature "${featureId}" not found (no plan at ${featurePlanPath}).`);

--- a/client/src/components/plan/PlanView.vue
+++ b/client/src/components/plan/PlanView.vue
@@ -294,13 +294,12 @@
               </RouterLink>
             </div>
           </div>
-          <div v-if="showExtendForm" class="plan-extend-form" style="display:flex; flex-direction:column; gap:8px; padding:10px 12px; border-bottom:1px solid var(--jg-border);">
-            <label style="font-size:12px; color:var(--jg-text-dim);">Additional scope to append (numbering continues from this plan's tasks)</label>
+          <div v-if="showExtendForm" class="plan-extend-form">
+            <label class="plan-extend-label">Additional scope to append (numbering continues from this plan's tasks)</label>
             <textarea v-model="extendDescription" rows="3" class="plan-extend-input"
-              placeholder="e.g. also add rate limiting to the login endpoint"
-              style="width:100%; padding:6px 8px; border-radius:6px; background:var(--jg-bg); border:1px solid var(--jg-border); color:var(--jg-text); font-family:var(--font-mono); font-size:12px;" />
-            <div style="display:flex; gap:8px; align-items:center; justify-content:flex-end;">
-              <label style="display:flex; align-items:center; gap:6px; margin-right:auto; font-size:12px; color:var(--jg-text-dim); cursor:pointer;">
+              placeholder="e.g. also add rate limiting to the login endpoint" />
+            <div class="plan-extend-actions">
+              <label class="plan-extend-deep">
                 <input type="checkbox" v-model="extendDeep" /> Deep analysis (discovery + risks for the added scope)
               </label>
               <Button severity="secondary" @click="showExtendForm = false">Cancel</Button>
@@ -1065,6 +1064,17 @@ onUnmounted(() => {
 }
 .btn-new-plan:hover { background: color-mix(in oklch, var(--jg-green) 12%, transparent); }
 .plan-list-items { flex: 1; overflow-y: auto; padding: 4px; }
+
+/* Extend-this-plan (append) form */
+.plan-extend-form { display: flex; flex-direction: column; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--jg-border); }
+.plan-extend-label { font-size: 12px; color: var(--jg-text-dim); }
+.plan-extend-input {
+  width: 100%; padding: 6px 8px; border-radius: 6px;
+  background: var(--jg-bg); border: 1px solid var(--jg-border); color: var(--jg-text);
+  font-family: var(--font-mono); font-size: 12px;
+}
+.plan-extend-actions { display: flex; gap: 8px; align-items: center; justify-content: flex-end; }
+.plan-extend-deep { display: flex; align-items: center; gap: 6px; margin-right: auto; font-size: 12px; color: var(--jg-text-dim); cursor: pointer; }
 
 .plan-item {
   padding: 8px 10px; cursor: pointer; border: 1px solid transparent;

--- a/client/src/components/plan/PlanView.vue
+++ b/client/src/components/plan/PlanView.vue
@@ -274,15 +274,31 @@
           <div class="plan-viewer-header">
             <span class="plan-viewer-title">{{ selectedPlan.title }}</span>
             <span class="plan-badge" :class="`plan-badge--${selectedPlan.status}`">{{ selectedPlan.status }}</span>
-            <RouterLink
-              v-if="selectedPlan.status !== 'draft'"
-              :to="`/projects/${projectId}/plans/${selectedPlan.id}/pipeline`"
-              style="margin-left:auto"
-            >
-              <Button>
-                Work Mode <i class="pi pi-arrow-right" />
+            <div v-if="selectedPlan.status !== 'draft'" style="margin-left:auto; display:flex; gap:8px;">
+              <Button severity="secondary" :disabled="generating" @click="toggleExtendForm">
+                <i class="pi pi-plus" /> Extend this plan
               </Button>
-            </RouterLink>
+              <RouterLink :to="`/projects/${projectId}/plans/${selectedPlan.id}/pipeline`">
+                <Button>
+                  Work Mode <i class="pi pi-arrow-right" />
+                </Button>
+              </RouterLink>
+            </div>
+          </div>
+          <div v-if="showExtendForm" class="plan-extend-form" style="display:flex; flex-direction:column; gap:8px; padding:10px 12px; border-bottom:1px solid var(--jg-border);">
+            <label style="font-size:12px; color:var(--jg-text-dim);">Additional scope to append (numbering continues from this plan's tasks)</label>
+            <textarea v-model="extendDescription" rows="3" class="plan-extend-input"
+              placeholder="e.g. also add rate limiting to the login endpoint"
+              style="width:100%; padding:6px 8px; border-radius:6px; background:var(--jg-bg); border:1px solid var(--jg-border); color:var(--jg-text); font-family:var(--font-mono); font-size:12px;" />
+            <div style="display:flex; gap:8px; align-items:center; justify-content:flex-end;">
+              <label style="display:flex; align-items:center; gap:6px; margin-right:auto; font-size:12px; color:var(--jg-text-dim); cursor:pointer;">
+                <input type="checkbox" v-model="extendDeep" /> Deep analysis (discovery + risks for the added scope)
+              </label>
+              <Button severity="secondary" @click="showExtendForm = false">Cancel</Button>
+              <Button :disabled="!extendDescription.trim() || generating" @click="extendPlan">
+                <i class="pi pi-sparkles" /> Generate Extension
+              </Button>
+            </div>
           </div>
           <div class="plan-viewer-body">
             <div class="md-content" v-html="renderedContent" />
@@ -404,6 +420,11 @@ const approving = ref(false);
 const revising = ref(false);
 const genLog = ref('');
 const genError = ref('');
+
+// Extend-an-existing-plan (append) state
+const showExtendForm = ref(false);
+const extendDescription = ref('');
+const extendDeep = ref(false);
 
 // xterm for progress log
 const genLogStr = computed(() => genLog.value);
@@ -612,6 +633,40 @@ async function loadProjectTool() {
       if (tool) selectedTool.value = tool;
     }
   } catch {}
+}
+
+function toggleExtendForm() {
+  showExtendForm.value = !showExtendForm.value;
+  if (showExtendForm.value) { extendDescription.value = ''; extendDeep.value = false; }
+}
+
+// Extend the selected (approved/done) plan: generate an extension draft, which
+// the user then approves — the appended tasks continue this plan's numbering.
+async function extendPlan() {
+  if (!extendDescription.value.trim() || generating.value || !selectedPlan.value) return;
+  const featureId = selectedPlan.value.feature_id || selectedPlan.value.id;
+  genError.value = '';
+  genLog.value = '';
+  generating.value = true;
+  showExtendForm.value = false;
+  try {
+    const body = { description: extendDescription.value, deep: extendDeep.value };
+    if (selectedTool.value)   body.tool   = selectedTool.value;
+    if (selectedModel.value)  body.model  = selectedModel.value;
+    if (selectedEffort.value) body.effort = selectedEffort.value;
+    const res = await fetch(`/api/projects/${projectId.value}/plans/${featureId}/extend`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error?.message || 'Failed');
+    }
+  } catch (e) {
+    genError.value = e.message;
+    generating.value = false;
+  }
 }
 
 async function generatePlan() {

--- a/client/src/components/plan/PlanView.vue
+++ b/client/src/components/plan/PlanView.vue
@@ -58,14 +58,6 @@
           <span class="plan-list-title">Plans</span>
           <div class="plan-list-actions">
             <button
-              class="btn-rebase"
-              :disabled="rebasing || !base.has_remote"
-              :title="base.has_remote ? `Pull origin/${base.branch || 'main'} into local (no commit)` : 'No remote configured'"
-              @click="rebaseBase"
-            >
-              <i :class="rebasing ? 'pi pi-spin pi-spinner' : 'pi pi-cloud-download'" /> Rebase
-            </button>
-            <button
               v-if="canAddNewPlan && !showNewPlanForm && !generating"
               class="btn-new-plan"
               @click="openNewPlanForm"
@@ -569,7 +561,6 @@ const base = reactive({ branch: 'main', has_remote: false, dirty: false });
 const pushingBase = ref(false);
 const baseNotice = ref('');
 const baseError = ref('');
-const rebasing = ref(false);
 
 async function loadBase() {
   try {
@@ -604,25 +595,6 @@ async function pushBase() {
     baseError.value = e.message;
   } finally {
     pushingBase.value = false;
-  }
-}
-
-// Pull remote base branch into local (fetch + rebase, no commit).
-async function rebaseBase() {
-  rebasing.value = true; baseNotice.value = ''; baseError.value = '';
-  try {
-    const res = await fetch(`/api/projects/${projectId.value}/base/pull`, { method: 'POST' });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error?.message || 'Rebase failed');
-    baseNotice.value = data.updated
-      ? `Rebased local ${data.branch} onto origin/${data.branch}`
-      : `${data.branch} already up to date with origin`;
-    loadBase();
-    loadPlans();
-  } catch (e) {
-    baseError.value = e.message;
-  } finally {
-    rebasing.value = false;
   }
 }
 
@@ -1092,15 +1064,6 @@ onUnmounted(() => {
   padding: 2px 8px; cursor: pointer; transition: background 0.12s;
 }
 .btn-new-plan:hover { background: color-mix(in oklch, var(--jg-green) 12%, transparent); }
-.btn-rebase {
-  display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
-  color: var(--jg-text-muted); background: transparent; border: 1px solid var(--jg-border);
-  padding: 2px 8px; cursor: pointer; transition: all 0.12s;
-}
-.btn-rebase:hover:not(:disabled) { color: var(--jg-cyan); border-color: var(--jg-cyan); }
-.btn-rebase:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-rebase .pi { font-size: 10px; }
 .plan-list-items { flex: 1; overflow-y: auto; padding: 4px; }
 
 .plan-item {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -88,7 +88,7 @@ Optionally override `model` and `effort` for a specific backend. These take prec
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `max_iterations` | number | 10 | Max loop iterations per session |
+| `max_iterations` | number | 0 | Max loop iterations per session (`0` = unlimited — run until all tasks complete) |
 | `retry_limit` | number | 2 | Retries before skipping failed task |
 | `kill_after_fails` | number | 3 | Consecutive fails before BLOCKED exit |
 | `branch_prefix` | string | `feat/` | Prefix for auto-created branches |
@@ -212,7 +212,7 @@ Example:
     "autonomy": "balanced"
   },
   "work": {
-    "max_iterations": 10,
+    "max_iterations": 0,
     "retry_limit": 2,
     "kill_after_fails": 3,
     "branch_prefix": "feat/",

--- a/docs/EXAMPLE.md
+++ b/docs/EXAMPLE.md
@@ -111,6 +111,14 @@ jonggrang work "Todo REST API ..." --yes   # plan → approve → execute
 jonggrang plan "Todo REST API ..." --src docs/brd.md   # reference source document for the agent to read
 ```
 
+**Option E — extend an approved plan (append):**
+
+```bash
+jonggrang plan --append feat-abc123 "also add input validation to the todo endpoints" --yes
+# generates an extension draft, approves it into the existing feature (task-006, task-007, ...),
+# and re-opens the execution phases so `jonggrang work` runs the new tasks.
+```
+
 ### Step 4: Check Task Board
 
 ```bash

--- a/docs/JONGGRANG.md
+++ b/docs/JONGGRANG.md
@@ -670,7 +670,7 @@ Append-only log written after each task (per-feature):
   },
 
   "work": {
-    "max_iterations": 10,
+    "max_iterations": 0,
     "retry_limit": 2,
     "kill_after_fails": 3,
     "branch_prefix": "feat/",

--- a/docs/JONGGRANG.md
+++ b/docs/JONGGRANG.md
@@ -526,8 +526,13 @@ Draft-scoped endpoints accept `sessionId` (or `session`) in JSON body or query s
 
 ```
 Plan: simple-api      (task-001..005, blocked_by chain) → worktree feat/simple-api      (serial within)
-Plan: version-endpoint(task-006..009, blocked_by chain) → worktree feat/version-endpoint (parallel with the above)
+Plan: version-endpoint(task-001..004, blocked_by chain) → worktree feat/version-endpoint (parallel with the above)
 ```
+
+> Task numbering is **per-plan**: each plan numbers its own tasks from `task-001`, so
+> the two plans above both start at `task-001`. A bare `task-003` resolves within a
+> feature scope (`--feature <id>`, else the active feature, else a single global match
+> for legacy ids); `AMBIGUOUS_TASK_ID` is raised when it can't be disambiguated.
 
 ### Issues — import GitHub/GitLab issues as plans (feature #55)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -122,6 +122,20 @@ jonggrang work "add REST API for todos" --yes
 
 This runs plan → approve → execute in one command. Good for well-defined, low-risk features.
 
+### I already approved a plan and want to add more scope
+
+Instead of creating a whole new plan, **extend** the existing one — the new tasks are appended to it, numbering continues from where it left off, and completed tasks stay untouched:
+
+```bash
+jonggrang status                    # grab the feature id you want to extend
+jonggrang plan --append feat-abc123 "also add rate limiting to the login endpoint"
+# review the extension draft, then:
+jonggrang approve --feature feat-abc123
+# or one-shot: jonggrang plan --append feat-abc123 "..." --yes
+```
+
+The web dashboard has an **"Extend this plan"** button on any approved plan for the same flow.
+
 ### I want to use Claude Code instead of OpenCode
 
 ```bash

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -376,6 +376,22 @@ The **Issues** menu (top app nav, beside `projects`) lists GitHub/GitLab issues 
 - **Detail drawer**: right-aligned overlay (reuses the Dialog/Drawer pattern in §6.7) — header `repo#number`, state badge, author/date, markdown body, comments, footer "Open original" + "Pickup → Plan".
 - **Pickup modal**: source chip + Existing/New project choice → routes to the target project's **pre-filled New Plan form** (plan-creation UX is unchanged; only the description arrives populated). Source link surfaces on the plan card as a "↗ repo#N" link.
 
+### Extend an approved plan (feature: append)
+
+On an approved/done plan in the Plan view, the header shows an **"Extend this plan"**
+secondary button (beside **Work Mode**). Clicking it reveals an inline form:
+
+- a **textarea** for the additional scope (placeholder: "e.g. also add rate limiting to the login endpoint"), mono font, `var(--jg-bg)` surface.
+- a **Deep analysis** checkbox (toggles `--deep` on the generated extension: discovery + risks for the added scope).
+- **Cancel** (secondary) / **Generate Extension** (primary, disabled until the textarea has content).
+
+The form POSTs to `POST /api/projects/:id/plans/:featureId/extend`, which spawns
+`jonggrang plan --append <featureId> "<desc>"`. The generated extension draft carries
+`append_to: <featureId>` in its frontmatter; the user then approves it (the existing
+`POST /:id/approve` detects `append_to` and decomposes the new tasks into the existing
+feature, numbering continued, completed tasks untouched). Appended tasks land in the
+same plan's kanban automatically (the board filters by `feature_id`).
+
 ### Plan clarifying-questions form (feature: plan ask)
 
 After **Generate Plan**, if the planning agent decides the request is ambiguous it

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -105,11 +105,19 @@ jonggrang plan        # no description → shows list of pending + archived plan
 
 | Situation | Command |
 |-----------|---------|
-| Add new scope on top of done work | `jonggrang plan "also add rate limiting"` |
-| Change remaining pending work | `jonggrang plan "use Passport.js instead"` |
+| Add new scope to an approved plan | `jonggrang plan --append <featureId> "also add rate limiting"` then `jonggrang approve --feature <featureId>` (or `--yes` for one shot) |
+| Change remaining pending work | `jonggrang plan "use Passport.js instead"` (a new plan / new feature) |
 | Undo completed tasks | Not supported — create new tasks to override |
 
 > **Rule: completed tasks are immutable.** They reflect real code. Any correction must be a new task.
+>
+> **Per-plan task numbering.** Each plan numbers its own tasks from `task-001`. An
+> append continues from that plan's current max (e.g. `task-006` after `task-001..005`)
+> and never renumbers or modifies existing/completed tasks. A bare `task-NNN` can
+> therefore recur across plans; task-id commands resolve it within a feature scope
+> (`--feature <id>`, else the active feature, else a single global match for legacy
+> ids), and error with `AMBIGUOUS_TASK_ID` when genuinely ambiguous. Existing
+> projects keep their current ids — no renumber, no migration.
 
 ---
 

--- a/docs/plans/2026-07-01-append-plan-extend-tasks.md
+++ b/docs/plans/2026-07-01-append-plan-extend-tasks.md
@@ -1,0 +1,365 @@
+---
+feature: append-plan-extend-tasks
+branch: feat/append-plan
+work_type: LARGE
+description: Let a user extend an EXISTING approved plan with additional scope and decompose the extra work as ADDITIONAL tasks appended to that plan's task list — plus fix task numbering so each plan numbers its tasks from 001 (per-feature), while an append continues from the plan's existing task count.
+created_at: 2026-07-01
+status: design — nothing implemented yet (this doc is for review)
+---
+
+# Plan: Append to an Existing Plan + Per-Plan Task Numbering
+
+> **Scope of THIS doc:** design only. Build order, exact touch-points, numbering
+> rules, the migration/compat story, and CLI + web surfaces. No code yet.
+>
+> **Two coupled deliverables** (they must ship together or numbering gets weird):
+> 1. **Per-plan task numbering** — each plan/feature numbers its tasks from `task-001`.
+> 2. **Append-to-existing-plan** — add scope to an approved plan and decompose
+>    *additional* tasks into it, continuing that plan's numbering.
+
+---
+
+## 1. Mental Model — read this first
+
+Today Jonggrang has **one global task counter**. The user wants **per-plan
+counters** plus an **append** path:
+
+```
+TODAY (global, monotonic):
+  feature A:  task-001 task-002 task-003
+  feature B:  task-004 task-005          ← continues A's numbers
+  feature C:  task-006 …
+
+WANTED (per-plan, resets to 001; append continues within the plan):
+  feature A:  task-001 task-002 task-003
+  feature B:  task-001 task-002          ← fresh plan → starts at 001
+  feature A (after APPEND "also add X"):
+              task-001 task-002 task-003  (unchanged, completed → immutable)
+              task-004 task-005           ← appended, continue A's own max
+```
+
+So there are **two numbering modes**, selected by *which flow ran*:
+
+| Flow | Target feature | Numbering |
+|---|---|---|
+| **New plan** (`plan "x"` → `approve`) | a brand-new feature | start at **task-001** |
+| **Append** (`plan --append <id> "x"` → `approve --feature <id>`) | an existing feature | **continue** from that feature's current max |
+
+> ⚠️ **The catch the user flagged ("penomoran task di check lagi"):** the current
+> code makes task IDs *globally unique on purpose* — `findTaskFeature` and the
+> `jonggrang task done/show/update/block/remove task-005` auto-lookup all assume a
+> bare `task-NNN` resolves to exactly one task across the whole project. Per-plan
+> numbering breaks that (two plans can both own `task-001`). §6 reworks resolution
+> so nothing silently picks the wrong task.
+
+---
+
+## 2. Current Behavior — audit (with citations)
+
+So we change exactly what's needed and nothing load-bearing breaks.
+
+### 2.1 Numbering is global & monotonic
+- `maxTaskNumber(allTasks)` scans **every** task across **all** features for the
+  largest `task-(\d+)` (`lib/jonggrang.js:503-510`).
+- `addTask` (`lib/jonggrang.js:512-524`) and `addTasksBulk`
+  (`lib/jonggrang.js:526-543`) seed the next id from that **global** max —
+  `task-${maxTaskNumber(all.tasks)+1}`.
+- The decompose prompt **tells the agent to continue the global sequence**:
+  > "Task IDs are GLOBALLY unique across all features. Continue numbering from the
+  > existing IDs listed above — do NOT restart at task-001. If the last existing ID
+  > is task-007, start at task-008." (`lib/jonggrang.js:1006-1008`; the
+  > "Existing Task IDs (across all features…)" block is built at `:948-963`.)
+
+### 2.2 Every `approve` makes a NEW feature (no append path)
+- `cmdApprove` (`bin/jonggrang.js:1429`) resolves a draft, reads its frontmatter
+  feature name, then **always** mints a fresh id:
+  `featureId = orchestration.generateFeatureId(featureName)` (`bin/jonggrang.js:1469`)
+  — slug + base36 timestamp (`lib/orchestration.js:408-417`), so re-approving the
+  "same" feature still yields a new folder.
+- It creates `.jonggrang/.output/features/<id>/` + `MANIFEST.yaml` up front
+  (`:1474-1479`), runs the decompose agent (`:1493-1494`), then archives the draft
+  plan into the feature and discards the draft session (`:1508-1509`).
+- **There is no `approve --feature <existing>` and no `plan --append`.** The
+  decompose prompt has a latent **"UPDATE MODE"** branch (`lib/jonggrang.js:957-962`,
+  "append after the last existing ID, never modify completed") but it only fires
+  when the target `featureId` already has completed tasks — which the normal
+  `approve` path can never produce, because it always targets a brand-new feature.
+
+### 2.3 Task-id resolution depends on global uniqueness
+- `findTaskFeature(projectRoot, taskId)` returns the (single) feature owning a
+  bare id by scanning all features (`lib/jonggrang.js:99-104`).
+- Per-feature task files were *explicitly* designed around globally-unique ids so
+  `jonggrang task done task-005` resolves unambiguously (comment `lib/jonggrang.js:472-482`).
+- `makeTask` stores **no separate ordinal** — the only number is inside the id
+  string (`lib/jonggrang.js:` `makeTask`). So "the task number" == the `NNN` in `task-NNN`.
+
+### 2.4 Web
+- `POST /api/projects/:id/approve` just spawns `approve --session <draft>`
+  (`apis/projects/approve.js:10-27`) → always a new feature.
+- Plans list / draft grouping is per-feature already (`apis/projects/plan.js`),
+  and the kanban is grouped by `feature_id` — so the **web already has a feature
+  context** everywhere it touches tasks. This is good news for §6.
+
+---
+
+## 3. The Numbering Decision (the crux)
+
+Three options. **Recommendation: Option C.**
+
+**Option A — keep global ids, fake per-plan display.** Store globally-unique ids,
+show a per-feature ordinal in the UI. *Rejected:* the user wants the real `task-001`
+per plan ("tiap plan nomornya mulai dari 001"), and tasks are referenced by id in
+commits, `blocked_by`, and CLI — a cosmetic-only number is a lie waiting to confuse.
+
+**Option B — composite ids (`<featureId>/task-001`).** Fully unambiguous. *Rejected
+for now:* invasive — every id reference (blocked_by, commits, web routes, hooks,
+existing data) changes shape; biggest blast radius.
+
+**Option C — per-feature `task-NNN`, feature-scoped resolution (RECOMMENDED).**
+- Each feature numbers its own tasks `task-001..task-N`. New plan → starts at 001.
+- Ids are unique **within a feature**, not globally.
+- Bare `task-NNN` resolves **within a feature context** (active feature / `--feature`),
+  with a clear error when genuinely ambiguous (§6).
+- Matches the user's literal ask, keeps id shape unchanged, and the web already
+  carries feature context. Smallest change that's still correct.
+
+---
+
+## 4. Part A — Per-Plan Task Numbering
+
+### 4.1 `lib/jonggrang.js` numbering becomes per-feature
+- New helper `maxTaskNumberInFeature(projectRoot, featureId)` — max `task-(\d+)`
+  among tasks **with that `feature_id`** (the per-feature file).
+- `addTask` / `addTasksBulk` (`:512-543`) seed from `maxTaskNumberInFeature(featureId)`
+  instead of the global `maxTaskNumber(all.tasks)`:
+  - a fresh feature's file is empty → max 0 → first id `task-001`.
+  - an append into an existing feature → max is that feature's own last → continues.
+- Keep the old global `maxTaskNumber` only if still needed by a migration/compat
+  reader; otherwise remove to avoid accidental reuse.
+- Duplicate-guard changes from "no id collisions globally" (`:517`, `:534`) to "no
+  id collisions **within this feature**" (`all.tasks` filtered by `feature_id`).
+
+### 4.2 Decompose prompt becomes per-feature (`buildTasksFromPlanPrompt`)
+- The "Existing Task IDs (across all features…)" block (`:948-963`) → show only the
+  **target feature's** existing ids (empty for a new plan).
+- Rewrite the rule at `:1006-1008`:
+  - **New feature:** "This is a NEW plan — number tasks starting at `task-001`."
+  - **Append (UPDATE MODE):** "This plan already has tasks `task-001..task-NNN`.
+    Continue from `task-(NNN+1)`; NEVER modify or renumber existing/completed tasks."
+- The schema example (`:996`, `:1002`) and `blocked_by` guidance stay (`task-NNN`
+  shape unchanged) — references are within-feature, which is what decompose already
+  produces.
+
+### 4.3 `task import` enforces per-feature numbering
+- `task import --feature <id>` (the path decompose uses) already targets a feature;
+  ensure auto-id assignment uses the per-feature max so an agent that omits `id`
+  still gets correct per-feature numbers, and an agent that *supplies* ids that
+  collide within the feature is rejected with a clear message.
+
+---
+
+## 5. Part B — Append to an Existing Plan
+
+### 5.1 CLI surface
+- **`jonggrang plan --append <featureId> "<additional scope>"`**
+  - Loads the existing feature's archived `plan.md` + its task list as context.
+  - Generates a draft that describes ONLY the additional scope (a delta), tagged in
+    frontmatter with `append_to: <featureId>` so `approve` knows where it goes.
+  - Reuses the normal plan draft session machinery (`.drafts/<session>/plan.md`).
+- **`jonggrang approve --feature <featureId>`** (and `approve` auto-detects
+  `append_to` in the draft frontmatter)
+  - Decomposes the delta plan into **additional** tasks **in the existing feature**,
+    numbering continued from that feature's max (Part A), completed tasks untouched.
+  - Does NOT mint a new feature id; does NOT create a new feature folder; appends to
+    the existing `jonggrang-tasks.json`; appends/links the delta plan into the
+    existing `features/<id>/plan.md` (e.g. an `## Appended <date>` section) so the
+    feature's plan stays the source of truth.
+  - MANIFEST: re-open the relevant phases (or record an append event) rather than
+    treating the feature as freshly minted.
+- Convenience: `jonggrang plan --append <id> "x" --yes` = append-plan + approve in
+  one shot (mirrors `plan "x" --yes`).
+
+### 5.2 Picking the target feature
+- `<featureId>` accepted directly; if omitted, fall back to `resolveActiveFeature`
+  (most-recent incomplete) and print which feature was chosen.
+- `jonggrang plan --append` with no id → list approved features to pick from
+  (mirror the no-arg `plan` picker).
+
+### 5.3 Web surface (mirror the plan-ask web shape)
+- On an existing plan in `PlanView.vue`, add **"Extend this plan"** → opens the same
+  description box but POSTs to a new **`POST /api/projects/:id/plans/:featureId/extend`**
+  (or `POST /:id/plan` with an `append_to` field).
+- Server spawns `plan --append <featureId> "<desc>"`; the existing draft → questions
+  (if plan-ask present) → `approve --feature <id>` round-trip is reused.
+- The kanban for that plan then shows the appended tasks continuing its numbering;
+  the per-plan board already filters by `feature_id`, so appended tasks land in the
+  right board automatically.
+
+---
+
+## 6. Task-ID Resolution Rework (consequence of §3 Option C)
+
+Per-feature ids mean a bare `task-005` can exist in multiple features. Every
+bare-id command must resolve within a **feature scope**:
+
+- Affected: `findTaskFeature` (`lib/jonggrang.js:99-104`) and its callers — the
+  `jonggrang task show/update/done/block/remove <id>` family (`bin/jonggrang.js`
+  task-id commands), `updateTaskMode`, and any `blocked_by` cross-checks.
+- New resolution order for a bare id:
+  1. If `--feature <id>` is given → resolve within that feature.
+  2. Else if a single feature is "active" (`resolveActiveFeature`) and owns the id → use it.
+  3. Else if exactly one feature across the project owns the id → use it (keeps old
+     globally-unique data working — backward compatible).
+  4. Else **error**: "task-005 exists in N plans: <ids>. Disambiguate with
+     `--feature <id>`." (No silent wrong-task picks — this is the safety the user wants.)
+- `blocked_by` stays **within-feature** (decompose only references sibling tasks),
+  so no cross-feature dependency ids are introduced.
+- Web: already feature-scoped (routes/kanban carry `feature_id`) — audit the task
+  PATCH/done endpoints to pass `feature_id` through to the lib resolver rather than
+  relying on a global lookup.
+
+---
+
+## 7. Backward Compatibility & Migration
+
+- **Do NOT renumber existing features.** Their `task-NNN` ids are referenced by real
+  git commits ("Task: task-007"), `progress.txt`, and `blocked_by`. Renumbering would
+  rewrite history semantics. Existing features keep their current (possibly global)
+  numbers; **only new features and new appends use per-feature numbering.**
+- The resolver (§6 step 3) keeps legacy globally-unique ids resolving by single-match,
+  so old projects keep working with no migration step.
+- Mixed projects (old global features + new per-feature features) are fine: ambiguity
+  only arises when two features share an id, and then the resolver errors helpfully.
+- No on-disk schema migration required. (Optional: a `jonggrang doctor`-style report
+  that flags duplicate ids across features so users know when to pass `--feature`.)
+
+---
+
+## 8. Edge Cases (don't miss these)
+
+1. **Append onto a feature with completed tasks** — completed tasks immutable; new
+   tasks appended after max; numbering continues (the "WANTED" example in §1).
+2. **Append twice** — second append continues from the (now larger) max; no gaps,
+   no reuse.
+3. **Two plans both have `task-003`, user runs `task done task-003`** — resolver
+   errors with the candidate list unless `--feature` / active feature disambiguates.
+4. **`blocked_by` in an append** references existing ids in the same feature (e.g.
+   appended `task-006 blocked_by task-004`) — must remain valid; cross-feature
+   `blocked_by` is rejected/ignored.
+5. **Agent ignores numbering instruction** (restarts at 001 inside an append, or
+   collides) — `addTasksBulk`/`task import` must reject id collisions *within the
+   feature* with a clear error so the agent retries (don't silently overwrite).
+6. **Empty append** (agent adds no tasks) — preserve the existing feature + plan,
+   error like the new-plan "no tasks created" guard (`bin/jonggrang.js:1500-1504`).
+7. **Append target not found / not yet approved** — clear error; suggest `plan` (new)
+   instead.
+8. **Web concurrent appends to the same feature** — one generation at a time per
+   feature (same constraint the plan flow already assumes).
+9. **Worktree/branch:** an append reuses the existing feature's branch (frontmatter
+   `branch:`), it does NOT cut a new branch — confirm in the parallel-run path.
+
+---
+
+## 9. Build Phases
+
+| Phase | Deliverable | Notes |
+|---|---|---|
+| **P1** | Per-feature `maxTaskNumberInFeature` + `addTask`/`addTasksBulk` seed from it; per-feature collision guard | Foundation; unit-testable without an agent |
+| **P2** | Task-id resolver rework (`findTaskFeature` + callers, `--feature` scope, ambiguity error) | Keeps legacy single-match working |
+| **P3** | Decompose prompt: per-feature numbering + real UPDATE MODE wording (`buildTasksFromPlanPrompt`) | New-vs-append branches |
+| **P4** | `plan --append <id>` (delta draft + `append_to` frontmatter) and `approve --feature <id>` / auto-detect | Core feature |
+| **P5** | Append archive/merge into `features/<id>/plan.md` + MANIFEST re-open; preserve completed tasks | State correctness |
+| **P6** | Web: "Extend this plan" in `PlanView.vue` + `POST /:id/plans/:featureId/extend` endpoint | Mirrors plan-ask web shape |
+| **P7** | Docs + tests | §11, §12 |
+
+Each phase is independently shippable; P1+P2 are the risky core (numbering +
+resolution) and should land + be tested before P4.
+
+---
+
+## 10. Numbering Rules — precise spec (the user's core requirement)
+
+```
+NEW PLAN  (plan "x" → approve, fresh feature F):
+    next = 1
+    tasks: task-001, task-002, …, task-0NN     (per-feature, always from 001)
+
+APPEND    (plan --append F "y" → approve --feature F):
+    let maxF = max NNN among F's existing task-NNN          # e.g. 005
+    appended: task-(maxF+1), task-(maxF+2), …               # e.g. task-006, task-007
+    existing/completed tasks: UNCHANGED, never renumbered
+
+Invariants:
+  - id format stays "task-" + zero-padded 3-digit number (padStart(3,'0'))
+  - numbers are contiguous within a feature (no gaps from append)
+  - a number is never reused within a feature
+  - across features, the SAME number may recur (that's the point) → resolve by feature
+```
+
+---
+
+## 11. Testing
+
+### CLI (deterministic + agent)
+- **P1 unit (no agent):** add tasks to feature A → 001,002; create feature B → resets
+  to 001,002; append to A → continues 003,004. Assert via `getAllTasks` + the files.
+- **Resolver unit:** bare id unique → resolves; duplicate across features → errors;
+  `--feature` disambiguates; legacy single-match still works.
+- **Agent e2e:** `plan "X" --yes` → tasks 001…; then `plan --append <id> "Y" --yes`
+  → appended tasks continue; completed tasks untouched; `task done <appended-id>`
+  works with feature scope.
+
+### Web e2e (browser + headless)
+- New plan → kanban shows 001-based tasks. "Extend this plan" → describe scope →
+  approve → appended tasks continue numbering in the SAME plan's board.
+- Sandbox + non-sandbox.
+
+### Acceptance checklist
+- [ ] New plan numbers tasks from `task-001`.
+- [ ] Append continues from the plan's own max; completed tasks immutable.
+- [ ] No number reused / no gaps within a feature.
+- [ ] Bare-id commands resolve by feature scope; ambiguity errors clearly.
+- [ ] Legacy projects (global ids) keep working with no migration.
+- [ ] Web "Extend this plan" round-trips end to end (CLI + web both verified).
+
+---
+
+## 12. Docs to Update (CLAUDE.md "Iron Rule")
+
+| Change | Update |
+|---|---|
+| New `plan --append` / `approve --feature` + numbering rule | `README.md` (Commands at a Glance + flags), `docs/WORKFLOW.md` (two-phase + "Modifying a plan after approval"), `docs/QUICKSTART.md`, `docs/EXAMPLE.md` |
+| Per-feature numbering + task-id resolution | `docs/JONGGRANG.md` (task state / project structure), `docs/WORKFLOW.md` |
+| Web "Extend this plan" | `docs/UI.md` |
+| Decompose/approve phase change | `docs/WORKFLOW.md`, `docs/ORCHESTRATION.md` if it touches the phase machine |
+
+---
+
+## 13. Open Decisions (need your call)
+
+1. **Numbering model:** confirm **Option C** (per-feature `task-NNN` + scoped
+   resolution) vs Option B (composite `<feature>/task-NNN`, fully unambiguous but
+   invasive).
+2. **Append command name:** `plan --append <id> "x"` (recommended) vs a dedicated
+   `plan extend <id> "x"` subcommand.
+3. **Append plan storage:** append a `## Appended <date>` section to the feature's
+   existing `plan.md` (recommended — single source of truth) vs keep delta plans as
+   separate files under the feature.
+4. **Renumber legacy features to per-feature?** Recommended **NO** (keeps git/commit
+   task references valid). Confirm.
+5. **Scope:** do P1–P3 (numbering + resolution) ship first as a standalone PR, with
+   P4–P6 (append flow + web) as a follow-up? Or all together?
+
+---
+
+## 14. Dependencies / Touch-Points (quick index)
+
+- `lib/jonggrang.js`: `maxTaskNumber` (:503), `addTask` (:512), `addTasksBulk` (:526),
+  `findTaskFeature` (:99), `buildTasksFromPlanPrompt` (:~938-1013), `makeTask`,
+  `getAllTasks` (:61), `resolveActiveFeature`.
+- `bin/jonggrang.js`: `cmdApprove` (:1429), `cmdPlan` (plan flags), task-id commands
+  (`task show/update/done/block/remove`), `task import` handler.
+- `lib/orchestration.js`: `generateFeatureId` (:408), MANIFEST create/complete.
+- `apis/projects/`: `approve.js` (:10), `plan.js` (plans list/draft), a new extend
+  endpoint, `PlanView.vue` + kanban.
+- No new npm deps.

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -96,14 +96,32 @@ function resolveActiveFeature(projectRoot) {
   return candidates[0].featureId;
 }
 
-// Locate which feature a task-id lives in, by scanning all feature files.
-// Used by task-id commands (show/update/done/block/remove) to resolve the
-// correct per-feature file without requiring --feature. Returns the featureId
-// or null if the task isn't found anywhere.
-function findTaskFeature(projectRoot, taskId) {
+// Locate which feature a task-id lives in. Used by task-id commands
+// (show/update/done/block/remove) to resolve the correct per-feature file.
+// Since numbering is per-feature, a bare id (task-005) can recur across plans;
+// disambiguate in order: (1) explicit opts.featureId, (2) the active feature,
+// (3) a single global match (legacy globally-unique ids keep working). If still
+// ambiguous, throw AMBIGUOUS_TASK_ID with the candidate features so the caller
+// can tell the user to pass --feature. Returns the featureId, or null if unknown.
+function findTaskFeature(projectRoot, taskId, opts = {}) {
   const all = getAllTasks(projectRoot);
-  const task = all.tasks.find(t => t.id === taskId);
-  return task ? (task.feature_id || null) : null;
+  const matches = all.tasks.filter(t => t.id === taskId);
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0].feature_id || null;
+  if (opts.featureId && matches.some(t => t.feature_id === opts.featureId)) return opts.featureId;
+  const active = resolveActiveFeature(projectRoot);
+  if (active && matches.some(t => t.feature_id === active)) return active;
+  // Genuinely ambiguous. The CLI resolver opts into a hard error so the user
+  // disambiguates; programmatic callers (worktree/web, which usually already run
+  // in a single-plan context) get a best-effort first match instead of a crash.
+  if (opts.throwOnAmbiguous) {
+    const candidates = matches.map(t => t.feature_id).filter(Boolean);
+    const err = new Error(`Task ${taskId} exists in ${matches.length} plans: ${candidates.join(', ')}. Disambiguate with --feature <id>.`);
+    err.code = 'AMBIGUOUS_TASK_ID';
+    err.candidates = candidates;
+    throw err;
+  }
+  return matches[0].feature_id || null;
 }
 
 // ============================================================
@@ -468,12 +486,13 @@ function countTotal(tasksFile) {
 
 // ── Task CRUD ─────────────────────────────────────────────────
 //
-// Task IDs are GLOBALLY unique across all features (required by the
-// auto-lookup UX: `jonggrang task done task-005` must resolve to one task).
-// addTask/addTasksBulk therefore scan ALL feature files via getAllTasks to
-// continue numbering and detect collisions, even though they write to a single
-// feature file. Read/update/remove operate on a single resolved feature file
-// (tasksFile) — callers resolve the path first.
+// Task numbering is PER-FEATURE: each feature numbers its tasks from task-001.
+// addTask/addTasksBulk seed the next id from THIS feature's own tasks and detect
+// collisions within the feature. A bare id (task-005) can therefore recur across
+// features; findTaskFeature resolves it within a feature scope (explicit
+// --feature, then the active feature, then a single global match for legacy
+// globally-unique ids) — see its doc comment. Read/update/remove operate on a
+// single resolved feature file (tasksFile) — callers resolve the path first.
 
 const VALID_STATUSES = new Set(['pending', 'in_progress', 'completed', 'blocked', 'waiting', 'skipped']);
 
@@ -498,11 +517,13 @@ function makeTask(taskData, id, featureId, defaultPriority) {
   };
 }
 
-// Find the largest task-NNN number across all task objects. Used by both
-// generateTaskId (single add) and addTasksBulk (continues numbering inline).
-function maxTaskNumber(allTasks) {
+// Find the largest task-NNN number in a task array. Numbering is PER-FEATURE:
+// each feature numbers its own tasks from task-001, so callers pass that
+// feature's tasks (data.tasks) — NOT the global set. An append into a feature
+// continues from its own max; a fresh feature (empty) starts at task-001.
+function maxTaskNumber(tasks) {
   let maxNum = 0;
-  for (const t of allTasks) {
+  for (const t of tasks) {
     const m = (t.id || '').match(/^task-(\d+)$/);
     if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
   }
@@ -512,10 +533,11 @@ function maxTaskNumber(allTasks) {
 function addTask(projectRoot, featureId, taskData) {
   const tasksFile = tasksFileFor(projectRoot, featureId);
   const data = getTasks(tasksFile);
-  const all = getAllTasks(projectRoot);
-  const id = taskData.id || `task-${String(maxTaskNumber(all.tasks) + 1).padStart(3, '0')}`;
-  if (all.tasks.some(t => t.id === id)) {
-    throw new Error(`Task ${id} already exists`);
+  // Per-feature numbering: seed from THIS feature's own tasks (starts at 001 for
+  // a new feature; continues for an append). Collisions are checked within the feature.
+  const id = taskData.id || `task-${String(maxTaskNumber(data.tasks) + 1).padStart(3, '0')}`;
+  if (data.tasks.some(t => t.id === id)) {
+    throw new Error(`Task ${id} already exists in feature ${featureId}`);
   }
   const task = makeTask(taskData, id, featureId, data.tasks.length + 1);
   data.tasks.push(task);
@@ -526,13 +548,14 @@ function addTask(projectRoot, featureId, taskData) {
 function addTasksBulk(projectRoot, featureId, taskDataArray) {
   const tasksFile = tasksFileFor(projectRoot, featureId);
   const data = getTasks(tasksFile);
-  const all = getAllTasks(projectRoot);
-  let nextNum = maxTaskNumber(all.tasks);
+  // Per-feature numbering (see addTask). New feature → nextNum 0 → first id task-001;
+  // append → continues from this feature's current max.
+  let nextNum = maxTaskNumber(data.tasks);
   const created = [];
   for (const taskData of taskDataArray) {
     const id = taskData.id || `task-${String(++nextNum).padStart(3, '0')}`;
-    if (all.tasks.some(t => t.id === id) || created.some(t => t.id === id)) {
-      throw new Error(`Task ${id} already exists`);
+    if (data.tasks.some(t => t.id === id) || created.some(t => t.id === id)) {
+      throw new Error(`Task ${id} already exists in feature ${featureId}`);
     }
     const task = makeTask(taskData, id, featureId, data.tasks.length + 1);
     data.tasks.push(task);
@@ -891,6 +914,105 @@ Existing code, services, or patterns this builds on. Write "None" if not applica
 - After writing the plan, output exactly: "Draft plan written to ${draftPath}"`;
 }
 
+/**
+ * Build a prompt to EXTEND an existing approved plan (feature `featureId`) with
+ * additional scope. The agent writes a delta draft to `draftPath` describing ONLY
+ * the new work; on approve the delta is decomposed into ADDITIONAL tasks appended
+ * to the existing feature (numbering continues, existing/completed tasks untouched).
+ * The draft carries `append_to: <featureId>` so approve routes it to the feature.
+ */
+function buildAppendPlanPrompt(additionalScope, existingPlanContent, existingTasks, configFile, projectRoot, draftPath, featureId, opts = {}) {
+  const fm = (() => {
+    const m = (existingPlanContent || '').match(/^---\n([\s\S]*?)\n---/);
+    if (!m) return {};
+    try { return require('js-yaml').load(m[1]) || {}; } catch { return {}; }
+  })();
+  const featureSlug = fm.feature || featureId;
+  const branch = fm.branch || `feat/${featureSlug}`;
+  const taskLines = (existingTasks || [])
+    .map(t => `- ${t.id} [${t.status}] ${t.title}`).join('\n');
+  const now = new Date().toISOString();
+
+  // Deep pre-pass output (discovery + analysis on the additional scope). When
+  // present, the extension plan is enriched with concrete file paths / risks /
+  // alternatives and `depth: deep` in the frontmatter.
+  const deep = opts.deep && (opts.deep.discovery || opts.deep.analysis) ? opts.deep : null;
+  const deepSection = deep
+    ? `\n## Deep Analysis (from discovery + brainstorm on the additional scope)\n### Discovery\n${(deep.discovery || '(none)').trim()}\n\n### Analysis\n${(deep.analysis || '(none)').trim()}\n`
+    : '';
+  const deepFrontmatter = deep ? '\ndepth: deep' : '';
+  const deepSectionsSpec = deep
+    ? `
+
+## Affected Areas
+- Concrete files/modules the additional work touches (from discovery)
+
+## Risks
+- Risk → mitigation
+
+## Alternatives Considered
+- Option considered and why it was rejected`
+    : '';
+  const deepRule = deep
+    ? '\n- This is a DEEP extension: ground Approach/Phases in the discovery findings, and include the Affected Areas / Risks / Alternatives sections + `depth: deep` in the frontmatter.'
+    : '';
+
+  return `# Jonggrang — Extend an Existing Plan${deep ? ' (Deep)' : ''}
+
+${buildProjectContext(configFile, { maxChars: 2500 })}
+
+## Existing Plan (already approved — context only; do NOT redo its work)
+\`\`\`markdown
+${(existingPlanContent || '').trim()}
+\`\`\`
+
+## Existing Tasks in this Plan (already decomposed — do NOT repeat these)
+${taskLines || '(none)'}
+
+## Additional Scope to Add
+${additionalScope}
+${deepSection}
+## Your Task
+Write a plan for ONLY the ADDITIONAL scope above — the new work to append onto the
+existing plan. Do NOT restate or redo anything already covered. Write it to
+\`${draftPath}\` using EXACTLY this format:
+
+\`\`\`
+---
+feature: ${featureSlug}
+branch: ${branch}
+work_type: BUGFIX|SMALL|MEDIUM|LARGE
+description: one-line summary of the ADDITIONAL scope
+append_to: ${featureId}${deepFrontmatter}
+created_at: ${now}
+---
+
+# Plan: ${featureSlug} — Extension
+
+## Approach
+2-4 sentences: what the additional work is and how it builds on the existing plan.
+
+## Phases
+1. Phase name — what happens (only the new work)
+...
+
+## Key Decisions
+- Decision: choice + brief rationale
+
+## Out of Scope
+- What is NOT included
+
+## Dependencies
+Builds on the existing plan's work.${deepSectionsSpec}
+\`\`\`
+
+## Rules
+- Plan ONLY the additional scope. The existing tasks above are done/decomposed already — never re-plan them.
+- Keep the frontmatter \`feature\`/\`branch\` identical to the existing plan, and keep \`append_to: ${featureId}\` exactly as shown.
+- 3-8 phases max, high-level; do NOT write code or the tasks file.${deepRule}
+- After writing the plan, output exactly: "Draft plan written to ${draftPath}"`;
+}
+
 // ============================================================
 // TWO-PHASE PLANNING — PHASE 1.5: REVISE PLAN WITH AI
 // ============================================================
@@ -945,21 +1067,21 @@ function buildTasksFromPlanPrompt(planContent, configFile, projectRoot, featureI
     if (cfg) configSection = `## Project Config\n\`\`\`json\n${JSON.stringify(cfg, null, 2)}\n\`\`\`\n`;
   }
 
-  // Show existing tasks across ALL features so the agent continues global ID numbering
-  // (task IDs are globally unique) instead of restarting at task-001.
-  const tasksFile = featureId ? tasksFileFor(projectRoot, featureId) : null;
+  // Per-feature numbering: each plan numbers its tasks from task-001. Show only
+  // THIS plan's existing tasks so the agent numbers correctly — a fresh plan
+  // starts at task-001; an append (this plan already has tasks) continues from
+  // this plan's own max and never renumbers what's already there.
+  const featureTasks = featureId
+    ? getAllTasks(projectRoot).tasks.filter(t => t.feature_id === featureId)
+    : [];
   let currentTasksSection = '';
   let updateNote = '';
-  const allTasks = getAllTasks(projectRoot);
-  if (allTasks.tasks.length > 0) {
-    const existingIds = allTasks.tasks.map(t => t.id).join(', ');
-    currentTasksSection = `## Existing Task IDs (across all features — continue numbering from here)\n${existingIds}\n`;
-    const completedInFeature = featureId
-      ? allTasks.tasks.filter(t => t.feature_id === featureId && t.status === 'completed').length
-      : 0;
-    if (completedInFeature > 0) {
-      updateNote = `\n## ⚠️ UPDATE MODE\n${completedInFeature} tasks already completed in this feature — NEVER modify or remove them. Append new tasks after the last existing ID.\n`;
-    }
+  if (featureTasks.length > 0) {
+    const existingIds = featureTasks.map(t => t.id).join(', ');
+    const nextId = `task-${String(maxTaskNumber(featureTasks) + 1).padStart(3, '0')}`;
+    const completedInFeature = featureTasks.filter(t => t.status === 'completed').length;
+    currentTasksSection = `## Existing Tasks in THIS Plan (do NOT renumber or modify these)\n${existingIds}\nNext id to use: ${nextId}\n`;
+    updateNote = `\n## ⚠️ APPEND MODE\nThis plan already has ${featureTasks.length} task(s)${completedInFeature ? ` (${completedInFeature} completed)` : ''}. Append NEW tasks only, starting at ${nextId}. NEVER modify, remove, or renumber existing tasks; completed tasks are immutable.\n`;
   }
 
   const featureFlag = featureId ? ` --feature ${featureId}` : '';
@@ -1004,8 +1126,8 @@ Each task object in the array must follow this schema:
 \`\`\`
 
 ## Rules
-- Task IDs are GLOBALLY unique across all features. Continue numbering from the existing IDs listed above — do NOT restart at task-001. If the last existing ID is task-007, start at task-008.
-- Always include "id" (task-008, task-009, ...) so blocked_by references work correctly
+- Task numbering is PER-PLAN. For a NEW plan (no existing tasks shown above), number tasks starting at task-001. If this plan already has tasks (APPEND MODE above), continue from the "Next id to use" — do NOT restart at task-001 and do NOT renumber existing tasks.
+- Always include "id" (task-001, task-002, ...) so blocked_by references work correctly. blocked_by must reference ids within THIS plan only.
 - Each task must be completable in a single AI context window
 - Description must be detailed enough to implement without ambiguity
 - Use blocked_by to encode phase dependencies using the "id" values you defined
@@ -2087,6 +2209,27 @@ function setPlanBase(planPath, base) {
   }
 }
 
+// Set (or replace) a safe scalar field in a plan.md's YAML frontmatter. Used for
+// machine-written fields the platform controls (e.g. `append_to: <featureId>`),
+// never free text — the value must be a safe token (isSafeBranchName). Returns
+// true only if the file was updated.
+function setPlanFrontmatterField(planPath, key, value) {
+  if (!/^[a-z_]+$/.test(key) || !isSafeBranchName(value)) return false;
+  try {
+    const raw = fs.readFileSync(planPath, 'utf8');
+    const m = raw.match(/^(---\n)([\s\S]*?)(\n---)/);
+    if (!m) return false;
+    let body = m[2];
+    const line = `${key}: "${value}"`;
+    const re = new RegExp(`^${key}:.*$`, 'm');
+    body = re.test(body) ? body.replace(re, line) : `${body}\n${line}`;
+    fs.writeFileSync(planPath, m[1] + body + m[3] + raw.slice(m.index + m[0].length), 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // List candidate base branches (local heads + origin remote-tracking refs,
 // deduped to short names) plus the resolved default. Host-side, read-only — it
 // works for sandbox projects too (the .git is bind-mounted) and needs no network
@@ -2378,11 +2521,14 @@ function buildBugsToTasksPrompt(openBugs, featureId, configFile, projectRoot) {
     if (cfg) configSection = `## Project Config\n\`\`\`json\n${JSON.stringify(cfg, null, 2)}\n\`\`\`\n`;
   }
 
+  // Per-feature numbering: show only THIS feature's existing tasks so the agent
+  // continues this plan's own sequence (fresh feature → starts at task-001).
   let existingSection = '';
-  const allTasks = getAllTasks(projectRoot);
-  if (allTasks.tasks.length > 0) {
-    const existingIds = allTasks.tasks.map(t => t.id).join(', ');
-    existingSection = `## Existing Task IDs (across all features — continue numbering from here, do NOT duplicate)\n${existingIds}\n`;
+  const featureTasks = getAllTasks(projectRoot).tasks.filter(t => t.feature_id === featureId);
+  if (featureTasks.length > 0) {
+    const existingIds = featureTasks.map(t => t.id).join(', ');
+    const nextId = `task-${String(maxTaskNumber(featureTasks) + 1).padStart(3, '0')}`;
+    existingSection = `## Existing Tasks in THIS Plan (do NOT renumber or duplicate)\n${existingIds}\nNext id to use: ${nextId}\n`;
   }
 
   const bugList = openBugs.map((b, i) =>
@@ -2432,7 +2578,7 @@ Each task object must follow this schema exactly:
 Rules:
 - priority 1 for all bugs (highest)
 - work_type is BUGFIX — keep tasks small and focused
-- Task IDs are GLOBALLY unique. Continue numbering from the existing IDs listed above — do NOT reuse them. Omit "id" to let the CLI auto-assign the next global number, or specify a continuing number.
+- Task numbering is PER-PLAN. Omit "id" to let the CLI auto-assign the next number for THIS plan (task-001 for a fresh plan, or continuing from "Next id to use" above). Do NOT reuse or renumber existing ids.
 - Do NOT include feature_id in the task objects — the CLI stamps it from --feature.
 - After running the import command, output one line per bug in the format:
   TASK_CREATED bug-001 task-005
@@ -2729,6 +2875,7 @@ module.exports = {
   // Prompt builders
   buildProjectContext,
   buildDraftPlanPrompt,
+  buildAppendPlanPrompt,
   buildRevisePlanPrompt,
   buildTasksFromPlanPrompt,
   buildBugsToTasksPrompt,
@@ -2755,6 +2902,7 @@ module.exports = {
   groupPlansAll,
   parsePlanFrontmatter,
   setPlanBase,
+  setPlanFrontmatterField,
   isSafeBranchName,
   listBranches,
   orderTaskIds,

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -963,7 +963,8 @@ function buildAppendPlanPrompt(additionalScope, existingPlanContent, existingTas
   const fm = (() => {
     const m = (existingPlanContent || '').match(/^---\n([\s\S]*?)\n---/);
     if (!m) return {};
-    try { return require('js-yaml').load(m[1]) || {}; } catch { return {}; }
+    const yaml = require('js-yaml');
+    try { return yaml.load(m[1]) || {}; } catch { return {}; }
   })();
   const featureSlug = fm.feature || featureId;
   const branch = fm.branch || `feat/${featureSlug}`;
@@ -1887,7 +1888,7 @@ function generateConfig(options) {
       max_team_size: parseInt(teamSize, 10),
     },
     work: {
-      max_iterations: 10,
+      max_iterations: 0,
       retry_limit: 2,
       kill_after_fails: 3,
       branch_prefix: 'feat/',
@@ -2621,9 +2622,9 @@ Rules:
 - work_type is BUGFIX — keep tasks small and focused
 - Task numbering is PER-PLAN. Omit "id" to let the CLI auto-assign the next number for THIS plan (task-001 for a fresh plan, or continuing from "Next id to use" above). Do NOT reuse or renumber existing ids.
 - Do NOT include feature_id in the task objects — the CLI stamps it from --feature.
-- After running the import command, output one line per bug in the format:
-  TASK_CREATED bug-001 task-005
-  TASK_CREATED bug-002 task-006`;
+- After running the import command, output one line per bug in the format (use the ids the CLI actually assigned — a fresh plan starts at task-001):
+  TASK_CREATED bug-001 task-001
+  TASK_CREATED bug-002 task-002`;
 }
 
 // ============================================================

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js"
+    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/scripts/append-plan-e2e.sh
+++ b/scripts/append-plan-e2e.sh
@@ -10,9 +10,14 @@
 #   bash scripts/append-plan-e2e.sh
 #   JONGGRANG_BIN=./bin/jonggrang.js bash scripts/append-plan-e2e.sh
 #   SKIP_WORK=1 bash scripts/append-plan-e2e.sh   # skip the heavy `work` step
+#   JG_MODEL=deepseek-v4-pro bash scripts/append-plan-e2e.sh  # use a different model
 #
 # Preflight: needs `jonggrang` on PATH (or JONGGRANG_BIN) + a working agent
-# backend (the `jonggrang` tool uses the Pi SDK in-process, no external dep).
+# backend. The `jonggrang` tool uses the Pi SDK in-process. Set up once:
+#   jonggrang login        # writes ~/.jonggrang/agent/auth.json (API key)
+# The script sets provider+model in the test project's jonggrang.json
+# automatically (defaults: opencode-go / deepseek-v4-flash). Override with
+# JG_PROVIDER=... JG_MODEL=...
 set -uo pipefail
 
 # Always test the CURRENT branch's code, not a globally-installed jonggrang
@@ -21,6 +26,11 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 JG="${JONGGRANG_BIN:-$REPO_ROOT/bin/jonggrang.js}"
 TMP="$(mktemp -d /tmp/jg-append-e2e.XXXXXX)"
 SKIP_WORK="${SKIP_WORK:-0}"
+# Pi SDK needs a provider+model in jonggrang.json. Defaults use the opencode-go
+# provider (key lives in ~/.jonggrang/agent/auth.json from `jonggrang login`).
+# Override with JG_PROVIDER=... JG_MODEL=... for a different backend.
+JG_PROVIDER="${JG_PROVIDER:-opencode-go}"
+JG_MODEL="${JG_MODEL:-deepseek-v4-flash}"
 
 PASS=0; FAIL=0; STEP=0
 ok()   { echo "  ✅ $1"; PASS=$((PASS+1)); }
@@ -52,11 +62,42 @@ echo "============================================="
 echo "  testing : $JG"
 echo "  (override with JONGGRANG_BIN=...; skip the heavy work step with SKIP_WORK=1)"
 
+# Pi SDK (tool=jonggrang) needs (a) a populated auth.json and (b) a model set
+# per-project. Fail early with a clear hint instead of a confusing "Agent did
+# not write the plan" midway through.
+AUTH_FILE="$HOME/.jonggrang/agent/auth.json"
+if [ ! -f "$AUTH_FILE" ] || [ "$(wc -c < "$AUTH_FILE" | tr -d ' ')" -le 5 ]; then
+  die "auth.json missing or empty ($AUTH_FILE). Run 'jonggrang login' first."
+fi
+if ! node -e "const a=require('$AUTH_FILE'); const hasKey=Object.values(a).some(v=>v&&(v.key||v.api_key||v.token)); process.exit(hasKey?0:1)" 2>/dev/null; then
+  die "No API key found in $AUTH_FILE. Run 'jonggrang login' first."
+fi
+
+# The Pi extension must parse (see issue #76 / PR #77). A parse error here
+# breaks 'jonggrang agent' AND every runAgent path that loads the extension.
+if ! node --experimental-strip-types -e "import('$REPO_ROOT/hooks/pi/jonggrang-extension.ts').then(()=>process.exit(0)).catch(e=>{console.error(e.message.split(String.fromCharCode(10))[0]);process.exit(1)})" 2>/dev/null; then
+  die "hooks/pi/jonggrang-extension.ts does not parse (issue #76). Apply PR #77 first, or cherry-pick it onto this branch."
+fi
+ok "preflight: auth.json has a key + Pi extension parses"
+
 # --- setup -----------------------------------------------------------------
-step "Setup: non-interactive init"
+step "Setup: non-interactive init + set Pi SDK model"
 ( cd "$TMP" && git init -q && "$JG" init --name jg-append-e2e --tool jonggrang --autonomy autonomous --force ) \
   || die "init failed"
 [ -f "$TMP/.jonggrang/jonggrang.json" ] && ok "project initialized" || bad "no jonggrang.json after init"
+
+# Patch provider+model into the project config (cmdModel is interactive TUI,
+# so we write the fields directly). Without this, Pi SDK has no model and the
+# agent silently fails to write the plan.
+node -e "
+const fs=require('fs');
+const p=process.argv[1];
+const cfg=JSON.parse(fs.readFileSync(p,'utf8'));
+cfg.provider=process.argv[2];
+cfg.model=process.argv[3];
+fs.writeFileSync(p, JSON.stringify(cfg,null,2));
+" "$TMP/.jonggrang/jonggrang.json" "$JG_PROVIDER" "$JG_MODEL"
+echo "  Pi SDK model: $JG_PROVIDER/$JG_MODEL"
 
 # --- 1. first plan → task-001, task-002 ------------------------------------
 step "Plan feature A → expect task-001, task-002"
@@ -90,12 +131,12 @@ rm -f /tmp/jg-e2e-ambiguous.log
 
 # --- 4. --feature disambiguates --------------------------------------------
 step "task done task-001 --feature A → expect success"
-if ( cd "$TMP" && "$JG" task done task-001 --feature "$FEATURE_A" ) >/tmp/jg-e2e-done.log 2>&1; then
+# Don't swallow stderr — if the agent/model errors here, we want to see it.
+if ( cd "$TMP" && "$JG" task done task-001 --feature "$FEATURE_A" ); then
   ok "disambiguated via --feature"
 else
-  bad "task done --feature failed (check /tmp/jg-e2e-done.log)"
+  bad "task done --feature failed (see output above)"
 fi
-rm -f /tmp/jg-e2e-done.log
 
 # --- 5. append → numbering continues ---------------------------------------
 step "Append to A → expect task-003, task-004 (completed tasks untouched)"

--- a/scripts/append-plan-e2e.sh
+++ b/scripts/append-plan-e2e.sh
@@ -40,10 +40,14 @@ die()  { echo "FATAL: $1"; exit 1; }
 
 # Capture the newest feature id under .output/features/ by snapshotting before
 # and after a command. Usage: before_ids=$(feature_ids); run cmd; new=$(newest_feature "$before_ids")
-feature_ids() { ls -1 "$TMP/.jonggrang/.output/features" 2>/dev/null | sort; }
+# Uses ls -t (mtime, newest first) NOT ls | sort — alphabetical sort returns the
+# wrong feature when names share a prefix (e.g. 'hello' vs 'health').
+feature_ids() { ls -1t "$TMP/.jonggrang/.output/features" 2>/dev/null; }
 newest_feature() {
   local before="$1"
-  diff <(printf '%s' "$before") <(feature_ids) | grep '^>' | sed 's/^> //' | tail -1
+  # diff before vs after; the new entry is the one only in 'after'. With -t sort,
+  # the newest feature is first, so head -1 of the new entries.
+  diff <(printf '%s\n' "$before") <(feature_ids) | grep '^>' | sed 's/^> //' | head -1
 }
 task_ids() { node -e "
 const lib=require('$REPO_ROOT/lib/jonggrang.js');
@@ -107,7 +111,10 @@ FEATURE_A=$(newest_feature "$BEFORE")
 [ -n "$FEATURE_A" ] || die "could not capture feature A id"
 A_IDS=$(task_ids "$FEATURE_A")
 echo "  feature A: $FEATURE_A  tasks: $A_IDS"
-case "$A_IDS" in task-001,task-002) ok "A numbered from 001" ;; *) bad "expected task-001,task-002, got $A_IDS" ;; esac
+# Per-plan numbering: a fresh feature MUST start at task-001. The agent decides
+# how many tasks to create (2, 3, ...), so don't assert an exact count — just
+# assert the first id is task-001 and ids are contiguous from there.
+case "$A_IDS" in task-001,*) ok "A starts at task-001 ($A_IDS)" ;; *) bad "expected to start at task-001, got $A_IDS" ;; esac
 
 # --- 2. second plan → resets to task-001 -----------------------------------
 step "Plan feature B → expect reset to task-001"
@@ -117,17 +124,27 @@ FEATURE_B=$(newest_feature "$BEFORE")
 [ -n "$FEATURE_B" ] || die "could not capture feature B id"
 B_IDS=$(task_ids "$FEATURE_B")
 echo "  feature B: $FEATURE_B  tasks: $B_IDS"
-case "$B_IDS" in task-001,task-002) ok "B reset to 001 (per-plan)" ;; *) bad "expected task-001,task-002, got $B_IDS" ;; esac
+# Per-plan: B must reset to task-001 (not continue A's sequence). Agent picks
+# the count; we only assert the reset.
+case "$B_IDS" in task-001,*) ok "B reset to task-001 (per-plan)" ;; *) bad "expected to start at task-001, got $B_IDS" ;; esac
 
-# --- 3. ambiguous bare id → AMBIGUOUS_TASK_ID ------------------------------
-step "task done task-001 (no --feature) → expect AMBIGUOUS_TASK_ID"
-( cd "$TMP" && "$JG" task done task-001 ) 2>&1 | tee /tmp/jg-e2e-ambiguous.log
-if grep -q "AMBIGUOUS_TASK_ID\|exists in.*plans" /tmp/jg-e2e-ambiguous.log; then
-  ok "ambiguous id rejected with a clear error"
+# --- 3. bare id resolves to active feature (not ambiguous) -----------------
+# With per-plan numbering, task-001 exists in both A and B. But feature B was
+# just approved, so it's the 'active' feature — findTaskFeature resolves the
+# bare id to B without erroring (design §6 resolution order: --feature → active
+# → single-match → error). The ambiguity error path is covered by the
+# deterministic smoke test (append-plan-smoke.sh) which has no active feature.
+step "task done task-001 (no --feature) → expect active-feature resolution (B)"
+DONE_OUT=$( cd "$TMP" && "$JG" task done task-001 2>&1 )
+echo "$DONE_OUT" | head -3
+RESOLVED_FEAT=$(echo "$DONE_OUT" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const m=s.match(/\"feature_id\":\s*\"([^\"]+)\"/);process.stdout.write(m?m[1]:'')})")
+if [ "$RESOLVED_FEAT" = "$FEATURE_B" ]; then
+  ok "bare task-001 resolved to active feature B ($FEATURE_B)"
+elif [ -n "$RESOLVED_FEAT" ]; then
+  bad "resolved to $RESOLVED_FEAT, expected active feature $FEATURE_B"
 else
-  bad "ambiguous id did NOT error (check /tmp/jg-e2e-ambiguous.log)"
+  bad "could not parse resolved feature from output"
 fi
-rm -f /tmp/jg-e2e-ambiguous.log
 
 # --- 4. --feature disambiguates --------------------------------------------
 step "task done task-001 --feature A → expect success"
@@ -144,10 +161,32 @@ step "Append to A → expect task-003, task-004 (completed tasks untouched)"
   || die "append failed"
 AP_IDS=$(task_ids "$FEATURE_A")
 echo "  feature A after append: $AP_IDS"
-case "$AP_IDS" in
-  task-001,task-002,task-003,task-004) ok "append continued numbering (003, 004)" ;;
-  *) bad "expected ...003,004, got $AP_IDS" ;;
-esac
+# Append must continue from feature A's own max (task-003 existed, so next is
+# task-004). Check that appended ids start right after the existing max and
+# there are NO GAPS (design §10: 'numbers are contiguous within a feature').
+# A real agent sometimes second-guesses per-plan numbering and skips ids it
+# thinks are 'globally taken' — that gap is a real finding, so we catch it.
+# A_IDS holds the pre-append ids (task-001,task-002,task-003 from step 2).
+READOUT=$(node -e "
+const lib=require('$REPO_ROOT/lib/jonggrang.js');
+const all=lib.getTasks(lib.tasksFileFor('$TMP','$FEATURE_A')).tasks.map(x=>x.id);
+const before=(process.argv[1]||'').split(',').filter(Boolean); // ids before append
+const beforeSet=new Set(before);
+const newIds=all.filter(id=>!beforeSet.has(id));               // ids added by append
+const beforeMax=Math.max(...before.map(id=>parseInt(id.match(/\\d+/)[0],10)));
+const expectedNext='task-'+String(beforeMax+1).padStart(3,'0');
+const nums=all.map(id=>parseInt(id.match(/\\d+/)[0],10)).sort((a,b)=>a-b);
+const contiguous=nums.every((n,i)=>n===i+1) ? 'contiguous' : 'gap';
+process.stdout.write([newIds[0]||'', expectedNext, contiguous].join(' '));
+" "$A_IDS" 2>/dev/null || true)
+read -r AP_FIRST_NEW EXPECTED_NEXT CONTIGUITY <<< "$READOUT"
+if [ -z "$AP_FIRST_NEW" ] || [ -z "$EXPECTED_NEXT" ]; then
+  bad "append assertion could not compute new/expected ids (readout='$READOUT')"
+elif [ "$AP_FIRST_NEW" = "$EXPECTED_NEXT" ] && [ "$CONTIGUITY" = "contiguous" ]; then
+  ok "append continued at $AP_FIRST_NEW (no gap)"
+else
+  bad "append first new task is $AP_FIRST_NEW, expected $EXPECTED_NEXT; sequence=$CONTIGUITY — GAP in numbering (agent may have skipped an id it thought was globally taken)"
+fi
 # completed task-001 must still be 'completed' (immutable)
 A_T1_STATUS=$(node -e "
 const lib=require('$REPO_ROOT/lib/jonggrang.js');

--- a/scripts/append-plan-e2e.sh
+++ b/scripts/append-plan-e2e.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# E2E smoke test for append-plan + per-plan numbering (PR #75).
+#
+# Unlike scripts/append-plan-smoke.sh (deterministic, no agent), this one runs
+# the REAL agent flow end-to-end: plan → approve → ambiguous-id error → append →
+# work. Slow (each plan/work step invokes an agent) but exercises the actual
+# CLI paths the user hits.
+#
+# Usage:
+#   bash scripts/append-plan-e2e.sh
+#   JONGGRANG_BIN=./bin/jonggrang.js bash scripts/append-plan-e2e.sh
+#   SKIP_WORK=1 bash scripts/append-plan-e2e.sh   # skip the heavy `work` step
+#
+# Preflight: needs `jonggrang` on PATH (or JONGGRANG_BIN) + a working agent
+# backend (the `jonggrang` tool uses the Pi SDK in-process, no external dep).
+set -uo pipefail
+
+# Always test the CURRENT branch's code, not a globally-installed jonggrang
+# (which may be an older version without the append-plan feature).
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+JG="${JONGGRANG_BIN:-$REPO_ROOT/bin/jonggrang.js}"
+TMP="$(mktemp -d /tmp/jg-append-e2e.XXXXXX)"
+SKIP_WORK="${SKIP_WORK:-0}"
+
+PASS=0; FAIL=0; STEP=0
+ok()   { echo "  ✅ $1"; PASS=$((PASS+1)); }
+bad()  { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+step() { STEP=$((STEP+1)); echo; echo "[$STEP] $1"; }
+die()  { echo "FATAL: $1"; exit 1; }
+
+# Capture the newest feature id under .output/features/ by snapshotting before
+# and after a command. Usage: before_ids=$(feature_ids); run cmd; new=$(newest_feature "$before_ids")
+feature_ids() { ls -1 "$TMP/.jonggrang/.output/features" 2>/dev/null | sort; }
+newest_feature() {
+  local before="$1"
+  diff <(printf '%s' "$before") <(feature_ids) | grep '^>' | sed 's/^> //' | tail -1
+}
+task_ids() { node -e "
+const lib=require('$REPO_ROOT/lib/jonggrang.js');
+const t=lib.getTasks(lib.tasksFileFor('$TMP','$1')).tasks.map(x=>x.id).join(',');
+process.stdout.write(t);
+" 2>/dev/null; }
+
+echo "Append-plan E2E smoke test"
+echo "  project : $TMP"
+echo "  jonggrang: $JG"
+echo "  skip work: $SKIP_WORK"
+echo "============================================="
+
+# --- preflight -------------------------------------------------------------
+[ -x "$JG" ] || die "'$JG' not found or not executable. Set JONGGRANG_BIN=/path/to/jonggrang"
+echo "  testing : $JG"
+echo "  (override with JONGGRANG_BIN=...; skip the heavy work step with SKIP_WORK=1)"
+
+# --- setup -----------------------------------------------------------------
+step "Setup: non-interactive init"
+( cd "$TMP" && git init -q && "$JG" init --name jg-append-e2e --tool jonggrang --autonomy autonomous --force ) \
+  || die "init failed"
+[ -f "$TMP/.jonggrang/jonggrang.json" ] && ok "project initialized" || bad "no jonggrang.json after init"
+
+# --- 1. first plan → task-001, task-002 ------------------------------------
+step "Plan feature A → expect task-001, task-002"
+BEFORE=$(feature_ids)
+( cd "$TMP" && "$JG" plan "simple hello endpoint that returns a greeting" --yes ) || die "plan A failed"
+FEATURE_A=$(newest_feature "$BEFORE")
+[ -n "$FEATURE_A" ] || die "could not capture feature A id"
+A_IDS=$(task_ids "$FEATURE_A")
+echo "  feature A: $FEATURE_A  tasks: $A_IDS"
+case "$A_IDS" in task-001,task-002) ok "A numbered from 001" ;; *) bad "expected task-001,task-002, got $A_IDS" ;; esac
+
+# --- 2. second plan → resets to task-001 -----------------------------------
+step "Plan feature B → expect reset to task-001"
+BEFORE=$(feature_ids)
+( cd "$TMP" && "$JG" plan "health check endpoint returning ok status" --yes ) || die "plan B failed"
+FEATURE_B=$(newest_feature "$BEFORE")
+[ -n "$FEATURE_B" ] || die "could not capture feature B id"
+B_IDS=$(task_ids "$FEATURE_B")
+echo "  feature B: $FEATURE_B  tasks: $B_IDS"
+case "$B_IDS" in task-001,task-002) ok "B reset to 001 (per-plan)" ;; *) bad "expected task-001,task-002, got $B_IDS" ;; esac
+
+# --- 3. ambiguous bare id → AMBIGUOUS_TASK_ID ------------------------------
+step "task done task-001 (no --feature) → expect AMBIGUOUS_TASK_ID"
+( cd "$TMP" && "$JG" task done task-001 ) 2>&1 | tee /tmp/jg-e2e-ambiguous.log
+if grep -q "AMBIGUOUS_TASK_ID\|exists in.*plans" /tmp/jg-e2e-ambiguous.log; then
+  ok "ambiguous id rejected with a clear error"
+else
+  bad "ambiguous id did NOT error (check /tmp/jg-e2e-ambiguous.log)"
+fi
+rm -f /tmp/jg-e2e-ambiguous.log
+
+# --- 4. --feature disambiguates --------------------------------------------
+step "task done task-001 --feature A → expect success"
+if ( cd "$TMP" && "$JG" task done task-001 --feature "$FEATURE_A" ) >/tmp/jg-e2e-done.log 2>&1; then
+  ok "disambiguated via --feature"
+else
+  bad "task done --feature failed (check /tmp/jg-e2e-done.log)"
+fi
+rm -f /tmp/jg-e2e-done.log
+
+# --- 5. append → numbering continues ---------------------------------------
+step "Append to A → expect task-003, task-004 (completed tasks untouched)"
+( cd "$TMP" && "$JG" plan --append "$FEATURE_A" "add input validation to the greeting endpoint" --yes ) \
+  || die "append failed"
+AP_IDS=$(task_ids "$FEATURE_A")
+echo "  feature A after append: $AP_IDS"
+case "$AP_IDS" in
+  task-001,task-002,task-003,task-004) ok "append continued numbering (003, 004)" ;;
+  *) bad "expected ...003,004, got $AP_IDS" ;;
+esac
+# completed task-001 must still be 'completed' (immutable)
+A_T1_STATUS=$(node -e "
+const lib=require('$REPO_ROOT/lib/jonggrang.js');
+const t=lib.getTasks(lib.tasksFileFor('$TMP','$FEATURE_A')).tasks.find(x=>x.id==='task-001');
+process.stdout.write(t?t.status:'missing');
+" 2>/dev/null)
+[ "$A_T1_STATUS" = "completed" ] && ok "task-001 still completed (immutable)" || bad "task-001 status=$A_T1_STATUS (should stay completed)"
+
+# plan.md should have an Appended section (not overwritten)
+if grep -q "## Appended" "$TMP/.jonggrang/.output/features/$FEATURE_A/plan.md" 2>/dev/null; then
+  ok "plan.md has '## Appended' section"
+else
+  bad "plan.md missing '## Appended' section"
+fi
+
+# --- 6. work re-runs appended tasks (phase 8 reopened) ---------------------
+if [ "$SKIP_WORK" = "1" ]; then
+  echo
+  echo "[6] (skipped — SKIP_WORK=1) work + phase-8 reopen check"
+else
+  step "work → expect phase 8 (Implement) reopened for appended tasks"
+  ( cd "$TMP" && "$JG" work ) || echo "  (work exited non-zero — check output above)"
+  PHASE8=$(node -e "
+const fs=require('fs'),yaml=require('js-yaml');
+const m=process.argv[1];
+try{const d=fs.readFileSync(m,'utf8');const y=yaml.load(d);
+ process.stdout.write((y.phases&&y.phases[8]?y.phases[8].status:'missing'));}catch(e){process.stdout.write('read-error');}
+" "$TMP/.jonggrang/.output/features/$FEATURE_A/MANIFEST.yaml" 2>/dev/null)
+  echo "  MANIFEST phase 8 status: $PHASE8"
+  case "$PHASE8" in completed) bad "phase 8 still completed — appended tasks may not run" ;; *) ok "phase 8 not completed (reopened/resumed)" ;; esac
+fi
+
+# --- summary ---------------------------------------------------------------
+echo
+echo "============================================="
+echo "  pass: $PASS   fail: $FAIL"
+echo "  project kept at: $TMP  (rm -rf to clean up)"
+echo "============================================="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/append-plan-smoke.sh
+++ b/scripts/append-plan-smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Deterministic lib-layer smoke test for per-plan task numbering + resolver (PR #75).
+# No agent backend needed — exercises lib/jonggrang.js directly.
+#
+# Usage:
+#   bash scripts/append-plan-smoke.sh
+#
+# What it verifies (design §10 invariants + §11 acceptance checklist):
+#   1. New feature A numbers tasks task-001, task-002
+#   2. New feature B resets to task-001, task-002
+#   3. Append into A continues at task-003, task-004
+#   4. Collision within a feature is rejected (not silently overwritten)
+#   5. Bare ambiguous id (task-001 in A and B) throws AMBIGUOUS_TASK_ID
+#   6. --feature scope disambiguates an ambiguous id
+#   7. Legacy single global match still resolves (backward compat)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# lib loads config from .jonggrang/jonggrang.json; create a minimal one so
+# require() doesn't blow up on missing config. addTask writes into
+# .output/features/<id>/ so pre-create the per-feature dirs it touches.
+mkdir -p "$TMP/.jonggrang/.output/features/feat-a"
+mkdir -p "$TMP/.jonggrang/.output/features/feat-b"
+mkdir -p "$TMP/.jonggrang/.output/features/feat-c"
+cat > "$TMP/.jonggrang/jonggrang.json" <<'JSON'
+{ "tool": "opencode", "mode": { "autonomy": "balanced" } }
+JSON
+
+cd "$REPO_ROOT"
+
+PASS=0; FAIL=0
+ok()   { echo "  ✅ $1"; PASS=$((PASS+1)); }
+bad()  { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+run()  { node -e "$1" -- "$TMP"; }
+
+echo "Append-plan lib tests (project root: $TMP)"
+echo "==========================================="
+
+# --- 1 & 2: per-feature numbering ------------------------------------------
+echo
+echo "[1] New feature A → task-001, task-002"
+A=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+lib.addTask(root,'feat-a',{title:'A1'}); lib.addTask(root,'feat-a',{title:'A2'});
+const t=lib.getTasks(lib.tasksFileFor(root,'feat-a')).tasks.map(x=>x.id).join(',');
+process.stdout.write(t);
+")
+[ "$A" = "task-001,task-002" ] && ok "A = $A" || bad "expected task-001,task-002, got $A"
+
+echo "[2] New feature B resets → task-001, task-002"
+B=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+lib.addTask(root,'feat-b',{title:'B1'}); lib.addTask(root,'feat-b',{title:'B2'});
+const t=lib.getTasks(lib.tasksFileFor(root,'feat-b')).tasks.map(x=>x.id).join(',');
+process.stdout.write(t);
+")
+[ "$B" = "task-001,task-002" ] && ok "B = $B" || bad "expected task-001,task-002, got $B"
+
+# --- 3: append continues ----------------------------------------------------
+echo "[3] Append into A continues → task-003, task-004"
+AP=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+lib.addTask(root,'feat-a',{title:'A3'}); lib.addTask(root,'feat-a',{title:'A4'});
+const t=lib.getTasks(lib.tasksFileFor(root,'feat-a')).tasks.map(x=>x.id).join(',');
+process.stdout.write(t);
+")
+[ "$AP" = "task-001,task-002,task-003,task-004" ] && ok "A after append = $AP" || bad "expected ...003,004, got $AP"
+
+# --- 4: collision within feature rejected ----------------------------------
+echo "[4] Duplicate id within a feature is rejected"
+COLL=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+try { lib.addTask(root,'feat-a',{id:'task-001',title:'dup'}); process.stdout.write('NO_THROW'); }
+catch(e){ process.stdout.write(e.message); }
+")
+case "$COLL" in
+  *already\ exists*) ok "rejected: $COLL" ;;
+  NO_THROW)          bad "addTask with duplicate id did NOT throw" ;;
+  *)                 bad "unexpected: $COLL" ;;
+esac
+
+# --- 5: ambiguous bare id throws AMBIGUOUS_TASK_ID -------------------------
+echo "[5] Ambiguous task-001 (in A and B) → AMBIGUOUS_TASK_ID"
+AMB=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+try { lib.findTaskFeature(root,'task-001',{throwOnAmbiguous:true}); process.stdout.write('NO_THROW'); }
+catch(e){ process.stdout.write(e.code||e.message); }
+")
+case "$AMB" in
+  AMBIGUOUS_TASK_ID) ok "threw AMBIGUOUS_TASK_ID" ;;
+  NO_THROW)          bad "ambiguous id did NOT throw" ;;
+  *)                 bad "unexpected: $AMB" ;;
+esac
+
+# --- 6: --feature disambiguates --------------------------------------------
+echo "[6] --feature feat-b disambiguates task-001 → feat-b"
+DIS=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+const fid=lib.findTaskFeature(root,'task-001',{featureId:'feat-b',throwOnAmbiguous:true});
+process.stdout.write(fid||'null');
+")
+[ "$DIS" = "feat-b" ] && ok "resolved → $DIS" || bad "expected feat-b, got $DIS"
+
+# --- 7: legacy single global match still resolves --------------------------
+echo "[7] Legacy single-match id resolves (backward compat)"
+LEG=$(run "
+const root=process.argv[1]; const lib=require('./lib/jonggrang.js');
+// feat-c has a globally-unique id task-099
+lib.addTask(root,'feat-c',{id:'task-099',title:'legacy'});
+const fid=lib.findTaskFeature(root,'task-099');  // no opts — old behavior
+process.stdout.write(fid||'null');
+")
+[ "$LEG" = "feat-c" ] && ok "legacy → $LEG" || bad "expected feat-c, got $LEG"
+
+# --- summary ---------------------------------------------------------------
+echo
+echo "==========================================="
+echo "  pass: $PASS   fail: $FAIL"
+echo "==========================================="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/test/task-numbering.test.js
+++ b/test/task-numbering.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Per-feature task numbering + bare-id resolver (feat/append-plan).
+// Numbering is PER-FEATURE: each feature numbers its own tasks from task-001,
+// so a bare id (task-001) recurs across features. findTaskFeature must resolve
+// within a feature scope, never silently pick the wrong plan.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../lib/jonggrang');
+
+function tmpRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'jong-numbering-'));
+}
+
+// In the real flow cmdApprove creates the feature dir + MANIFEST before the
+// decompose agent adds tasks. Mirror that: ensure the feature folder exists.
+function ensureFeature(root, featureId) {
+  fs.mkdirSync(path.join(root, '.jonggrang', '.output', 'features', featureId), { recursive: true });
+}
+function addTask(root, featureId, data) { ensureFeature(root, featureId); return lib.addTask(root, featureId, data); }
+function addTasksBulk(root, featureId, arr) { ensureFeature(root, featureId); return lib.addTasksBulk(root, featureId, arr); }
+
+test('new feature numbers tasks from task-001', () => {
+  const root = tmpRepo();
+  try {
+    const a = addTask(root, 'feat-a', { title: 'first' });
+    const b = addTask(root, 'feat-a', { title: 'second' });
+    assert.equal(a.id, 'task-001');
+    assert.equal(b.id, 'task-002');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a second feature resets numbering to task-001 (per-feature, not global)', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' });
+    addTask(root, 'feat-a', { title: 'a2' });
+    const b1 = addTask(root, 'feat-b', { title: 'b1' });
+    assert.equal(b1.id, 'task-001', 'second feature must start at task-001, not continue the global count');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('append into a feature continues from its own max', () => {
+  const root = tmpRepo();
+  try {
+    addTasksBulk(root, 'feat-a', [{ title: 'a1' }, { title: 'a2' }]); // 001, 002
+    const appended = addTasksBulk(root, 'feat-a', [{ title: 'a3' }, { title: 'a4' }]);
+    assert.deepEqual(appended.map(t => t.id), ['task-003', 'task-004']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('addTasksBulk on a fresh feature starts at task-001', () => {
+  const root = tmpRepo();
+  try {
+    const created = addTasksBulk(root, 'feat-x', [{ title: 'x1' }, { title: 'x2' }, { title: 'x3' }]);
+    assert.deepEqual(created.map(t => t.id), ['task-001', 'task-002', 'task-003']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findTaskFeature: unknown id → null', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' });
+    assert.equal(lib.findTaskFeature(root, 'task-999'), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findTaskFeature: single global match resolves (legacy globally-unique ids keep working)', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' });        // task-001 in feat-a only
+    addTask(root, 'feat-b', { title: 'b1' });         // task-001 in feat-b
+    addTask(root, 'feat-b', { title: 'b2' });         // task-002 ONLY in feat-b
+    assert.equal(lib.findTaskFeature(root, 'task-002'), 'feat-b');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findTaskFeature: colliding id resolves to the explicit opts.featureId', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' }); // task-001 in feat-a
+    addTask(root, 'feat-b', { title: 'b1' }); // task-001 in feat-b (collision)
+    assert.equal(lib.findTaskFeature(root, 'task-001', { featureId: 'feat-a' }), 'feat-a');
+    assert.equal(lib.findTaskFeature(root, 'task-001', { featureId: 'feat-b' }), 'feat-b');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findTaskFeature: colliding id with throwOnAmbiguous throws AMBIGUOUS_TASK_ID', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' });
+    addTask(root, 'feat-b', { title: 'b1' });
+    assert.throws(
+      () => lib.findTaskFeature(root, 'task-001', { throwOnAmbiguous: true }),
+      (err) => {
+        assert.equal(err.code, 'AMBIGUOUS_TASK_ID');
+        assert.deepEqual(new Set(err.candidates), new Set(['feat-a', 'feat-b']));
+        return true;
+      }
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findTaskFeature: colliding id without opts degrades to best-effort (no throw), never crashes callers', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' });
+    addTask(root, 'feat-b', { title: 'b1' });
+    const resolved = lib.findTaskFeature(root, 'task-001'); // programmatic caller, no hint
+    assert.ok(['feat-a', 'feat-b'].includes(resolved), 'returns one of the candidate features, does not throw');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Regression for the web-pipeline applySignal collision bug: a task_status signal
+// from feature B's worker must mark B's task-001 done, NOT feature A's task-001.
+// applySignal now passes the emitting group's featureId as the resolver hint.
+test('scoped resolve + markTaskDone hits the correct feature (applySignal collision fix)', () => {
+  const root = tmpRepo();
+  try {
+    addTask(root, 'feat-a', { title: 'a1' }); // feat-a/task-001
+    addTask(root, 'feat-b', { title: 'b1' }); // feat-b/task-001 (same bare id)
+
+    // Simulate applySignal for a signal emitted by feat-b's worker.
+    const fid = lib.findTaskFeature(root, 'task-001', { featureId: 'feat-b' });
+    assert.equal(fid, 'feat-b');
+    lib.markTaskDone(lib.tasksFileFor(root, fid), 'task-001');
+
+    assert.equal(lib.getTask(lib.tasksFileFor(root, 'feat-b'), 'task-001').status, 'completed');
+    assert.equal(lib.getTask(lib.tasksFileFor(root, 'feat-a'), 'task-001').status, 'pending',
+      'feature A must be untouched — no cross-feature write');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What & why

Adds the ability to **extend an approved plan** with additional scope — decomposing the extra work as tasks **appended** to the existing feature — and fixes task numbering so **each plan numbers its tasks from `task-001`** (an append continues from that plan's own max, instead of one global counter across all features).

Design doc: `docs/plans/2026-07-01-append-plan-extend-tasks.md`

## Changes

**Per-plan numbering**
- `addTask` / `addTasksBulk` seed from the feature's own tasks (was globally monotonic).
- Decompose prompt: a new plan starts at `task-001`; **APPEND MODE** continues from the plan's max and never renumbers/modifies completed tasks.
- `findTaskFeature` resolves a bare id within a feature scope: explicit `--feature` → active feature → single global match (legacy globally-unique ids still resolve), else a clear `AMBIGUOUS_TASK_ID` error (no silent wrong-task picks).

**Append / extend**
- `jonggrang plan --append <featureId> "scope"` generates a delta draft stamped `append_to: <id>`.
- `jonggrang approve --feature <id>` (and auto-detect of `append_to`) decomposes **additional** tasks into the existing feature, merges a `## Appended <ts>` section into its `plan.md`, and **re-opens the execution phases** so `jonggrang work` runs the newly appended tasks.
- `plan --append --deep`: a discovery + analysis pre-pass on the added scope enriches the extension (`## Affected Areas` / `## Risks` + `depth: deep`).
- **Web:** "Extend this plan" button + a "Deep analysis" toggle in `PlanView.vue`, backed by `POST /api/projects/:id/plans/:featureId/extend`.

Backward compatible: existing features keep their current ids (no renumber/migration); legacy globally-unique ids still resolve by single match.

## Testing

- **Unit / numbering:** new feature → `001`; second feature resets to `001`; append continues; resolver disambiguation + legacy single-match. ✅
- **CLI (real agent):** new plan → `001,002`; `plan --append --yes` → `003-007` continue, completed preserved, `plan.md` merged, single feature. ✅
- **Full lifecycle (×3):** plan → approve → `work` (implemented + committed) → append → `work` again → executed appended tasks. 6 tasks done, atomic commits, module works. ✅
- **Web (browser, `:local` sandbox):** new plan → `001,002`; "Extend" → `003,004` continue; **Deep toggle** → draft with `depth: deep` + Affected Areas + `append_to` → approve → `005-009` continue, `plan.md` merged. ✅
- **Regression:** `npm test` 10/10; all changed JS syntax-clean; client builds.

### Bugs caught & fixed during testing
1. `parsePlanFrontmatter` (bin) dropped the `append_to` field → append was treated as a new feature. Fixed (parse it + strip surrounding quotes).
2. After an append, `jonggrang work` skipped Implement because the MANIFEST's phase 8 stayed `completed` → appended tasks were never executed. Fixed by re-opening the execution phases (≥8) on append.

## Follow-ups (not in this PR)
Per the repo's "Iron Rule", user-facing docs still need updating: `README.md` (Commands at a Glance + flags), `docs/WORKFLOW.md` ("Modifying a plan after approval"), `docs/JONGGRANG.md` (task-state / numbering), `docs/UI.md` (Extend this plan). Listed in the design doc §12.
