### PR TITLE
fix(pi-extension): repair before_agent_start callback (parse error #76)

### DIFF
--- a/hooks/pi/jonggrang-extension.ts
+++ b/hooks/pi/jonggrang-extension.ts
@@ -217,8 +217,10 @@ export default function (pi: ExtensionAPI) {
     codemapInjected = true;
     const banner = codemapStale
       ? `\n\n> ⚠️ Codemap may be outdated. Run \`jonggrang codemap --refresh\` to update.`
+      : "";
     const section = `\n\n## Codebase Map (LLM-free, cached)\n\n${codemapMarkdown}${banner}`;
     return { systemPrompt: section + event.systemPrompt };
+  });
 
   // ── LAYER 2: tool_call → fileProtection + secretCommandBlock + agentFirst + compactionGate + taskRoleClaim ─
   // event.toolName is the Pi API property (lowercase: "read", "edit", "write", "bash", "grep", "find", "ls")


### PR DESCRIPTION
## What & why

Fixes #76.

`jonggrang agent` fails immediately with a TS parse error because `hooks/pi/jonggrang-extension.ts` does not parse. The Pi SDK loads this extension raw (no build step), so any parse error kills the extension — which breaks the entire `jonggrang agent` TUI and any Pi SDK `runAgent` path that loads it (worktree workers included).

## Root cause

Two syntax errors in the `before_agent_start` handler (lines 214-222):

```typescript
pi.on("before_agent_start", (event) => {
  ...
  const banner = codemapStale          // ← incomplete ternary: no ': ...', no ';'
    ? `... update.`
  const section = `...`;              // ← parser chokes here: "expected ':'"
  return { systemPrompt: ... };
                                     // ← missing '});' to close the callback
  // ── LAYER 2: tool_call → ...
```

## Fix

```typescript
pi.on("before_agent_start", (event) => {
  ...
  const banner = codemapStale
    ? `... update.`
    : "";
  const section = `...`;
  return { systemPrompt: ... };
});
```

Add the `: ""` else branch and close the callback with `});`.

## Validation

```bash
# before: parse error at :220:4
# after:
node --experimental-strip-types -e "import('./hooks/pi/jonggrang-extension.ts')"
# → IMPORT OK
```

The repo's `npm run check:syntax` only scans `.js` files (not `.ts`), so this wasn't caught by CI. Worth considering a TS parse check for `hooks/pi/*.ts` as a follow-up.

## Provenance

Introduced in `3d856ea2` (2026-06-17). Present on `main` — not a regression from PR #75.