### PR TITLE
fix: inject base branch information into LLM prompts and frontmatter for improved codebase navigation

### DIFF
--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1025,6 +1025,7 @@ function parsePlanFrontmatter(content) {
   return {
     feature:     get('feature'),
     branch:      get('branch'),
+    base:        get('base'),
     work_type:   get('work_type'),
     description: get('description'),
     created_at:  get('created_at'),
@@ -1382,7 +1383,16 @@ async function cmdPlan(args, opts = {}) {
 
   if (!await ensureInit()) return;
 
-  const resolvedBase = baseBranch || lib.resolveBaseBranch(PROJECT_ROOT);
+  let resolvedBase = baseBranch;
+  if (appendTo && !resolvedBase && fs.existsSync(appendPlanPath)) {
+    const fm = lib.parsePlanFrontmatter(appendPlanPath);
+    if (fm.base) {
+      resolvedBase = fm.base;
+    }
+  }
+  if (!resolvedBase) {
+    resolvedBase = lib.resolveBaseBranch(PROJECT_ROOT);
+  }
 
   // ── Revise mode: AI rewrites an existing draft ──────────────
   if (reviseMode) {

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1382,6 +1382,8 @@ async function cmdPlan(args, opts = {}) {
 
   if (!await ensureInit()) return;
 
+  const resolvedBase = baseBranch || lib.resolveBaseBranch(PROJECT_ROOT);
+
   // ── Revise mode: AI rewrites an existing draft ──────────────
   if (reviseMode) {
     const sid = sessionId || lib.resolveActiveDraft(PROJECT_ROOT);
@@ -1519,7 +1521,7 @@ async function cmdPlan(args, opts = {}) {
     if (!answers && !noAsk && !autoApprove) {
       lib.clearPlanQuestions(questionsFile);
       logInfo('Analyzing goal — the agent may ask clarifying questions first...');
-      const qPrompt = lib.buildPlanQuestionsPrompt(description, CONFIG_FILE, srcPath);
+      const qPrompt = lib.buildPlanQuestionsPrompt(description, CONFIG_FILE, srcPath, resolvedBase);
       await lib.runAgent(qPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
       const q = lib.getPlanQuestions(questionsFile);
       if (q.questions && q.questions.length > 0) {
@@ -1564,7 +1566,7 @@ async function cmdPlan(args, opts = {}) {
       const discoveryFile = path.join(draftDir, 'deep-plan-discovery.md');
       const analysisFile = path.join(draftDir, 'deep-plan-analysis.md');
       logInfo(`${BOLD}[1/3]${NC} Codebase discovery (for the additional scope)...`);
-      await lib.runAgent(lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile), TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
+      await lib.runAgent(lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile, null, { baseBranch: resolvedBase }), TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
       if (lib.fileExists(discoveryFile)) {
         const discoveryContent = fs.readFileSync(discoveryFile, 'utf8');
         logInfo(`${BOLD}[2/3]${NC} Complexity analysis & brainstorm...`);
@@ -1578,7 +1580,7 @@ async function cmdPlan(args, opts = {}) {
       logInfo('Generating extension plan...');
     }
 
-    const prompt = lib.buildAppendPlanPrompt(description, existingPlan, existingTasks, CONFIG_FILE, PROJECT_ROOT, draftFile, appendTo, { deep: deepCtx });
+    const prompt = lib.buildAppendPlanPrompt(description, existingPlan, existingTasks, CONFIG_FILE, PROJECT_ROOT, draftFile, appendTo, { deep: deepCtx, baseBranch: resolvedBase });
     await lib.runAgent(prompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
     const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
     if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1612,13 +1614,13 @@ async function cmdPlan(args, opts = {}) {
 
     // Phase 1: Discovery
     logInfo(`${BOLD}[1/3]${NC} Codebase discovery...`);
-    const discoveryPrompt = lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile, srcPath, { clarifications });
+    const discoveryPrompt = lib.buildDeepPlanDiscoveryPrompt(description, CONFIG_FILE, discoveryFile, srcPath, { clarifications, baseBranch: resolvedBase });
     await lib.runAgent(discoveryPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
 
     if (!lib.fileExists(discoveryFile)) {
       logError(`Discovery agent did not write ${discoveryFile}`);
       logInfo('Falling back to standard plan generation...');
-      const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications });
+      const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications, baseBranch: resolvedBase });
       await lib.runAgent(fallbackPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
       const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
       if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1633,7 +1635,7 @@ async function cmdPlan(args, opts = {}) {
       if (!lib.fileExists(analysisFile)) {
         logError(`Analysis agent did not write ${analysisFile}`);
         logInfo('Falling back to standard plan generation using discovery only...');
-        const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications });
+        const fallbackPrompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications, baseBranch: resolvedBase });
         await lib.runAgent(fallbackPrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
         const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
         if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1643,7 +1645,7 @@ async function cmdPlan(args, opts = {}) {
         logInfo(`${BOLD}[3/3]${NC} Condensing into enriched plan.md...`);
         const analysisContent = fs.readFileSync(analysisFile, 'utf8');
         const condensePrompt = lib.buildDeepPlanCondensePrompt(
-          description, discoveryContent, analysisContent, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications }
+          description, discoveryContent, analysisContent, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications, baseBranch: resolvedBase }
         );
         await lib.runAgent(condensePrompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
         const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
@@ -1670,7 +1672,7 @@ async function cmdPlan(args, opts = {}) {
     // Clear stale feedback-loop state — planning is read-only, must not be blocked.
     feedback.clearFeedbackState(PROJECT_ROOT);
 
-    const prompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications });
+    const prompt = lib.buildDraftPlanPrompt(description, CONFIG_FILE, PROJECT_ROOT, draftFile, srcPath, { clarifications, baseBranch: resolvedBase });
     await lib.runAgent(prompt, TOOL, 'autonomous', PROJECT_ROOT, { debug: DEBUG, model: MODEL, effort: EFFORT });
     const _v = lib.verifyDraftWritten(PROJECT_ROOT, draftFile);
     if (_v === 'moved') logWarn(`Agent wrote to root plan.md — moved to session ${sid}.`);
@@ -1687,8 +1689,8 @@ async function cmdPlan(args, opts = {}) {
   // write it into the generated plan.md frontmatter (overriding anything the AI
   // may have put there). Covers both deep + standard generation paths above.
   // Warn if it didn't take — otherwise the worktree silently cuts from HEAD.
-  if (baseBranch && lib.fileExists(draftFile) && !lib.setPlanBase(draftFile, baseBranch)) {
-    logWarn(`Could not write base "${baseBranch}" to the plan frontmatter — the worktree will start from HEAD unless you set it manually.`);
+  if (resolvedBase && lib.fileExists(draftFile) && !lib.setPlanBase(draftFile, resolvedBase)) {
+    logWarn(`Could not write base "${resolvedBase}" to the plan frontmatter — the worktree will start from HEAD unless you set it manually.`);
   }
 
   if (autoApprove) {

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -790,6 +790,18 @@ function buildProjectContext(projectRootOrConfigFile, opts = {}) {
   return block;
 }
 
+function buildBaseBranchContext(branchToUse) {
+  return `## Base Branch Context
+- Read AGENTS.md for project conventions
+- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`.
+  If the current branch differs from \`${branchToUse}\`, you must query the base branch files using \`git show\`.
+  Because \`${branchToUse}\` may only exist on the remote (e.g. if the local branch hasn't been checked out yet), follow these steps to read a file from the base branch safely:
+  1. Check if the local ref exists: run \`git rev-parse --verify ${branchToUse}\` (checking stdout/exit status).
+  2. If local verification succeeds, query/read the file with: \`git show ${branchToUse}:<path>\`.
+  3. If local verification fails, use the remote ref: query/read the file with \`git show origin/${branchToUse}:<path>\`. If this fails or the remote ref is not found, run \`git fetch origin ${branchToUse}\` first, then run \`git show origin/${branchToUse}:<path>\`.
+  Do NOT fallback to reading current local files directly if the base branch differs, as they may contain uncommitted or unrelated changes.`;
+}
+
 function buildWorkPrompt(taskId, tasksFile, mode, testFeedback) {
   const task = getTask(tasksFile, taskId);
   if (!task) return '';
@@ -910,9 +922,7 @@ ${buildFeatureSection(description, srcPath)}
 
 ${buildProjectContext(configFile, { maxChars: 3000 })}
 
-## Project Context
-- Read AGENTS.md for project conventions
-- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
+${buildBaseBranchContext(branchToUse)}
 
 ${completedSection}${clarSection}## Your Task
 
@@ -974,6 +984,7 @@ function buildAppendPlanPrompt(additionalScope, existingPlanContent, existingTas
   })();
   const featureSlug = fm.feature || featureId;
   const branch = fm.branch || `feat/${featureSlug}`;
+  const branchToUse = opts.baseBranch || fm.base || (projectRoot ? resolveBaseBranch(projectRoot) : 'main');
   const taskLines = (existingTasks || [])
     .map(t => `- ${t.id} [${t.status}] ${t.title}`).join('\n');
   const now = new Date().toISOString();
@@ -1006,6 +1017,8 @@ function buildAppendPlanPrompt(additionalScope, existingPlanContent, existingTas
 
 ${buildProjectContext(configFile, { maxChars: 2500 })}
 
+${buildBaseBranchContext(branchToUse)}
+
 ## Existing Plan (already approved — context only; do NOT redo its work)
 \`\`\`markdown
 ${(existingPlanContent || '').trim()}
@@ -1026,6 +1039,7 @@ existing plan. Do NOT restate or redo anything already covered. Write it to
 ---
 feature: ${featureSlug}
 branch: ${branch}
+base: "${branchToUse}"
 work_type: BUGFIX|SMALL|MEDIUM|LARGE
 description: one-line summary of the ADDITIONAL scope
 append_to: ${featureId}${deepFrontmatter}
@@ -1053,7 +1067,7 @@ Builds on the existing plan's work.${deepSectionsSpec}
 
 ## Rules
 - Plan ONLY the additional scope. The existing tasks above are done/decomposed already — never re-plan them.
-- Keep the frontmatter \`feature\`/\`branch\` identical to the existing plan, and keep \`append_to: ${featureId}\` exactly as shown.
+- Keep the frontmatter \`feature\`/\`branch\`/\`base\` identical to the existing plan, and keep \`append_to: ${featureId}\` exactly as shown.
 - 3-8 phases max, high-level; do NOT write code or the tasks file.${deepRule}
 - After writing the plan, output exactly: "Draft plan written to ${draftPath}"`;
 }
@@ -2685,9 +2699,7 @@ ${buildFeatureSection(description, srcPath, 'Feature Request')}
 
 ${buildProjectContext(configFile, { maxChars: 3500 })}
 
-## Project Context
-- Read AGENTS.md for project conventions and patterns
-- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
+${buildBaseBranchContext(branchToUse)}
 ${clarSection}
 ## Your Task
 
@@ -3087,10 +3099,8 @@ function buildPlanQuestionsPrompt(description, configFile, srcPath = null, baseB
 
 ${buildFeatureSection(description, srcPath, 'Feature Request')}
 
-## Project Context
-${configSection}- Read AGENTS.md for project conventions
-- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
-- Skim the codebase (ls/find/read) only as much as needed to judge what is ambiguous
+${configSection}${buildBaseBranchContext(branchToUse)}
+- Skim the codebase (ls/find/read) only as much as needed on the base branch to judge what is ambiguous
 
 ## Your Task
 1. **Analyze the goal.** In 1-2 sentences, restate what the user wants to achieve.
@@ -3195,6 +3205,7 @@ module.exports = {
   // Prompt builders
   buildFeatureSection,
   buildProjectContext,
+  buildBaseBranchContext,
   buildDraftPlanPrompt,
   buildAppendPlanPrompt,
   buildRevisePlanPrompt,

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -881,6 +881,7 @@ ${bugCmd}
  * The AI writes the draft to `draftPath` but does NOT touch jonggrang-tasks.json.
  */
 function buildDraftPlanPrompt(description, configFile, projectRoot, draftPath, srcPath = null, opts = {}) {
+  const branchToUse = opts.baseBranch || (projectRoot ? resolveBaseBranch(projectRoot) : 'main');
   let configSection = '';
   if (configFile && fileExists(configFile)) {
     const cfg = readJSON(configFile);
@@ -909,6 +910,10 @@ ${buildFeatureSection(description, srcPath)}
 
 ${buildProjectContext(configFile, { maxChars: 3000 })}
 
+## Project Context
+- Read AGENTS.md for project conventions
+- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
+
 ${completedSection}${clarSection}## Your Task
 
 Create a high-level plan for this feature. Write it to \`${draftPath}\` using EXACTLY this format:
@@ -917,6 +922,7 @@ Create a high-level plan for this feature. Write it to \`${draftPath}\` using EX
 ---
 feature: short-kebab-case-name
 branch: feat/short-kebab-case-name
+base: "${branchToUse}"
 work_type: BUGFIX|SMALL|MEDIUM|LARGE
 description: one-line summary of the feature
 created_at: ${now}
@@ -2663,6 +2669,7 @@ Rules:
  * feature, then writes a discovery report to .jonggrang/.ephemeral/deep-plan-discovery.md
  */
 function buildDeepPlanDiscoveryPrompt(description, configFile, discoveryPath, srcPath = null, opts = {}) {
+  const branchToUse = opts.baseBranch || (configFile && fileExists(configFile) ? resolveBaseBranch(path.dirname(configFile)) : 'main');
   let configSection = '';
   if (configFile && fileExists(configFile)) {
     const cfg = readJSON(configFile);
@@ -2677,6 +2684,10 @@ function buildDeepPlanDiscoveryPrompt(description, configFile, discoveryPath, sr
 ${buildFeatureSection(description, srcPath, 'Feature Request')}
 
 ${buildProjectContext(configFile, { maxChars: 3500 })}
+
+## Project Context
+- Read AGENTS.md for project conventions and patterns
+- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
 ${clarSection}
 ## Your Task
 
@@ -2807,6 +2818,7 @@ After writing the file, output exactly: "Analysis complete: ${analysisPath}"`;
  * Reads both ephemeral files and writes a richer plan.md than the standard one.
  */
 function buildDeepPlanCondensePrompt(description, discoveryContent, analysisContent, configFile, projectRoot, draftPath, srcPath = null, opts = {}) {
+  const branchToUse = opts.baseBranch || (projectRoot ? resolveBaseBranch(projectRoot) : 'main');
   let completedSection = '';
   const allTasks = getAllTasks(projectRoot);
   const done = allTasks.tasks.filter(t => t.status === 'completed');
@@ -2825,6 +2837,9 @@ function buildDeepPlanCondensePrompt(description, discoveryContent, analysisCont
 ${buildFeatureSection(description, srcPath, 'Feature Request')}
 
 ${buildProjectContext(configFile, { maxChars: 3000 })}
+
+## Project Context
+The base branch for this feature is \`${branchToUse}\`.
 
 ${clarSection}## Discovery Report
 \`\`\`markdown
@@ -2848,6 +2863,7 @@ Write \`${draftPath}\` using EXACTLY this format (enriched version for --deep pl
 ---
 feature: short-kebab-case-name
 branch: feat/short-kebab-case-name
+base: "${branchToUse}"
 work_type: BUGFIX|SMALL|MEDIUM|LARGE
 description: one-line summary of the feature
 created_at: ${now}
@@ -3059,7 +3075,8 @@ function formatClarifications(answers) {
  * (it never writes plan.md here). If the request is unambiguous it outputs
  * NO_QUESTIONS and stops.
  */
-function buildPlanQuestionsPrompt(description, configFile, srcPath = null) {
+function buildPlanQuestionsPrompt(description, configFile, srcPath = null, baseBranch = null) {
+  const branchToUse = baseBranch || (configFile && fileExists(configFile) ? resolveBaseBranch(path.dirname(configFile)) : 'main');
   let configSection = '';
   if (configFile && fileExists(configFile)) {
     const cfg = readJSON(configFile);
@@ -3072,6 +3089,7 @@ ${buildFeatureSection(description, srcPath, 'Feature Request')}
 
 ## Project Context
 ${configSection}- Read AGENTS.md for project conventions
+- Explore the codebase to understand existing structure on the base branch \`${branchToUse}\`. If the current branch differs, query the base branch (e.g. using \`git show ${branchToUse}:<path>\` or similar) to ensure you are analyzing the correct files.
 - Skim the codebase (ls/find/read) only as much as needed to judge what is ambiguous
 
 ## Your Task

--- a/test/draft-placement.test.js
+++ b/test/draft-placement.test.js
@@ -47,6 +47,28 @@ test('buildDeepPlanCondensePrompt references draftPath and never the root plan.m
     'prompt must not hardcode the legacy root .jonggrang/plan.md');
 });
 
+test('buildDraftPlanPrompt includes base branch instructions and frontmatter entry', () => {
+  const prompt = lib.buildDraftPlanPrompt('a feature', null, os.tmpdir(), FAKE_DRAFT, null, { baseBranch: 'my-custom-branch' });
+  assert.ok(prompt.includes('base branch `my-custom-branch`'), 'prompt should mention the base branch');
+  assert.ok(prompt.includes('base: "my-custom-branch"'), 'prompt should specify the base branch in the frontmatter template');
+});
+
+test('buildDeepPlanDiscoveryPrompt includes base branch instructions', () => {
+  const prompt = lib.buildDeepPlanDiscoveryPrompt('a feature', null, FAKE_DRAFT, null, { baseBranch: 'my-custom-branch' });
+  assert.ok(prompt.includes('base branch `my-custom-branch`'), 'prompt should mention the base branch in discovery');
+});
+
+test('buildDeepPlanCondensePrompt includes base branch instructions and frontmatter entry', () => {
+  const prompt = lib.buildDeepPlanCondensePrompt('a feature', 'discovery', 'analysis', null, os.tmpdir(), FAKE_DRAFT, null, { baseBranch: 'my-custom-branch' });
+  assert.ok(prompt.includes('base branch for this feature is `my-custom-branch`'), 'prompt should mention the base branch in condense');
+  assert.ok(prompt.includes('base: "my-custom-branch"'), 'prompt should specify the base branch in the frontmatter template');
+});
+
+test('buildPlanQuestionsPrompt includes base branch instructions', () => {
+  const prompt = lib.buildPlanQuestionsPrompt('a feature', null, null, 'my-custom-branch');
+  assert.ok(prompt.includes('base branch `my-custom-branch`'), 'prompt should mention the base branch in questions');
+});
+
 // ── Layer 2: verifyDraftWritten self-heals stray agent writes ────────────
 
 function tempProject() {

--- a/test/draft-placement.test.js
+++ b/test/draft-placement.test.js
@@ -69,6 +69,35 @@ test('buildPlanQuestionsPrompt includes base branch instructions', () => {
   assert.ok(prompt.includes('base branch `my-custom-branch`'), 'prompt should mention the base branch in questions');
 });
 
+test('buildAppendPlanPrompt includes base branch instructions and frontmatter entry', () => {
+  // Scenario 1: Base branch passed through options overrides everything
+  const prompt1 = lib.buildAppendPlanPrompt(
+    'additional scope',
+    '---\nfeature: my-feat\nbase: "old-base"\n---\n# plan',
+    [],
+    null,
+    os.tmpdir(),
+    FAKE_DRAFT,
+    'my-feat',
+    { baseBranch: 'my-custom-branch' }
+  );
+  assert.ok(prompt1.includes('base branch `my-custom-branch`'), 'prompt should mention the custom base branch');
+  assert.ok(prompt1.includes('base: "my-custom-branch"'), 'prompt should specify the custom base branch in the frontmatter template');
+
+  // Scenario 2: Base branch is inherited from the existing plan frontmatter when option is not set
+  const prompt2 = lib.buildAppendPlanPrompt(
+    'additional scope',
+    '---\nfeature: my-feat\nbase: "my-inherited-branch"\n---\n# plan',
+    [],
+    null,
+    os.tmpdir(),
+    FAKE_DRAFT,
+    'my-feat'
+  );
+  assert.ok(prompt2.includes('base branch `my-inherited-branch`'), 'prompt should inherit the base branch from the existing plan');
+  assert.ok(prompt2.includes('base: "my-inherited-branch"'), 'prompt should specify the inherited base branch in the frontmatter template');
+});
+
 // ── Layer 2: verifyDraftWritten self-heals stray agent writes ────────────
 
 function tempProject() {


### PR DESCRIPTION
## Summary
Previously, the feature planning process in `jonggrang` would only query or explore codebase files based on the `main` (or default) branch. In projects where the base/target branch is not `main`, or where we target a specific branch using the `--base` flag or interactive inputs during `jonggrang plan`, the agent prompts were still generated to check `main` and omitted writing the custom base branch configuration to the plan frontmatter.

This PR addresses this by resolving the base branch (using the `--base` option, falling back to the default resolved base branch) early in `cmdPlan` and passing this branch down to all prompt generators (`buildPlanQuestionsPrompt`, `buildDraftPlanPrompt`, `buildDeepPlanDiscoveryPrompt`, and `buildDeepPlanCondensePrompt`). It also ensures that the target plan frontmatter explicitly templates `base: "<branch>"` and writes it to the plan's frontmatter draft.

## What've Changed
* **Resolved Base Branch Early**: Updated `cmdPlan` in `bin/jonggrang.js` to resolve the target base branch (`resolvedBase`) upfront.
* **Planning Prompts Branch Awareness**:
  * Modified `buildPlanQuestionsPrompt` in `lib/jonggrang.js` to accept `baseBranch` and instruct the intake agent to explore the codebase on that branch.
  * Updated `buildDraftPlanPrompt`, `buildDeepPlanDiscoveryPrompt`, and `buildDeepPlanCondensePrompt` to receive `baseBranch` through `opts.baseBranch` and inject appropriate instructions for the agent to query and navigate codebase files relative to it.
* **Plan Frontmatter Base Insertion**: Ensured the resolved base branch is explicitly documented via `base: "<branch>"` inside the draft plan templates, and stamped by the orchestrator.
* **Test Suite Verification**: Updated prompt unit tests in `test/draft-placement.test.js` to verify the base branch instructions and frontmatter injection, and added a test for the Q&A prompt.

## How to Test
1. Run the test suite:
   ```bash
   npm test
   ```
2. Verify that the new tests for `buildDraftPlanPrompt`, `buildDeepPlanDiscoveryPrompt`, `buildDeepPlanCondensePrompt`, and `buildPlanQuestionsPrompt` pass.
3. Test manually by running `jonggrang plan --base <branch-name>` and verifying that:
   - The generated AI planning/discovery prompt instructs the LLM to read and explore codebase files on `<branch-name>`.
   - The final plan draft `plan.md` has `base: "<branch-name>"` set in its YAML frontmatter.