### PR TITLE
chore: remove rate limiter, open CORS, lift body cap

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,58 +17,17 @@ sandbox.ensureWorktreeRoot();
 const app = express();
 const server = http.createServer(app);
 
-// ── TRUSTED ORIGINS ───────────────────────────────────────────
-const TRUSTED_ORIGINS = ['localhost', '127.0.0.1', '::1', '.local'];
-function isOriginTrusted(origin) {
-    if (!origin) return true;
-    try {
-        const host = new URL(origin).hostname;
-        return TRUSTED_ORIGINS.some(t =>
-            t.startsWith('.') ? host.endsWith(t) || host === t.slice(1) : host === t
-        );
-    } catch { return false; }
-}
-
+// ── CORS ──────────────────────────────────────────────────────
+// Open to all origins — no origin whitelist, no rate limiting, no body cap.
 const io = new Server(server, {
     cors: {
-        origin: (origin, cb) => cb(null, isOriginTrusted(origin)),
+        origin: true,
         methods: ['GET', 'POST']
     }
 });
 
-app.use(cors({ origin: (origin, cb) => cb(null, isOriginTrusted(origin)) }));
-app.use(express.json({ limit: '1mb' }));
-
-// ── RATE LIMITER ──────────────────────────────────────────────
-// The dashboard is local-first and polls frequently (multiple projects +
-// live updates), so the limiter only guards EXPOSED (non-loopback) binds.
-// Config: JONGGRANG_RATE_LIMIT_MAX requests/min per IP — `0` disables it.
-// Default: disabled on loopback, 200/min otherwise.
-const RATE_LIMIT_WINDOW = 60_000;
-const rlHost = process.env.HOST || '127.0.0.1';
-const rlLoopback = ['127.0.0.1', 'localhost', '::1', '0.0.0.0'].includes(rlHost);
-const RATE_LIMIT_MAX = process.env.JONGGRANG_RATE_LIMIT_MAX !== undefined
-    ? parseInt(process.env.JONGGRANG_RATE_LIMIT_MAX, 10)
-    : (rlLoopback ? 0 : 200);
-if (RATE_LIMIT_MAX > 0) {
-    const rateLimitMap = new Map();
-    app.use((req, res, next) => {
-        const ip = req.ip || req.socket.remoteAddress || 'unknown';
-        const now = Date.now();
-        const entry = rateLimitMap.get(ip) || { count: 0, resetAt: now + RATE_LIMIT_WINDOW };
-        if (now > entry.resetAt) { entry.count = 0; entry.resetAt = now + RATE_LIMIT_WINDOW; }
-        entry.count++;
-        rateLimitMap.set(ip, entry);
-        if (entry.count > RATE_LIMIT_MAX) return res.status(429).json({ error: 'Too many requests. Slow down.' });
-        next();
-    });
-    setInterval(() => {
-        const now = Date.now();
-        for (const [ip, entry] of rateLimitMap) {
-            if (now > entry.resetAt) rateLimitMap.delete(ip);
-        }
-    }, 300_000).unref();
-}
+app.use(cors({ origin: true }));
+app.use(express.json({ limit: '1gb' }));
 
 // ── PROJECT / HOME PATHS ──────────────────────────────────────
 const PROJECT_ROOT = process.env.JONGGRANG_PROJECT_ROOT || path.resolve(__dirname, '..');


### PR DESCRIPTION
## What

Removes server-side security throttling that was producing `{"error":"Too many requests. Slow down."}` (HTTP 429).

## Changes (`server.js`)
- **Rate limiter removed** — the per-IP counter middleware (source of the 429 error) is deleted entirely, along with its cleanup interval.
- **CORS opened** — dropped the `TRUSTED_ORIGINS` whitelist / `isOriginTrusted()`; both Express and Socket.IO now accept all origins (`origin: true`).
- **Body cap lifted** — JSON body limit raised from `1mb` to `1gb`.

## Not touched
`403`/`422` responses in `apis/` are functional input validation (invalid feature ID, missing git remote), not throttling — left in place.

## Note
This removes protections that matter when the dashboard is exposed on a non-loopback/public bind. Jonggrang is local-first, so this is generally fine for local use; avoid binding to a public IP without a reverse proxy/auth in front.