### PR TITLE
test: add agent-browser container smoke guard

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,9 +50,16 @@ jobs:
           file: ./docker/Dockerfile.dev
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev
+            ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev-${{ github.sha }}
           cache-from: type=gha,scope=agent-dev
           cache-to: type=gha,mode=max,scope=agent-dev
+
+      - name: Smoke-test agent-browser
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev-${{ github.sha }}
+        run: bash scripts/agent-browser-smoke.sh "$IMAGE"
 
   # Pushes to main and release tags build & push latest + tunnel (multi-arch).
   # On a release tag (vX.Y.Z) the images are also tagged X.Y.Z and X.Y.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ jonggrang work --feature feat-abc123 # Target a specific approved feature (multi
   - Jonggrang (Pi SDK) → `npm install -g @earendil-works/pi-coding-agent`
 - [jq](https://jqlang.github.io/jq/) → `brew install jq`
 - git
+- *(optional)* [agent-browser](https://github.com/vercel-labs/agent-browser) → `npm install -g agent-browser && agent-browser install` — lets agents validate frontend design in a real headless browser. Preinstalled (with Chrome) in the Jonggrang sandbox image.
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,21 @@ RUN npm install -g --no-fund --no-audit \
     jonggrang \
     @anthropic-ai/claude-code \
     opencode-ai \
-    @openai/codex
+    @openai/codex \
+    agent-browser
+
+# ── agent-browser Chrome (frontend design validation for every agent) ─────────
+# Bundles a headless Chromium + Linux system libs so `agent-browser` works
+# offline inside the sandbox. Chrome for Testing ships Linux amd64 only, so on
+# arm64 we install Playwright's Chromium build (agent-browser auto-detects it).
+# All coding agents use this to validate frontend design
+# (see skills/library/frontend/validating-visual-design).
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "amd64" ]; then \
+         agent-browser install --with-deps; \
+       else \
+         npx --yes playwright@latest install --with-deps chromium; \
+       fi
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,16 +49,13 @@ RUN npm install -g --no-fund --no-audit \
 
 # ── agent-browser Chrome (frontend design validation for every agent) ─────────
 # Bundles a headless Chromium + Linux system libs so `agent-browser` works
-# offline inside the sandbox. Chrome for Testing ships Linux amd64 only, so on
-# arm64 we install Playwright's Chromium build (agent-browser auto-detects it).
-# All coding agents use this to validate frontend design
+# offline inside the sandbox. We use Playwright's Chromium build because it is
+# cross-arch (Chrome for Testing has no Linux arm64 build, and its --with-deps
+# path shells out to `sudo apt-get`, which is absent here). Playwright installs
+# the apt deps directly as root (no sudo) and agent-browser auto-detects the
+# resulting Chromium. All coding agents use this to validate frontend design
 # (see skills/library/frontend/validating-visual-design).
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then \
-         agent-browser install --with-deps; \
-       else \
-         npx --yes playwright@latest install --with-deps chromium; \
-       fi
+RUN npx --yes playwright@latest install --with-deps chromium
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -43,7 +43,21 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN npm install -g --no-fund --no-audit \
     @anthropic-ai/claude-code \
     opencode-ai \
-    @openai/codex
+    @openai/codex \
+    agent-browser
+
+# ── agent-browser Chrome (frontend design validation for every agent) ─────────
+# Bundles a headless Chromium + Linux system libs so `agent-browser` works
+# offline inside the sandbox. Chrome for Testing ships Linux amd64 only, so on
+# arm64 we install Playwright's Chromium build (agent-browser auto-detects it).
+# All coding agents use this to validate frontend design
+# (see skills/library/frontend/validating-visual-design).
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "amd64" ]; then \
+         agent-browser install --with-deps; \
+       else \
+         npx --yes playwright@latest install --with-deps chromium; \
+       fi
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -48,16 +48,13 @@ RUN npm install -g --no-fund --no-audit \
 
 # ── agent-browser Chrome (frontend design validation for every agent) ─────────
 # Bundles a headless Chromium + Linux system libs so `agent-browser` works
-# offline inside the sandbox. Chrome for Testing ships Linux amd64 only, so on
-# arm64 we install Playwright's Chromium build (agent-browser auto-detects it).
-# All coding agents use this to validate frontend design
+# offline inside the sandbox. We use Playwright's Chromium build because it is
+# cross-arch (Chrome for Testing has no Linux arm64 build, and its --with-deps
+# path shells out to `sudo apt-get`, which is absent here). Playwright installs
+# the apt deps directly as root (no sudo) and agent-browser auto-detects the
+# resulting Chromium. All coding agents use this to validate frontend design
 # (see skills/library/frontend/validating-visual-design).
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then \
-         agent-browser install --with-deps; \
-       else \
-         npx --yes playwright@latest install --with-deps chromium; \
-       fi
+RUN npx --yes playwright@latest install --with-deps chromium
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docs/AGENTTOOLS.md
+++ b/docs/AGENTTOOLS.md
@@ -2,6 +2,15 @@
 
 This guide covers every file and function you must touch to integrate a new AI agent backend into jonggrang. The four existing backends — `claude` (CLI spawn), `opencode` (CLI spawn with JSON streaming), `codex` (CLI spawn with JSONL streaming), and `jonggrang` (Pi SDK, in-process) — serve as reference implementations.
 
+> **Not every tool is a backend.** Some tools are *shared utilities* that agents call via
+> Bash rather than agent runtimes that drive the pipeline. For example
+> [`agent-browser`](https://github.com/vercel-labs/agent-browser) (frontend design
+> validation) is not integrated through this guide — it is installed in the sandbox image
+> (`docker/Dockerfile`) and surfaced to agents through a skill
+> (`skills/library/frontend/validating-visual-design`) plus the instruction templates. Use
+> the skill + image route for shared CLIs; use the checklist below only for new agent
+> *backends* selected via `.jonggrang/jonggrang.json`.
+
 ---
 
 ## Two Backend Patterns

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -52,7 +52,7 @@ To keep this phase from overflowing a small context window, the agent is fed the
 The agent writes the tests, runs them, and verifies coverage. Tests are not an afterthought appended at the end; they are part of the definition of done for every task.
 
 ### Review
-A dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan?
+A dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan? For frontend work the reviewer does not stop at the source — it drives the *rendered* UI in a real headless browser via the `agent-browser` CLI (preinstalled in the sandbox), checking layout, responsiveness, theming, and accessibility that code inspection and unit tests cannot see.
 
 ### Hooks (Continuous Enforcement)
 Not a final stage, but a continuous enforcement layer woven into the implement loop. Every tool call, every file edit, every agent exit passes through hooks first. They police what the agent cannot be trusted to police itself: no secrets leaking into context, no orchestrator making direct edits it should delegate, no agent spawning when the context window is near-full, no exit until review and tests are green.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -41,7 +41,8 @@ skills/
     │   └── error-handling-patterns/SKILL.md
     ├── frontend/
     │   ├── debugging-react-hooks/SKILL.md
-    │   └── optimizing-react-performance/SKILL.md
+    │   ├── optimizing-react-performance/SKILL.md
+    │   └── validating-visual-design/SKILL.md     ← agent-browser design validation
     ├── testing/
     │   ├── unit-testing-patterns/SKILL.md
     │   └── fixing-flaky-tests/SKILL.md
@@ -111,6 +112,7 @@ The Gateway is the routing layer between agent intent and skill files. Instead o
 |----------|--------|-----------------------|
 | route, controller, service, endpoint, middleware | backend | developing-with-tdd, debugging-systematically, error-handling-patterns |
 | component, hook, render, state, UI | frontend | debugging-react-hooks, optimizing-react-performance |
+| visual, design check, screenshot, responsive, browser validation, agent-browser | frontend | validating-visual-design |
 | REST, GraphQL, OpenAPI, validation | api | input-validation |
 | test, spec, coverage, mock, fixture | testing | unit-testing-patterns, fixing-flaky-tests |
 | migration, query, schema, ORM | database | safe-migrations |

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -365,6 +365,13 @@ The orchestrate command runs a deterministic 17-phase pipeline. Each phase is ex
 | 16 | TestQuality | Reviewer | Test quality review → REVIEW_COMPLETE | — |
 | 17 | Complete | Lead | Final summary, update `.jonggrang/.output/features/{id}/progress.txt`, MANIFEST → done | — |
 
+> **Frontend design validation.** In phases that touch the UI — Implement (8),
+> DesignVerify (10), and the interface-quality audit — agents use the `agent-browser`
+> CLI (preinstalled in the sandbox, with Chrome) to open the running app in a real
+> headless browser and check the *rendered* result: layout, responsive behavior,
+> theming, and accessibility. Routed via the `validating-visual-design` skill. This
+> catches design regressions that typecheck and unit tests cannot.
+
 ### Phase Skipping by Work Type
 
 ```

--- a/docs/plans/2026-07-14-agent-browser-integration.md
+++ b/docs/plans/2026-07-14-agent-browser-integration.md
@@ -1,0 +1,97 @@
+---
+title: Integrate agent-browser for frontend design validation
+date: 2026-07-14
+status: implemented
+branch: feat/browseruse
+---
+
+# Plan — Add `vercel-labs/agent-browser` to the sandbox and make every coding agent aware of it
+
+## Goal
+
+Ship [`agent-browser`](https://github.com/vercel-labs/agent-browser) (a native Rust
+browser-automation CLI for AI agents) inside the Jonggrang sandbox image, and wire it
+into the skill/template layer so that **every** agent backend (`claude`, `opencode`,
+`codex`, `jonggrang`) knows the tool exists and uses it to **validate frontend design**
+(screenshots, accessibility snapshots, responsive/contrast checks) before signalling
+completion.
+
+## Background (research findings)
+
+- `agent-browser` installs via `npm install -g agent-browser`; Chrome is fetched with
+  `agent-browser install` (`--with-deps` on Linux to pull system libs). No Node/Playwright
+  needed at runtime for the daemon.
+- Key commands for design validation: `open <url>`, `snapshot` (a11y tree + `@refs`),
+  `screenshot page.png`, `click @ref`, `fill @ref`, `get text @ref`, `wait`, `close`.
+  Runs headless — works in the container.
+- Two channels make an agent "aware" of a tool in Jonggrang:
+  1. **Sandbox image** — `docker/Dockerfile` + `docker/Dockerfile.dev`, "AI tools" block
+     (`npm install -g jonggrang @anthropic-ai/claude-code opencode-ai @openai/codex`).
+  2. **Skills** — any `skills/**/SKILL.md` is auto-copied on `jonggrang init` into
+     `.claude/skills`, `.opencode/skills`, `.jonggrang/skills`, `.codex/skills`
+     (`lib/jonggrang.js:2061` `skillTargets`). One skill ⇒ all backends see it. Skills are
+     seeded paths, already excluded from feature-branch commits.
+- Existing frontend touchpoints to extend: `skills/core/gateway-frontend/SKILL.md` (intent
+  router) and `skills/library/frontend/auditing-interface-quality/SKILL.md`
+  (Phase 10 Reviewer, read-only).
+
+## Decisions (confirmed)
+
+- **Install:** npm global **+** bundle Chrome via `agent-browser install --with-deps`
+  (ready offline; accepts the ~150–300 MB image growth).
+- **Scope:** full — skills + agent role templates + project-instruction templates + docs.
+
+## Changes
+
+### 1. Sandbox image
+- `docker/Dockerfile` — add `agent-browser` to the global `npm install -g` block, then a
+  `RUN agent-browser install --with-deps` step to bundle Chrome + Linux deps.
+- `docker/Dockerfile.dev` — mirror the same.
+
+### 2. Skills (primary "all agents know" channel)
+- **New:** `skills/library/frontend/validating-visual-design/SKILL.md` — concrete
+  agent-browser workflow: start dev server → `open` → `snapshot`/`screenshot` →
+  check layout/contrast/responsive/a11y → `close`, with example commands and completion
+  signal.
+- **Edit:** `skills/core/gateway-frontend/SKILL.md` — add routing row for intents
+  (`visual`, `design check`, `screenshot`, `responsive`, `browser validation`) → the new
+  skill; add `agent-browser` to the `trigger` keywords.
+- **Edit:** `skills/library/frontend/auditing-interface-quality/SKILL.md` — make
+  agent-browser the concrete tool for the Diagnostic Scan (screenshot evidence + a11y
+  snapshot). Reviewer stays read-only on source; agent-browser only observes.
+
+### 3. Agent role & project templates
+- `templates/CLAUDE.md.template` (+ `templates/AGENTS.md.template`) — add a
+  "Browser Automation" section (per agent-browser README): when/how to validate frontend
+  with agent-browser.
+- `templates/agents/developer.md` — in "Validation Before Signaling", add a visual-check
+  step with agent-browser when the task touches UI.
+- `templates/agents/reviewer.md` — in "Phase 10 — Design Verification", reference
+  agent-browser.
+
+### 4. Docs (Iron Rule — CLAUDE.md doc-sync)
+- `README.md` (Requirements) — note agent-browser ships in the sandbox.
+- `docs/SKILLS.md` — list the new `validating-visual-design` skill.
+- `docs/WORKFLOW.md` / `docs/PHILOSOPHY.md` — Phase 10 now has a real visual-validation tool.
+- `docs/AGENTTOOLS.md` — short note: agent-browser is a shared agent tool (not a backend).
+
+## Verification (done)
+- Built an Ubuntu 24.04 image with the exact agent-browser block and ran the full
+  design-validation workflow inside a container: `open → set viewport → snapshot →
+  screenshot → click → close`. Snapshot returned the a11y tree (heading/textbox/button
+  roles); screenshots were valid PNGs at the requested dimensions (1280×800 and 375×812);
+  the captured render was visually correct. All core checks passed.
+- Changes left uncommitted / unpushed (user commits themselves).
+
+## Cross-arch finding (fixed during e2e)
+`agent-browser install` fetches **Chrome for Testing, which ships Linux amd64 only** — it
+fails the image build on ARM64. The Dockerfiles now branch on `dpkg --print-architecture`:
+amd64 uses `agent-browser install --with-deps`; arm64 installs Playwright's Chromium
+(`npx playwright install --with-deps chromium`), which `agent-browser` auto-detects (no env
+var needed). Also corrected the documented CLI syntax: screenshots use `screenshot <path>`
+(no `--full-page` flag) and resizing uses `set viewport <w> <h>` (no `--viewport` flag).
+
+## Out of scope
+- No new `jonggrang` CLI subcommand or backend integration (`agent-browser` is a tool the
+  agents call via Bash, not an agent backend).
+- No cloud-browser providers (Browser Use / Kernel) — local headless Chrome only.

--- a/scripts/agent-browser-smoke.sh
+++ b/scripts/agent-browser-smoke.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke-test agent-browser inside a Jonggrang agent image.
+# Verifies the packaged browser can open a page, read its accessibility tree,
+# resize the viewport, capture a valid PNG, and close cleanly.
+#
+# Usage:
+#   bash scripts/agent-browser-smoke.sh [image]
+#
+# Default:
+#   ghcr.io/porcupine-md/jonggrang-agent:dev
+
+IMAGE="${1:-${IMAGE:-ghcr.io/porcupine-md/jonggrang-agent:dev}}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jg-agent-browser-smoke.XXXXXX")"
+CONTAINER_NAME="jg-agent-browser-smoke-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+docker info >/dev/null 2>&1 || fail "docker daemon is not available"
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  printf 'Pulling %s\n' "$IMAGE"
+  docker pull "$IMAGE" >/dev/null
+fi
+
+cat > "$TMP_DIR/index.html" <<'HTML'
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <h1>Jonggrang browser smoke</h1>
+      <button type="button">Ready</button>
+    </main>
+  </body>
+</html>
+HTML
+
+cat > "$TMP_DIR/server.js" <<'JS'
+const fs = require('fs');
+const http = require('http');
+
+const page = fs.readFileSync('/smoke/index.html');
+http.createServer((_request, response) => {
+  response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+  response.end(page);
+}).listen(4173, '127.0.0.1');
+JS
+
+cat > "$TMP_DIR/verify-png.js" <<'JS'
+const fs = require('fs');
+const png = fs.readFileSync('/smoke/mobile.png');
+
+if (png.toString('hex', 0, 8) !== '89504e470d0a1a0a') {
+  throw new Error('screenshot is not a PNG');
+}
+const width = png.readUInt32BE(16);
+const height = png.readUInt32BE(20);
+if (width !== 375 || height !== 812) {
+  throw new Error(`expected 375x812 screenshot, got ${width}x${height}`);
+}
+JS
+
+printf 'Testing agent-browser in %s\n' "$IMAGE"
+docker run --name "$CONTAINER_NAME" --rm \
+  -v "$TMP_DIR:/smoke" \
+  "$IMAGE" \
+  bash -lc '
+    set -euo pipefail
+
+    cleanup() {
+      agent-browser close >/dev/null 2>&1 || true
+      kill "${SERVER_PID:-}" >/dev/null 2>&1 || true
+    }
+    trap cleanup EXIT INT TERM
+
+    command -v agent-browser >/dev/null
+    agent-browser --version
+
+    node /smoke/server.js >/tmp/jg-agent-browser-smoke-server.log 2>&1 &
+    SERVER_PID=$!
+
+    for _ in $(seq 1 30); do
+      if curl -fsS http://127.0.0.1:4173 >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.2
+    done
+    curl -fsS http://127.0.0.1:4173 >/dev/null
+
+    agent-browser open http://127.0.0.1:4173 >/dev/null
+    agent-browser wait --load networkidle >/dev/null
+
+    SNAPSHOT="$(agent-browser snapshot)"
+    grep -q "Jonggrang browser smoke" <<<"$SNAPSHOT"
+    grep -q "button" <<<"$SNAPSHOT"
+
+    agent-browser set viewport 375 812 >/dev/null
+    agent-browser screenshot /smoke/mobile.png >/dev/null
+    node /smoke/verify-png.js
+
+    agent-browser close >/dev/null
+  '
+
+printf 'PASS: agent-browser open/snapshot/viewport/screenshot/close\n'

--- a/skills/core/gateway-frontend/SKILL.md
+++ b/skills/core/gateway-frontend/SKILL.md
@@ -4,7 +4,7 @@ description: Route frontend tasks to the right library skill. Detects React/Vue/
 type: gateway
 tier: core
 domains: [frontend, ui, components]
-trigger: "React, Vue, Angular, component, JSX, TSX, CSS, Tailwind, frontend, UI, browser, DOM, Next.js"
+trigger: "React, Vue, Angular, component, JSX, TSX, CSS, Tailwind, frontend, UI, browser, DOM, Next.js, agent-browser, visual, design check, screenshot, responsive"
 ---
 
 ## Purpose
@@ -24,6 +24,7 @@ You are the Frontend Gateway. Detect intent from the current task and return the
 | `accessibility`, `a11y`, `aria`, `screen reader` | `skills/library/frontend/accessibility/SKILL.md` |
 | `css`, `tailwind`, `styled-components`, `emotion` | `skills/library/frontend/styling-patterns/SKILL.md` |
 | `ssr`, `ssg`, `next.js`, `hydration`, `server component` | `skills/library/frontend/ssr-patterns/SKILL.md` |
+| `visual`, `design check`, `screenshot`, `responsive`, `contrast`, `browser validation`, `verify UI`, `agent-browser` | `skills/library/frontend/validating-visual-design/SKILL.md` |
 | `component`, `jsx`, `tsx`, `react` (general) | `skills/library/frontend/react-component-patterns/SKILL.md` |
 
 ## Output Format

--- a/skills/library/frontend/auditing-interface-quality/SKILL.md
+++ b/skills/library/frontend/auditing-interface-quality/SKILL.md
@@ -16,15 +16,28 @@ Perform a systematic audit of the interface quality across accessibility (A11y),
 ## Execution Steps
 
 1. **Discover Context:** Use `glob` and `read` to review the frontend components built or modified for the current feature.
-2. **Diagnostic Scan:**
+2. **Live Browser Check (agent-browser):** Whenever the app can be served, validate the
+   *rendered* UI — not just the source — with the `agent-browser` CLI (preinstalled in the
+   sandbox). It only observes the page, so it is safe under the read-only Reviewer role.
+   ```bash
+   agent-browser open <app-url> && agent-browser wait --load networkidle
+   agent-browser snapshot                       # a11y tree with roles/labels
+   agent-browser screenshot audit-desktop.png
+   agent-browser set viewport 375 812           # re-check responsive
+   agent-browser screenshot audit-mobile.png
+   agent-browser close
+   ```
+   Save screenshots into the active feature directory. See
+   `skills/library/frontend/validating-visual-design/SKILL.md` for the full workflow.
+3. **Diagnostic Scan** (use the snapshot/screenshots as evidence):
    - **Accessibility (A11y):** Check for contrast issues, missing ARIA roles, poor keyboard navigation, semantic HTML, and alt text.
    - **Performance:** Look for layout thrashing, expensive animations, unoptimized images, or unnecessary re-renders.
    - **Theming:** Look for hard-coded colors instead of design tokens, and broken dark mode implementations.
    - **Responsive Design:** Check for fixed widths, touch target sizes (<44px), and horizontal scrolling issues on narrow viewports.
-3. **Compile Audit Report:**
+4. **Compile Audit Report:**
    - Document each issue with its Location, Severity (Critical/High/Medium/Low), Category, Impact, and Recommendation.
    - Summarize the overall UI/UX compliance.
-4. **Save Report:**
+5. **Save Report:**
    - Write the final audit report using the `write` tool to `.jonggrang/.output/features/<active-feature-dir>/interface-audit.md`.
 
 ## Completion Signal

--- a/skills/library/frontend/validating-visual-design/SKILL.md
+++ b/skills/library/frontend/validating-visual-design/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: validating-visual-design
+description: Validate frontend design in a real browser using the agent-browser CLI — screenshots, accessibility snapshots, responsive and contrast checks.
+type: workflow
+tier: library
+domains: [frontend]
+trigger: "visual, design check, screenshot, responsive, contrast, layout, browser validation, agent-browser, verify UI, does it look right, render"
+---
+
+# Validating Visual Design with agent-browser
+
+Frontend code that typechecks and passes unit tests can still render broken.
+This skill uses **`agent-browser`** — a browser-automation CLI preinstalled in the
+Jonggrang sandbox — to open the running app in a real (headless) Chrome and verify
+the design actually works.
+
+`agent-browser` is available to every agent backend (claude, opencode, codex,
+jonggrang). Call it via Bash. Chrome for Testing is already installed in the sandbox
+image, so no setup is needed there. On a bare host, run `agent-browser install` once.
+
+## When to use
+
+- After implementing or changing any UI (component, page, layout, styling).
+- Before signalling completion on a task that touches the frontend.
+- During Phase 10 design verification / interface-quality audits.
+
+## Core commands
+
+```bash
+agent-browser open http://localhost:3000       # open a URL (starts the browser)
+agent-browser snapshot                          # accessibility tree with @refs (a11y check)
+agent-browser screenshot design.png             # capture the rendered page (PNG)
+agent-browser set viewport 375 812              # resize (e.g. mobile) before capturing
+agent-browser get text @e1                       # read text by ref from snapshot
+agent-browser click @e2                          # interact by ref
+agent-browser fill @e3 "value"                   # fill an input by ref
+agent-browser wait --load networkidle            # wait until the page settles
+agent-browser close                              # shut the browser down
+```
+
+## Workflow
+
+1. **Start the dev server** for the app (e.g. `npm run dev &`) and note its URL.
+   Wait until it is reachable before opening the browser.
+2. **Open the page:** `agent-browser open <url>` then `agent-browser wait --load networkidle`.
+3. **Capture evidence:** `agent-browser screenshot <feature>.png`. Read the screenshot
+   back to inspect layout, spacing, alignment, colors, and dark mode.
+4. **Check accessibility & structure:** `agent-browser snapshot` — verify semantic
+   roles, labels, and that key elements are present and reachable.
+5. **Check responsiveness:** resize to a narrow viewport and screenshot again to
+   catch horizontal scroll, overflow, and touch-target sizing.
+   ```bash
+   agent-browser set viewport 375 812        # mobile portrait
+   agent-browser screenshot mobile.png
+   agent-browser set viewport 1280 800       # back to desktop
+   ```
+6. **Exercise interactions** the task depends on (`click`/`fill`) and confirm the
+   resulting state via `snapshot`/`screenshot`.
+7. **Tear down:** `agent-browser close` and stop the dev server.
+
+## What to look for
+
+- **Layout:** no overlap, no unintended overflow/horizontal scroll, correct alignment.
+- **Responsive:** usable at mobile (375px) and desktop widths; touch targets ≥ 44px.
+- **Theming:** dark mode renders; colors come from design tokens, not hard-coded values.
+- **Accessibility:** headings, labels, ARIA roles, alt text present in the snapshot.
+- **Content:** expected text and elements actually appear (not blank / error state).
+
+## Validation
+
+The design is validated when a screenshot + snapshot of the built UI have been
+captured and reviewed against the task's acceptance criteria, with no critical
+layout, responsive, theming, or accessibility issues outstanding.
+
+## Notes
+
+- `agent-browser` runs headless in the sandbox; no display server is required.
+- Reviewers are read-only on source code — `agent-browser` only observes, so it is
+  safe to run during audits. Save any screenshots inside the active feature's
+  `.jonggrang/.output/features/<feature_id>/` directory.
+- Do not put secrets/credentials in command args; use the app's own login flow.

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -186,6 +186,27 @@ created_at: 2026-04-16T10:30:00Z
 
 ---
 
+## Browser Automation (frontend design validation)
+
+The `agent-browser` CLI is preinstalled in the Jonggrang sandbox and available to every
+agent backend (claude, opencode, codex, jonggrang). Use it to validate frontend design in
+a real headless browser — do not sign off UI work on typecheck + unit tests alone.
+
+```bash
+agent-browser open http://localhost:3000   # open the running app
+agent-browser wait --load networkidle
+agent-browser snapshot                       # accessibility tree with @refs (a11y)
+agent-browser screenshot ui.png              # capture; review layout/contrast/dark mode
+agent-browser set viewport 375 812           # responsive re-check, then screenshot again
+agent-browser close
+```
+
+Full workflow lives in the `validating-visual-design` skill
+(`.claude/skills/validating-visual-design/SKILL.md` or the equivalent path for your tool).
+On a bare host (outside the sandbox), run `agent-browser install` once to fetch Chrome.
+
+---
+
 ## Bug Reporting
 
 When you discover a defect **outside the scope of your current task**, report it immediately:

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -46,9 +46,28 @@ jonggrang bug "description of what is broken" --feature <feature_id>
 
 Get the `feature_id` by running: `jonggrang task show <id>` — look for the `feature_id` field in the output.
 
+## Browser Automation (frontend design validation)
+
+The `agent-browser` CLI is available (preinstalled in the Jonggrang sandbox) for
+validating frontend design in a real headless browser. When your task touches the UI,
+verify the *rendered* result — not just that the code compiles — before signalling done:
+
+```bash
+agent-browser open http://localhost:3000   # open the running app
+agent-browser wait --load networkidle
+agent-browser snapshot                       # accessibility tree with @refs
+agent-browser screenshot ui.png              # capture + review layout/contrast/dark mode
+agent-browser close
+```
+
+Full workflow (responsive checks, interactions): read
+`.claude/skills/validating-visual-design/SKILL.md`. On a bare host (no sandbox), run
+`agent-browser install` once to fetch Chrome.
+
 ## Rules
 
 - Only modify files listed in your task's `"files"` array
+- Validate frontend design with `agent-browser` when the task touches UI
 - Follow patterns in AGENTS.md
 - One atomic commit per task
 - Do not skip validation

--- a/templates/agents/developer.md
+++ b/templates/agents/developer.md
@@ -55,6 +55,18 @@ npm run test -- --run  # run just the new/changed tests
 
 If any check fails, fix before signaling.
 
+**Frontend tasks — validate the rendered design too.** Typecheck + unit tests do not
+prove the UI looks right. If your task touched any component, page, layout, or styling,
+verify it in a real browser with `agent-browser` (preinstalled in the sandbox) before
+signalling. Load the `validating-visual-design` gateway skill for the full workflow:
+
+```bash
+agent-browser open <app-url> && agent-browser wait --load networkidle
+agent-browser snapshot                       # a11y tree
+agent-browser screenshot ui.png              # review layout/contrast/responsive/dark mode
+agent-browser close
+```
+
 ## Bugs Discovered While Implementing
 
 If you notice a defect that is **outside the scope of your current task** (e.g., a bug in an adjacent module, an incorrect helper, a broken edge case you weren't asked to fix):

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -39,6 +39,11 @@ Depends on which phase you're called for:
 - [ ] File structure matches plan's `files` list
 - [ ] No extra scope added (scope creep)
 - [ ] Function signatures match design
+- [ ] **Frontend:** rendered UI matches the design. Verify in a real headless browser
+      with `agent-browser` (preinstalled; read-only observation, safe for Reviewer) —
+      `open` the app, take a `snapshot` + `screenshot`, and check layout, responsive
+      behavior, theming, and accessibility. See the `validating-visual-design` and
+      `auditing-interface-quality` skills.
 
 ### Phase 11 — Domain Compliance
 - [ ] REST: correct HTTP verbs, status codes, plural nouns


### PR DESCRIPTION
## What & why

Adds a small CI smoke guard for the agent-browser integration. No runtime behavior changes.

The script serves a tiny page inside the agent image, then checks `open → snapshot → viewport → screenshot → close`. It also verifies the screenshot is a real 375×812 PNG and cleans up the browser/server on failure.

CI tags the dev image with the commit SHA before running the smoke, so the test cannot accidentally pick up another PR’s `:dev` image.

## Checked

- smoke passed against `ghcr.io/porcupine-md/jonggrang-agent:dev`
- script syntax passed
- workflow YAML parsed successfully
- `git diff --check` passed