### PR TITLE
fix: use sandbox-aware draft plan deletion in Docker sandbox mode

### DIFF
--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -488,7 +488,7 @@ module.exports = function (deps) {
 
         const draft = resolveDraft(project, requestedSession(req));
         try {
-            if (draft) fs.rmSync(lib.draftDirFor(project.path, draft.sessionId), { recursive: true, force: true });
+            if (draft) sandbox.removeDraftDir(project, lib.draftDirFor(project.path, draft.sessionId));
             res.status(204).send();
         } catch (err) {
             res.status(500).json({ error: err.message });

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -398,45 +398,42 @@ function remove(projectId) {
     });
 }
 
-// Purge a deleted project's on-disk state. The central worktree dir is always
-// removed (it is jonggrang-internal state, not the user's repo); the bind-mounted
-// project repo is removed only when `deleteRepo`. For SANDBOX projects the files
-// were written by the in-container root user, so a host fs.rmSync EACCESes —
-// clear the contents via a throwaway root container (the project's agent image,
-// already present locally) first, then remove the now-empty dirs. Synchronous so
-// the DELETE handler can run it inline before responding.
-function purgeProjectFiles(project, { deleteRepo = false } = {}) {
-    const targets = [projectWorktreeDir(project.id)];
-    if (deleteRepo && project.path) targets.push(project.path);
-    const useContainer = !!(project.sandbox && project.sandbox.enabled);
-    const image = (project.sandbox && project.sandbox.image) || DEFAULT_AGENT_IMAGE;
-    for (const dir of targets) {
-        if (!dir || !fs.existsSync(dir)) continue;
-        if (useContainer) {
-            try {
-                execFileSync('docker', ['run', '--rm', '-v', `${dir}:/t`, image,
-                    'sh', '-c', 'rm -rf /t/* /t/.[!.]* /t/..?* 2>/dev/null; true'],
-                    { stdio: 'ignore', timeout: 120000 });
-            } catch { /* image missing / docker error — fall through to host rm */ }
-        }
-        try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
-    }
-}
-
-// Safely delete a filesystem directory irrespective of file ownership.
-// When the project uses Docker sandbox mode, a throwaway root container
-// removes root-owned content first; host fs.rmSync follows as fallback.
-function removeDraftDir(project, targetDir) {
+// Remove a directory whose contents may be root-owned (written by the in-container
+// root user). For sandbox projects a throwaway root container (the project's agent
+// image, already present locally) clears the contents first; host fs.rmSync then
+// removes the now-empty dir. Best-effort: container failure falls through to host
+// rm, and host rm errors are swallowed (force:true already suppresses ENOENT).
+function removeDirViaContainer(project, dir) {
     const useContainer = !!(project.sandbox && project.sandbox.enabled);
     const image = (project.sandbox && project.sandbox.image) || DEFAULT_AGENT_IMAGE;
     if (useContainer) {
         try {
-            execFileSync('docker', ['run', '--rm', '-v', `${targetDir}:/t`, image,
-                'sh', '-c', 'rm -rf /t'],
+            execFileSync('docker', ['run', '--rm', '-v', `${dir}:/t`, image,
+                'sh', '-c', 'rm -rf /t/* /t/.[!.]* /t/..?* 2>/dev/null; true'],
                 { stdio: 'ignore', timeout: 120000 });
         } catch { /* image missing / docker error — fall through to host rm */ }
     }
-    try { fs.rmSync(targetDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+// Purge a deleted project's on-disk state. The central worktree dir is always
+// removed (it is jonggrang-internal state, not the user's repo); the bind-mounted
+// project repo is removed only when `deleteRepo`. Synchronous so the DELETE
+// handler can run it inline before responding.
+function purgeProjectFiles(project, { deleteRepo = false } = {}) {
+    const targets = [projectWorktreeDir(project.id)];
+    if (deleteRepo && project.path) targets.push(project.path);
+    for (const dir of targets) {
+        if (!dir || !fs.existsSync(dir)) continue;
+        removeDirViaContainer(project, dir);
+    }
+}
+
+// Safely delete a draft directory irrespective of file ownership. Used by the
+// DELETE /:id/plan route so host processes can discard root-owned draft files
+// created inside the Docker sandbox.
+function removeDraftDir(project, targetDir) {
+    removeDirViaContainer(project, targetDir);
 }
 
 function buildExecArgs(containerName, containerPath, cmd, cmdArgs, secretVars) {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -423,6 +423,22 @@ function purgeProjectFiles(project, { deleteRepo = false } = {}) {
     }
 }
 
+// Safely delete a filesystem directory irrespective of file ownership.
+// When the project uses Docker sandbox mode, a throwaway root container
+// removes root-owned content first; host fs.rmSync follows as fallback.
+function removeDraftDir(project, targetDir) {
+    const useContainer = !!(project.sandbox && project.sandbox.enabled);
+    const image = (project.sandbox && project.sandbox.image) || DEFAULT_AGENT_IMAGE;
+    if (useContainer) {
+        try {
+            execFileSync('docker', ['run', '--rm', '-v', `${targetDir}:/t`, image,
+                'sh', '-c', 'rm -rf /t'],
+                { stdio: 'ignore', timeout: 120000 });
+        } catch { /* image missing / docker error — fall through to host rm */ }
+    }
+    try { fs.rmSync(targetDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
 function buildExecArgs(containerName, containerPath, cmd, cmdArgs, secretVars) {
     const envFlags = [];
     for (const [k, v] of Object.entries(secretVars || {})) {
@@ -481,4 +497,5 @@ module.exports = {
     EDITOR_CONTAINER_PORT, getEditorHostPort,
     WORKTREE_MOUNT, worktreeRoot, projectWorktreeDir, featureOutputDir, ensureWorktreeRoot, ensureProjectWorktreeDir,
     AGENT_IMAGE_REPO, DEFAULT_AGENT_IMAGE,
+    removeDraftDir,
 };


### PR DESCRIPTION
## Summary

Fixes draft plan deletion (discard plan endpoint) failing with `EACCES` permission errors when running in Docker sandbox mode.

## What Changed

- **`lib/sandbox.js`**: Added `removeDraftDir` helper function that safely removes draft directories. If running in Docker sandbox mode, deletion is delegated to a throwaway container to handle root-owned files created by Docker, falling back to `fs.rmSync`.
- **`apis/projects/plan.js`**: Updated `DELETE /:id/plan` route to use `sandbox.removeDraftDir` instead of direct `fs.rmSync`.

## Context

Draft files under `.jonggrang/.drafts/` are created inside the Docker sandbox container as `root`. Host processes attempting to delete them encounter `EACCES` permission errors. Delegating deletion via container execution resolves the file ownership issue.