### PR TITLE
feat: jonggrang design — global design templates + web Design studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Project entry points: CLI binary, Pi TUI extension, web dashboard server. Hooks 
 | `jonggrang issues list` | List GitHub/GitLab issues from configured sources (or `--repo owner/repo`) |
 | `jonggrang issues pickup <p> <repo> <n>` | Generate a plan in this project from a GitHub/GitLab issue |
 | `jonggrang manifest` | Inspect output files tracked per phase (`list`, `show [id]`, `add`) |
+| `jonggrang design` | Global, reusable design templates + web studio (`list`, `new`, `promote`, `show`, `get`, `validate`) |
 | `jonggrang memory` | Read, recall, stage fragments, compact feature memory, and promote stable project lessons |
 | `jonggrang codemap` | Show/refresh deterministic codebase map (LLM-free, cached at `.jonggrang/codemap/codemap.json`) |
 
@@ -155,6 +156,7 @@ Two-layer config: `~/.jonggrang/settings.json` (your defaults) → `.jonggrang/j
 | [CONFIG.md](docs/CONFIG.md) | Tweak every knob |
 | [UI_CONTEXT.md](docs/UI_CONTEXT.md) | Understand UI guides, baseline packs, and feature handoffs |
 | [UI_BASELINES.md](docs/UI_BASELINES.md) | Add or version a UI baseline pack |
+| [DESIGN.md](docs/DESIGN.md) | Global design templates + the web Design studio |
 | [COMMIT-CONVENTION.md](docs/COMMIT-CONVENTION.md) | Write agent-readable commit messages |
 
 ---

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jonggrang work "feature" --yes       # Full pipeline in one command
 jonggrang plan "feature" --src docs/brd.md  # Reference source document for the agent to read
 jonggrang plan "feature" --deep      # 3-phase deep analysis (risks, alternatives)
 jonggrang plan "feature" --base develop  # Cut the worktree from a chosen branch (fetched fresh from origin)
+jonggrang plan "feature" --baseline helo@1  # Style from a design template / baseline pack (skips the design question); web = the "design:" picker
 jonggrang plan "feature" --no-ask    # Skip the agent's clarifying-questions step
 jonggrang plan --append feat-abc123 "also add rate limiting"  # Extend an approved plan (tasks appended, numbering continues)
 jonggrang plan --append feat-abc123 "..." --deep  # Deep analysis on the added scope (Affected Areas / Risks)

--- a/apis/design.js
+++ b/apis/design.js
@@ -35,6 +35,31 @@ html, body { margin: 0; background: var(--ui-canvas, #fff); color: var(--ui-text
 }
 
 module.exports = function register(app, io, _ctx) {
+  // Live preview: watch the design store so ANY change — the studio's Save button
+  // OR the TUI agent writing files directly (in sandbox mode via the ~/.jonggrang
+  // bind mount) — emits `design.changed` and refreshes the open preview. Polling is
+  // used so it also fires for writes made inside the container. (fixes: preview not
+  // live-updating on agent edits — used to require a manual refresh.)
+  let designWatcher = null;
+  try {
+    const chokidar = require('chokidar');
+    const root = design.designRoot();
+    fs.mkdirSync(root, { recursive: true });
+    designWatcher = chokidar.watch(root, {
+      ignoreInitial: true,
+      usePolling: true,
+      interval: 400,
+      depth: 4,
+      awaitWriteFinish: { stabilityThreshold: 250, pollInterval: 100 },
+    });
+    const onFsEvent = (changed) => {
+      const rel = path.relative(root, changed);
+      const name = rel.split(path.sep)[0];
+      if (name && name !== 'core' && io && io.emit) io.emit('design.changed', { name, path: rel });
+    };
+    for (const ev of ['add', 'change', 'unlink', 'addDir', 'unlinkDir']) designWatcher.on(ev, onFsEvent);
+  } catch { /* watching is best-effort */ }
+
   // List templates.
   app.get('/api/design', (req, res) => {
     try {
@@ -258,5 +283,8 @@ module.exports = function register(app, io, _ctx) {
     });
   }
 
-  return function cleanup() { killAllPtys(); };
+  return function cleanup() {
+    killAllPtys();
+    if (designWatcher) { try { designWatcher.close(); } catch { /* ignore */ } }
+  };
 };

--- a/apis/design.js
+++ b/apis/design.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const design = require('../lib/design');
+const uiContext = require('../lib/ui-context');
 
 function escapeHtml(value) {
   return String(value).replace(/[&<>"']/g, ch => (
@@ -69,6 +70,18 @@ module.exports = function register(app, io, _ctx) {
         valid: t.valid, errors: t.errors || [], source: t.source,
       }));
       res.json({ templates, root: design.designRoot() });
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // All selectable UI baselines (built-in packs + personal design templates),
+  // as `<id>@<version>` keys. Feeds the New Plan "Design" picker so a baseline
+  // can be chosen up front (plan --baseline <key>) instead of being asked for.
+  app.get('/api/baselines', (req, res) => {
+    try {
+      const baselines = uiContext.listAllBaselinePacks()
+        .filter(p => p.valid)
+        .map(p => ({ key: p.key, id: p.id, version: p.version, intent: p.intent || '', source: p.source }));
+      res.json({ baselines });
     } catch (err) { res.status(500).json({ error: err.message }); }
   });
 
@@ -169,15 +182,36 @@ module.exports = function register(app, io, _ctx) {
   const AGENT_IMAGE = process.env.JONGGRANG_AGENT_IMAGE || 'ghcr.io/porcupine-md/jonggrang-agent:dev';
   const DESIGN_CONTAINER = 'jonggrang-design-studio';
 
-  function resolveToolCommand(tool) {
+  // `resume` picks up the tool's prior conversation for this template instead of
+  // starting fresh (claude --resume, opencode --continue, jonggrang/pi agent -r).
+  function resolveToolCommand(tool, resume) {
     switch (tool) {
-      case 'claude':    return { cmd: 'claude',    args: ['--dangerously-skip-permissions'] };
-      case 'opencode':  return { cmd: 'opencode',  args: [] };
+      case 'claude':    return { cmd: 'claude',    args: resume ? ['--dangerously-skip-permissions', '--resume'] : ['--dangerously-skip-permissions'] };
+      case 'opencode':  return { cmd: 'opencode',  args: resume ? ['--continue'] : [] };
       case 'codex':     return { cmd: 'codex',     args: [] };
-      case 'jonggrang': return { cmd: 'jonggrang', args: ['agent'] };
+      case 'jonggrang': return { cmd: 'jonggrang', args: resume ? ['agent', '-r'] : ['agent'] };
       case 'shell':     return { cmd: 'bash',      args: [] };
       default:          return null;
     }
+  }
+
+  // Studio session ledger: remembers which (template, tool, mode) combos have had a
+  // TUI opened, so the NEXT open resumes instead of starting a new conversation.
+  // Kept in ~/.jonggrang/web/ (outside the design store the preview watcher watches).
+  // Keyed by mode because sandbox (cwd /root/…) and host (cwd ~/…) sessions are
+  // stored under different cwd keys by the tools and are not cross-resumable.
+  function designSessionsFile() { return path.join(os.homedir(), '.jonggrang', 'web', 'design-sessions.json'); }
+  function readDesignSessions() { try { return JSON.parse(fs.readFileSync(designSessionsFile(), 'utf8')); } catch { return {}; } }
+  function designSessionKey(name, tool, sandbox) { return `${name}::${tool}::${sandbox ? 'sandbox' : 'host'}`; }
+  function hasDesignSession(name, tool, sandbox) { return Boolean(readDesignSessions()[designSessionKey(name, tool, sandbox)]); }
+  function markDesignSession(name, tool, sandbox) {
+    try {
+      const f = designSessionsFile();
+      const s = readDesignSessions();
+      s[designSessionKey(name, tool, sandbox)] = true;
+      fs.mkdirSync(path.dirname(f), { recursive: true });
+      fs.writeFileSync(f, JSON.stringify(s, null, 2));
+    } catch { /* best-effort ledger */ }
   }
 
   // Harness/config + design-store mounts (mirror the project sandbox DEFAULT_VOLUMES).
@@ -209,7 +243,11 @@ module.exports = function register(app, io, _ctx) {
   }
 
   function spawnDesign(name, tool, cols, rows, sandbox) {
-    const resolved = resolveToolCommand(tool);
+    // Auto-resume: if this template+tool+mode has been opened before, launch the
+    // tool with its resume/continue flag so it continues the prior conversation.
+    const canResume = tool !== 'shell';
+    const resume = canResume && hasDesignSession(name, tool, !!sandbox);
+    const resolved = resolveToolCommand(tool, resume);
     if (!resolved) throw new Error(`unsupported tool: ${tool}`);
     const key = `design:${name}`;
     if (designPtys.has(key)) { try { designPtys.get(key).kill(); } catch { /* ignore */ } designPtys.delete(key); }
@@ -226,6 +264,8 @@ module.exports = function register(app, io, _ctx) {
         { name: 'xterm-256color', ...dims, cwd: dir, env: { ...process.env, TERM: 'xterm-256color' } });
     }
     designPtys.set(key, proc);
+    // Record the session so the next open of this template+tool+mode resumes.
+    if (canResume) markDesignSession(name, tool, !!sandbox);
     proc.onData(data => { if (io && io.emit) io.emit('pty.data', { project_id: key, session: 'design', data }); });
     proc.onExit(({ exitCode }) => { designPtys.delete(key); if (io && io.emit) io.emit('pty.exit', { project_id: key, session: 'design', exitCode }); });
     return proc;

--- a/apis/design.js
+++ b/apis/design.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// Global design-template API (see lib/design.js + docs/plans/2026-08-15-jonggrang-design-studio.md).
+// Backs the web "Design" studio: list/read/create/promote/save/delete templates, validate
+// (lint on save), and render a self-contained preview document for a sandboxed <iframe>.
+
+const fs = require('fs');
+const path = require('path');
+const design = require('../lib/design');
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, ch => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]
+  ));
+}
+
+function renderPreviewDoc(tokensCss, bodyHtml, theme, width) {
+  return `<!doctype html>
+<html data-theme="${theme === 'dark' ? 'dark' : 'light'}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+${tokensCss}
+html, body { margin: 0; background: var(--ui-canvas, #fff); color: var(--ui-text, #111);
+  font-family: system-ui, -apple-system, sans-serif; }
+.preview-wrap { max-width: ${width}px; margin: 0 auto; padding: var(--ui-space-8, 2rem) var(--ui-space-4, 1rem); }
+.preview-item { margin-bottom: var(--ui-space-8, 2rem); }
+.preview-item > .preview-label { font: 600 0.72rem/1.4 system-ui; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--ui-text-muted, #666); margin: 0 0 var(--ui-space-3, .75rem); }
+</style>
+</head>
+<body><div class="preview-wrap">${bodyHtml}</div></body>
+</html>`;
+}
+
+module.exports = function register(app, io, _ctx) {
+  // List templates.
+  app.get('/api/design', (req, res) => {
+    try {
+      const templates = design.listTemplates().map(t => ({
+        id: t.id, key: t.key, version: t.version, intent: t.intent,
+        product_shapes: t.product_shapes || [], components: (t.components || []).map(c => c.id),
+        valid: t.valid, errors: t.errors || [], source: t.source,
+      }));
+      res.json({ templates, root: design.designRoot() });
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // Read one template (manifest + guide + tokens + components + validation).
+  app.get('/api/design/:name', (req, res) => {
+    try {
+      const t = design.loadTemplate(req.params.name);
+      res.json({
+        key: t.key, dir: t.dir, manifest: t.manifest,
+        guideFragment: t.guideFragment, tokenTemplate: t.tokenTemplate,
+        components: t.components.map(c => ({ id: c.id, variants: c.variants, file: c.file, html: c.html })),
+        validation: design.validateTemplate(req.params.name),
+      });
+    } catch (err) { res.status(404).json({ error: err.message }); }
+  });
+
+  // Create (scaffold) a template.
+  app.post('/api/design', (req, res) => {
+    try {
+      const { name, intent, product_shapes, recommend_keywords, force } = req.body || {};
+      res.status(201).json(design.newTemplate(name, { intent, product_shapes, recommend_keywords, force }));
+    } catch (err) { res.status(400).json({ error: err.message }); }
+  });
+
+  // Promote a project's UI.md + tokens into a template.
+  app.post('/api/design/promote', (req, res) => {
+    try {
+      const { name, fromProjectPath, force } = req.body || {};
+      if (!fromProjectPath) return res.status(400).json({ error: 'fromProjectPath required' });
+      res.status(201).json(design.promoteFromProject(name, path.resolve(fromProjectPath), { force }));
+    } catch (err) { res.status(400).json({ error: err.message }); }
+  });
+
+  // Save a file inside a template (studio editor) — path-guarded, lints on save.
+  app.put('/api/design/:name/file', (req, res) => {
+    try {
+      const { file, content } = req.body || {};
+      if (!file || content == null) return res.status(400).json({ error: 'file and content required' });
+      const dir = path.join(design.designRoot(), req.params.name);
+      if (!fs.existsSync(dir)) return res.status(404).json({ error: 'template not found' });
+      const target = path.resolve(dir, file);
+      if (target !== path.resolve(dir) && !target.startsWith(path.resolve(dir) + path.sep)) {
+        return res.status(400).json({ error: 'path escapes template dir' });
+      }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, String(content), 'utf8');
+      const validation = design.validateTemplate(req.params.name);
+      if (io && io.emit) io.emit('design.changed', { name: req.params.name, file });
+      res.json({ ok: true, validation });
+    } catch (err) { res.status(400).json({ error: err.message }); }
+  });
+
+  // Delete a template.
+  app.delete('/api/design/:name', (req, res) => {
+    try { res.json(design.removeTemplate(req.params.name)); }
+    catch (err) { res.status(404).json({ error: err.message }); }
+  });
+
+  // Validate (lint).
+  app.get('/api/design/:name/validate', (req, res) => {
+    try { res.json(design.validateTemplate(req.params.name)); }
+    catch (err) { res.status(404).json({ error: err.message }); }
+  });
+
+  // Self-contained preview HTML for a sandboxed iframe.
+  app.get('/api/design/:name/preview', (req, res) => {
+    try {
+      const t = design.loadTemplate(req.params.name);
+      const theme = req.query.theme === 'dark' ? 'dark' : 'light';
+      const width = Math.max(240, Math.min(4000, parseInt(req.query.width, 10) || 1024));
+      let body;
+      if (req.query.component) {
+        const comp = t.components.find(c => c.id === req.query.component);
+        if (!comp) return res.status(404).type('html').send('<p>component not found</p>');
+        body = comp.html;
+      } else if (t.components.length) {
+        body = t.components.map(c =>
+          `<div class="preview-item"><p class="preview-label">${escapeHtml(c.id)}</p>${c.html}</div>`).join('\n');
+      } else {
+        body = '<p style="color:var(--ui-text-muted)">No components yet — ask the studio agent to add one.</p>';
+      }
+      res.type('html').send(renderPreviewDoc(t.tokenTemplate, body, theme, width));
+    } catch (err) { res.status(404).type('html').send(`<p>${escapeHtml(err.message)}</p>`); }
+  });
+
+  return function cleanup() {};
+};

--- a/apis/design.js
+++ b/apis/design.js
@@ -129,5 +129,75 @@ module.exports = function register(app, io, _ctx) {
     } catch (err) { res.status(404).type('html').send(`<p>${escapeHtml(err.message)}</p>`); }
   });
 
-  return function cleanup() {};
+  // ── Studio terminal: the selected tool's native TUI (unsafe) in the template dir ──
+  // Reuses the same pty.* socket events as the project terminal, keyed by a
+  // `design:<name>` project_id so the existing xterm composable works unchanged.
+  const pty = require('node-pty');
+  const designPtys = new Map(); // key: design:<name>
+
+  function resolveToolCommand(tool) {
+    switch (tool) {
+      case 'claude':    return { cmd: 'claude',    args: ['--dangerously-skip-permissions'] };
+      case 'opencode':  return { cmd: 'opencode',  args: [] };
+      case 'codex':     return { cmd: 'codex',     args: [] };
+      case 'jonggrang': return { cmd: 'jonggrang', args: ['agent'] };
+      case 'shell':     return { cmd: process.env.SHELL || 'bash', args: [] };
+      default:          return null;
+    }
+  }
+
+  app.post('/api/design/:name/terminal/start', (req, res) => {
+    try {
+      const name = req.params.name;
+      const dir = path.join(design.designRoot(), name);
+      if (!fs.existsSync(dir)) return res.status(404).json({ error: 'template not found' });
+      const { cols = 80, rows = 24, tool = 'shell' } = req.body || {};
+      const resolved = resolveToolCommand(tool);
+      if (!resolved) return res.status(400).json({ error: `unsupported tool: ${tool}` });
+      const key = `design:${name}`;
+      if (designPtys.has(key)) { try { designPtys.get(key).kill(); } catch { /* ignore */ } designPtys.delete(key); }
+      const proc = pty.spawn(resolved.cmd, resolved.args, {
+        name: 'xterm-256color',
+        cols: Math.max(20, cols | 0), rows: Math.max(6, rows | 0),
+        cwd: dir,
+        env: { ...process.env, TERM: 'xterm-256color' },
+      });
+      designPtys.set(key, proc);
+      proc.onData(data => { if (io && io.emit) io.emit('pty.data', { project_id: key, session: 'design', data }); });
+      proc.onExit(({ exitCode }) => {
+        designPtys.delete(key);
+        if (io && io.emit) io.emit('pty.exit', { project_id: key, session: 'design', exitCode });
+      });
+      res.json({ ok: true, tool, cwd: dir });
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  app.post('/api/design/:name/terminal/stop', (req, res) => {
+    const key = `design:${req.params.name}`;
+    const proc = designPtys.get(key);
+    if (proc) { try { proc.kill(); } catch { /* ignore */ } designPtys.delete(key); }
+    res.json({ ok: true });
+  });
+
+  if (io && io.on) {
+    io.on('connection', socket => {
+      socket.on('pty.input', ({ project_id, data }) => {
+        if (typeof project_id === 'string' && project_id.startsWith('design:')) {
+          const proc = designPtys.get(project_id);
+          if (proc) proc.write(data);
+        }
+      });
+      socket.on('pty.resize', ({ project_id, cols, rows }) => {
+        if (typeof project_id === 'string' && project_id.startsWith('design:')) {
+          const proc = designPtys.get(project_id);
+          if (proc && cols > 0 && rows > 0) { try { proc.resize(cols, rows); } catch { /* ignore */ } }
+        }
+      });
+    });
+  }
+
+  return function cleanup() {
+    for (const proc of designPtys.values()) { try { proc.kill(); } catch { /* ignore */ } }
+    designPtys.clear();
+  };
 };

--- a/apis/design.js
+++ b/apis/design.js
@@ -129,11 +129,20 @@ module.exports = function register(app, io, _ctx) {
     } catch (err) { res.status(404).type('html').send(`<p>${escapeHtml(err.message)}</p>`); }
   });
 
-  // ── Studio terminal: the selected tool's native TUI (unsafe) in the template dir ──
+  // ── Studio terminal: the selected tool's native TUI (unsafe), host or sandbox ──
   // Reuses the same pty.* socket events as the project terminal, keyed by a
   // `design:<name>` project_id so the existing xterm composable works unchanged.
+  // Sandbox mode execs into a shared container that mounts ~/.jonggrang (design
+  // store + templates) and the tool config dirs (~/.claude, ~/.opencode, …) plus
+  // IS_SANDBOX=1 — mirroring the project sandbox DEFAULT_VOLUMES so the tool's
+  // session/harness AND the store carry over.
   const pty = require('node-pty');
+  const os = require('os');
+  const { execFileSync } = require('child_process');
   const designPtys = new Map(); // key: design:<name>
+
+  const AGENT_IMAGE = process.env.JONGGRANG_AGENT_IMAGE || 'ghcr.io/porcupine-md/jonggrang-agent:dev';
+  const DESIGN_CONTAINER = 'jonggrang-design-studio';
 
   function resolveToolCommand(tool) {
     switch (tool) {
@@ -141,34 +150,69 @@ module.exports = function register(app, io, _ctx) {
       case 'opencode':  return { cmd: 'opencode',  args: [] };
       case 'codex':     return { cmd: 'codex',     args: [] };
       case 'jonggrang': return { cmd: 'jonggrang', args: ['agent'] };
-      case 'shell':     return { cmd: process.env.SHELL || 'bash', args: [] };
+      case 'shell':     return { cmd: 'bash',      args: [] };
       default:          return null;
     }
+  }
+
+  // Harness/config + design-store mounts (mirror the project sandbox DEFAULT_VOLUMES).
+  function designMounts() {
+    const home = os.homedir();
+    const specs = [];
+    const add = (src, dst) => { const s = src.replace(/^~/, home); if (fs.existsSync(s)) specs.push('-v', `${s}:${dst}`); };
+    add('~/.jonggrang', '/root/.jonggrang');            // design store + templates
+    add('~/.claude', '/root/.claude');
+    add('~/.claude.json', '/root/.claude.json');
+    add('~/.opencode', '/root/.opencode');
+    add('~/.config/opencode', '/root/.config/opencode');
+    add('~/.local/share/opencode', '/root/.local/share/opencode');
+    add('~/.codex', '/root/.codex');
+    return specs;
+  }
+  function containerRunning() {
+    try { return execFileSync('docker', ['ps', '-q', '-f', `name=^${DESIGN_CONTAINER}$`], { encoding: 'utf8' }).trim().length > 0; }
+    catch { return false; }
+  }
+  function ensureDesignContainer() {
+    if (containerRunning()) return;
+    try { execFileSync('docker', ['rm', '-f', DESIGN_CONTAINER], { stdio: 'ignore' }); } catch { /* not present */ }
+    execFileSync('docker', ['run', '-d', '--name', DESIGN_CONTAINER, '--env', 'IS_SANDBOX=1', ...designMounts(), AGENT_IMAGE, 'sleep', 'infinity'], { stdio: 'ignore' });
+  }
+  function killAllPtys() {
+    for (const proc of designPtys.values()) { try { proc.kill(); } catch { /* ignore */ } }
+    designPtys.clear();
+  }
+
+  function spawnDesign(name, tool, cols, rows, sandbox) {
+    const resolved = resolveToolCommand(tool);
+    if (!resolved) throw new Error(`unsupported tool: ${tool}`);
+    const key = `design:${name}`;
+    if (designPtys.has(key)) { try { designPtys.get(key).kill(); } catch { /* ignore */ } designPtys.delete(key); }
+    const dims = { cols: Math.max(20, cols | 0), rows: Math.max(6, rows | 0) };
+    let proc;
+    if (sandbox) {
+      ensureDesignContainer();
+      const cwd = `/root/.jonggrang/design/${name}`;
+      proc = pty.spawn('docker', ['exec', '-it', '--workdir', cwd, DESIGN_CONTAINER, resolved.cmd, ...resolved.args],
+        { name: 'xterm-256color', ...dims, cwd: os.homedir(), env: { ...process.env, TERM: 'xterm-256color' } });
+    } else {
+      const dir = path.join(design.designRoot(), name);
+      proc = pty.spawn(resolved.cmd, resolved.args,
+        { name: 'xterm-256color', ...dims, cwd: dir, env: { ...process.env, TERM: 'xterm-256color' } });
+    }
+    designPtys.set(key, proc);
+    proc.onData(data => { if (io && io.emit) io.emit('pty.data', { project_id: key, session: 'design', data }); });
+    proc.onExit(({ exitCode }) => { designPtys.delete(key); if (io && io.emit) io.emit('pty.exit', { project_id: key, session: 'design', exitCode }); });
+    return proc;
   }
 
   app.post('/api/design/:name/terminal/start', (req, res) => {
     try {
       const name = req.params.name;
-      const dir = path.join(design.designRoot(), name);
-      if (!fs.existsSync(dir)) return res.status(404).json({ error: 'template not found' });
-      const { cols = 80, rows = 24, tool = 'shell' } = req.body || {};
-      const resolved = resolveToolCommand(tool);
-      if (!resolved) return res.status(400).json({ error: `unsupported tool: ${tool}` });
-      const key = `design:${name}`;
-      if (designPtys.has(key)) { try { designPtys.get(key).kill(); } catch { /* ignore */ } designPtys.delete(key); }
-      const proc = pty.spawn(resolved.cmd, resolved.args, {
-        name: 'xterm-256color',
-        cols: Math.max(20, cols | 0), rows: Math.max(6, rows | 0),
-        cwd: dir,
-        env: { ...process.env, TERM: 'xterm-256color' },
-      });
-      designPtys.set(key, proc);
-      proc.onData(data => { if (io && io.emit) io.emit('pty.data', { project_id: key, session: 'design', data }); });
-      proc.onExit(({ exitCode }) => {
-        designPtys.delete(key);
-        if (io && io.emit) io.emit('pty.exit', { project_id: key, session: 'design', exitCode });
-      });
-      res.json({ ok: true, tool, cwd: dir });
+      if (!fs.existsSync(path.join(design.designRoot(), name))) return res.status(404).json({ error: 'template not found' });
+      const { cols = 80, rows = 24, tool = 'shell', sandbox = false } = req.body || {};
+      spawnDesign(name, tool, cols, rows, !!sandbox);
+      res.json({ ok: true, tool, sandbox: !!sandbox });
     } catch (err) { res.status(500).json({ error: err.message }); }
   });
 
@@ -177,6 +221,24 @@ module.exports = function register(app, io, _ctx) {
     const proc = designPtys.get(key);
     if (proc) { try { proc.kill(); } catch { /* ignore */ } designPtys.delete(key); }
     res.json({ ok: true });
+  });
+
+  // Sandbox container controls (shared across templates).
+  app.get('/api/design/sandbox/status', (req, res) => {
+    let running = false; try { running = containerRunning(); } catch { /* ignore */ }
+    res.json({ container: DESIGN_CONTAINER, image: AGENT_IMAGE, running });
+  });
+  app.post('/api/design/sandbox/restart', (req, res) => {
+    try { killAllPtys(); execFileSync('docker', ['restart', DESIGN_CONTAINER], { stdio: 'ignore' }); res.json({ ok: true }); }
+    catch (err) { res.status(500).json({ error: err.message }); }
+  });
+  app.post('/api/design/sandbox/rebuild', (req, res) => {
+    try {
+      killAllPtys();
+      try { execFileSync('docker', ['rm', '-f', DESIGN_CONTAINER], { stdio: 'ignore' }); } catch { /* ignore */ }
+      ensureDesignContainer();
+      res.json({ ok: true, recreated: true, image: AGENT_IMAGE });
+    } catch (err) { res.status(500).json({ error: err.message }); }
   });
 
   if (io && io.on) {
@@ -196,8 +258,5 @@ module.exports = function register(app, io, _ctx) {
     });
   }
 
-  return function cleanup() {
-    for (const proc of designPtys.values()) { try { proc.kill(); } catch { /* ignore */ } }
-    designPtys.clear();
-  };
+  return function cleanup() { killAllPtys(); };
 };

--- a/apis/projects/plan.js
+++ b/apis/projects/plan.js
@@ -300,8 +300,11 @@ module.exports = function (deps) {
         const project = webState.getProject(req.params.id);
         if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
 
-        const { description, deep, tool, model, effort, fileContent, fileName, base } = req.body || {};
+        const { description, deep, tool, model, effort, fileContent, fileName, base, baseline } = req.body || {};
 
+        if (baseline && !/^[A-Za-z0-9][\w.@-]*$/.test(String(baseline))) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'baseline must be a plain design/baseline id (letters, digits, . _ - @)' } });
+        }
         if (!description && !fileContent) {
             return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'description or file required' } });
         }
@@ -351,6 +354,7 @@ module.exports = function (deps) {
         if (model) args.push('--model', model);
         if (effort) args.push('--effort', effort);
         if (base) args.push('--base', base);
+        if (baseline) args.push('--baseline', baseline);
         const child = spawnForProject(project, args);
         wireProjectProcess(project.id, child, 'plan');
         activePlan.set(project.id, { child, command: 'plan' });
@@ -386,8 +390,11 @@ module.exports = function (deps) {
         const project = webState.getProject(req.params.id);
         if (!project) return res.status(404).json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Not found' } });
 
-        const { description, deep, tool, model, effort, base, answers } = req.body || {};
+        const { description, deep, tool, model, effort, base, answers, baseline } = req.body || {};
         if (!description) return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'description required' } });
+        if (baseline && !/^[A-Za-z0-9][\w.@-]*$/.test(String(baseline))) {
+            return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'baseline must be a plain design/baseline id (letters, digits, . _ - @)' } });
+        }
         if (!Array.isArray(answers) || answers.length === 0) {
             return res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'answers must be a non-empty array' } });
         }
@@ -435,6 +442,7 @@ module.exports = function (deps) {
         if (model) args.push('--model', model);
         if (effort) args.push('--effort', effort);
         if (base) args.push('--base', base);
+        if (baseline) args.push('--baseline', baseline);
         const child = spawnForProject(project, args);
         wireProjectProcess(project.id, child, 'plan');
         activePlan.set(project.id, { child, command: 'plan' });

--- a/apis/storage.js
+++ b/apis/storage.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Global object-storage API — S3-compatible uploads for plan mode + design studio.
+// Config secrets live in ~/.jonggrang/web/storage.json (see lib/storage.js); the
+// GET endpoint never returns the keys. Upload takes a raw body (any content-type)
+// so large files skip base64 inflation and the app-level JSON parser.
+
+const express = require('express');
+const storage = require('../lib/storage');
+
+module.exports = function register(app, io, _ctx) {
+  // Non-secret config for the Settings UI.
+  app.get('/api/storage/config', (req, res) => {
+    try { res.json(storage.publicConfig()); }
+    catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // Save config. undefined = leave as-is; '' = clear a field (mirrors git-tokens).
+  app.put('/api/storage/config', (req, res) => {
+    const b = req.body || {};
+    try {
+      const patch = {};
+      for (const k of ['provider', 'endpoint', 'bucket', 'region', 'publicUrl', 'accessKeyId', 'secretAccessKey']) {
+        if (b[k] !== undefined) patch[k] = String(b[k]);
+      }
+      if (b.forcePathStyle !== undefined) patch.forcePathStyle = !!b.forcePathStyle;
+      storage.saveConfig(patch);
+      res.json(storage.publicConfig());
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // Connectivity check for the Settings "Test" button.
+  app.post('/api/storage/test', async (req, res) => {
+    try { await storage.testConnection(); res.json({ ok: true }); }
+    catch (err) { res.status(400).json({ ok: false, error: err.message }); }
+  });
+
+  // Upload a file → { key, url, filename }. Body is the raw file bytes; the name
+  // comes from ?filename= (or X-Filename), the mime from Content-Type.
+  app.post('/api/storage/upload', express.raw({ type: () => true, limit: '64mb' }), async (req, res) => {
+    try {
+      if (!storage.isConfigured()) return res.status(400).json({ error: 'storage is not configured — set it in Settings' });
+      const filename = req.query.filename || req.headers['x-filename'] || 'file';
+      const contentType = req.headers['content-type'] || 'application/octet-stream';
+      const buf = req.body;
+      if (!Buffer.isBuffer(buf) || buf.length === 0) return res.status(400).json({ error: 'empty upload body' });
+      const result = await storage.upload(buf, String(filename), contentType);
+      res.json(result);
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  return () => {};
+};

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -1143,10 +1143,10 @@ function listAvailablePlans(jonggrangDir) {
   return plans;
 }
 
-function buildUiPlanContext(sessionId, description, srcPath = null, force = false) {
+function buildUiPlanContext(sessionId, description, srcPath = null, force = false, chosenBaseline = null) {
   if (!force && !uiContext.detectUiWork(description, { srcPath })) return null;
   const audit = uiContext.auditUiProject(PROJECT_ROOT, { userRoot: path.join(os.homedir(), '.jonggrang') });
-  return uiContext.buildPlanningContext(PROJECT_ROOT, sessionId, description, audit);
+  return uiContext.buildPlanningContext(PROJECT_ROOT, sessionId, description, audit, chosenBaseline);
 }
 
 function verifyUiDraftPlan(planFile, sessionId) {
@@ -1468,6 +1468,7 @@ async function cmdPlan(args, opts = {}) {
   let answersInput = '';   // --answers <file|-> : run Pass B directly with these answers
   let answersInline = '';  // --answers-inline <base64-json> : same, sandbox/web-safe
   let noAsk = false;       // --no-ask : skip the clarification step entirely
+  let baselineId = '';     // --baseline <id> : pre-select a UI design baseline/template
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -1482,7 +1483,25 @@ async function cmdPlan(args, opts = {}) {
     else if (arg === '--answers') answersInput = args[++i] || '';
     else if (arg === '--answers-inline') answersInline = args[++i] || '';
     else if (arg === '--no-ask') noAsk = true;
+    else if (arg === '--baseline') baselineId = args[++i] || '';
+    else if (arg.startsWith('--baseline=')) baselineId = arg.slice(11);
     else if (!arg.startsWith('--')) description = arg;
+  }
+
+  // --baseline <id>: pre-select a UI design baseline/template (built-in pack or a
+  // personal ~/.jonggrang/design/<name>). Selecting it up front means the planner
+  // uses that design directly and never asks the "which starter?" question. A bare
+  // id (e.g. "helo") resolves to its single "<id>@<version>" key when unambiguous.
+  if (baselineId) {
+    const keys = uiContext.baselineKeys();
+    if (!keys.includes(baselineId)) {
+      const byId = keys.filter(k => k.split('@')[0] === baselineId);
+      if (byId.length === 1) baselineId = byId[0];
+      else {
+        logError(`Unknown --baseline "${baselineId}". Available: ${keys.join(', ') || '(none)'}.`);
+        process.exit(1);
+      }
+    }
   }
 
   // Validate --base up front: it ends up interpolated into `git fetch` at
@@ -1605,7 +1624,7 @@ async function cmdPlan(args, opts = {}) {
     }
 
     if (!isInteractiveTTY) {
-      logError('Usage: jonggrang plan "<feature-description>" [--yes]');
+      logError('Usage: jonggrang plan "<feature-description>" [--baseline <id>] [--yes]');
       process.exit(1);
     }
 
@@ -1648,9 +1667,9 @@ async function cmdPlan(args, opts = {}) {
   const questionsFile = lib.questionsFileFor(PROJECT_ROOT, sid);
   const answersFile = lib.answersFileFor(PROJECT_ROOT, sid);
   process.env.JONGGRANG_DRAFT_SESSION = sid;
-  let uiPlan = buildUiPlanContext(sid, description, srcPath);
+  let uiPlan = buildUiPlanContext(sid, description, srcPath, Boolean(baselineId), baselineId || null);
   if (uiPlan) {
-    logInfo(`UI work detected — guide ${uiPlan.guideStatus}; baseline recommendation ${uiPlan.baseline || 'needs user choice'}.`);
+    logInfo(`UI work detected — guide ${uiPlan.guideStatus}; baseline ${baselineId ? `selected ${uiPlan.baseline}` : `recommendation ${uiPlan.baseline || 'needs user choice'}`}.`);
     if ((autoApprove || noAsk) && (uiPlan.requiresBaselineConsent || !uiPlan.baseline)) {
       logError('A starter baseline cannot be selected with --yes/--no-ask before the user confirms they have no preferred UI direction or reference. Run interactive plan once, provide answers, or explicitly name a baseline id in the request.');
       process.exit(1);
@@ -3481,7 +3500,7 @@ async function cmdMenuFull(runJonggrangApp) {
           await cmdReview();
           break;
         case 'agent':
-          await cmdAgent();
+          await cmdAgent(rest);
           break;
         case 'web':
           cmdWeb();
@@ -3532,13 +3551,23 @@ function spawnJonggrang(args) {
 }
 
 async function cmdAgent(rawArgs = []) {
-  // Optional interactive seed: `agent [--readonly] <initial prompt>`. Used by the
-  // web "Discuss" mode to open the Pi TUI already primed with a plan draft and,
-  // when --readonly is set, restricted to non-mutating tools.
+  // Optional interactive seed: `agent [--readonly] [-r|-c|--session <id>] <initial prompt>`.
+  // Used by the web "Discuss" mode to open the Pi TUI already primed with a plan draft
+  // and, when --readonly is set, restricted to non-mutating tools. The resume flags map
+  // straight to Pi: -r/--resume (browse & select a prior session), -c/--continue
+  // (continue the most recent), --session <id> (a specific session). The Design studio
+  // passes -r to continue a template's prior conversation.
   let readonly = false;
+  let resumeFlag = null;   // '--resume' | '--continue'
+  let sessionId = '';
   const promptParts = [];
-  for (const a of rawArgs) {
+  for (let i = 0; i < rawArgs.length; i++) {
+    const a = rawArgs[i];
     if (a === '--readonly') readonly = true;
+    else if (a === '-r' || a === '--resume') resumeFlag = '--resume';
+    else if (a === '-c' || a === '--continue') resumeFlag = '--continue';
+    else if (a === '--session') sessionId = rawArgs[++i] || '';
+    else if (a.startsWith('--session=')) sessionId = a.slice('--session='.length);
     else promptParts.push(a);
   }
   const initialPrompt = promptParts.join(' ').trim();
@@ -3696,6 +3725,13 @@ async function cmdAgent(rawArgs = []) {
   const piArgs = [];
   if (initialPrompt) piArgs.push(initialPrompt);
   if (readonly) piArgs.push('--tools', 'read,grep,find,ls');
+  // Resume a prior conversation. An explicit --session id wins; otherwise -r/-c map
+  // to Pi's session picker / continue-most-recent. Skipped when seeding a fresh
+  // prompt (a seeded discussion starts a new session by design).
+  if (!initialPrompt) {
+    if (sessionId) piArgs.push('--session', sessionId);
+    else if (resumeFlag) piArgs.push(resumeFlag);
+  }
   piArgs.push(...extArgs);
 
   await main(piArgs, { extensionFactories: [jonggrangExtension] });

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -2146,10 +2146,12 @@ async function cmdApprove(args, opts = {}) {
       if (uiTasks.length === 0) throw new Error('UI plan produced no tasks with ui_context');
 
       let finalGuideContent = approvedUi.guideContent;
+      let foundationId = null;
       if (approvedUi.tokenStatus === 'planned') {
         const foundations = uiTasks.filter(task => task.ui_context.foundation === true);
         if (foundations.length !== 1) throw new Error('planned token source needs exactly one UI-foundation task');
-        finalGuideContent = uiContext.updateFrontmatter(finalGuideContent, { token_owner_task: foundations[0].id });
+        foundationId = foundations[0].id;
+        finalGuideContent = uiContext.updateFrontmatter(finalGuideContent, { token_owner_task: foundationId });
       }
       const finalGuideRevision = uiContext.contentDigest(finalGuideContent);
       const tasksFile = lib.tasksFileFor(PROJECT_ROOT, featureId);
@@ -2162,6 +2164,12 @@ async function cmdApprove(args, opts = {}) {
           task.ui_context.guide_revision = finalGuideRevision;
           task.ui_context.baseline = approvedUi.baseline;
           task.ui_context.token_source = approvedUi.tokenSource;
+          // Every dependent UI task must wait for the token foundation; add the
+          // dependency deterministically if the decomposition agent omitted it.
+          if (foundationId && task.id !== foundationId) {
+            task.blocked_by = Array.isArray(task.blocked_by) ? task.blocked_by : [];
+            if (!task.blocked_by.includes(foundationId)) task.blocked_by.push(foundationId);
+          }
         }
       }
       lib.writeJSON(tasksFile, taskData);

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -17,6 +17,7 @@ const hooksLib = require('../lib/hooks');
 const compaction = require('../lib/compaction');
 const feedback = require('../lib/feedback');
 const uiContext = require('../lib/ui-context');
+const design = require('../lib/design');
 
 // ============================================================
 // CONFIGURATION
@@ -4728,6 +4729,156 @@ Examples:
 }
 
 // ============================================================
+// DESIGN — global design templates (~/.jonggrang/design/<name>)
+// ============================================================
+
+function cmdDesign(args) {
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+  if (!subcommand || subcommand === 'help' || subcommand === '--help') { cmdDesignHelp(); return; }
+
+  const flags = {};
+  const positional = [];
+  let j = 0;
+  while (j < subArgs.length) {
+    if (subArgs[j] === '--from')          { flags.from = subArgs[++j]; }
+    else if (subArgs[j] === '--intent')   { flags.intent = subArgs[++j]; }
+    else if (subArgs[j] === '--shapes')   { flags.shapes = subArgs[++j]; }
+    else if (subArgs[j] === '--keywords') { flags.keywords = subArgs[++j]; }
+    else if (subArgs[j] === '--variant')  { flags.variant = subArgs[++j]; }
+    else if (subArgs[j] === '--force')    { flags.force = true; }
+    else if (subArgs[j] === '--json')     { flags.json = true; }
+    else { positional.push(subArgs[j]); }
+    j++;
+  }
+  const pretty = !flags.json && process.stdout.isTTY;
+
+  try {
+    switch (subcommand) {
+      case 'list':     designList(pretty); break;
+      case 'new':      designNew(positional[0], flags, pretty); break;
+      case 'promote':  designPromote(positional[0], flags, pretty); break;
+      case 'show':     designShow(positional[0], pretty); break;
+      case 'validate': designValidate(positional[0], pretty); break;
+      case 'remove':
+      case 'rm':       designRemove(positional[0], pretty); break;
+      case 'get':      designGet(positional[0], positional[1], flags); break; // design get <name> <what>
+      default:
+        // design <name> get <what>
+        if (positional[0] === 'get') designGet(subcommand, positional[1], flags);
+        else designShow(subcommand, pretty);
+    }
+  } catch (err) {
+    if (pretty) logError(err.message);
+    else console.log(JSON.stringify({ error: err.message }));
+    process.exit(1);
+  }
+}
+
+function designList(pretty) {
+  const templates = design.listTemplates();
+  if (!pretty) { console.log(JSON.stringify(templates.map(t => ({ id: t.id, key: t.key, valid: t.valid, source: t.source })))); return; }
+  console.log(`Design templates  ${DIM}(${design.designRoot()})${NC}`);
+  if (!templates.length) { console.log('  (none) — create one with: jonggrang design new <name>'); return; }
+  for (const t of templates) {
+    const mark = t.valid ? `${GREEN}✓${NC}` : `${RED}✗${NC}`;
+    console.log(`  ${mark} ${t.key}${t.intent ? `  ${DIM}${t.intent}${NC}` : ''}`);
+    if (!t.valid) console.log(`      ${RED}${(t.errors || []).join('; ')}${NC}`);
+  }
+}
+
+function designNew(name, flags, pretty) {
+  if (!name) throw new Error('Usage: jonggrang design new <name> [--intent "..."] [--shapes a,b] [--keywords a,b]');
+  const res = design.newTemplate(name, {
+    intent: flags.intent,
+    product_shapes: flags.shapes ? flags.shapes.split(',').map(s => s.trim()).filter(Boolean) : undefined,
+    recommend_keywords: flags.keywords ? flags.keywords.split(',').map(s => s.trim()).filter(Boolean) : undefined,
+    force: flags.force,
+  });
+  if (pretty) logSuccess(`Created design template ${name} at ${res.dir}`);
+  else console.log(JSON.stringify(res));
+}
+
+function designPromote(name, flags, pretty) {
+  if (!name) throw new Error('Usage: jonggrang design promote <name> [--from <project-path>]');
+  const projectRoot = flags.from ? path.resolve(flags.from) : PROJECT_ROOT;
+  const res = design.promoteFromProject(name, projectRoot, { force: flags.force });
+  if (pretty) {
+    logSuccess(`Promoted ${projectRoot} → design template ${name}`);
+    console.log(`  ${DIM}${res.dir}${NC}`);
+    if (res.tokenSource) console.log(`  token source: ${res.tokenSource}`);
+  } else console.log(JSON.stringify(res));
+}
+
+function designShow(name, pretty) {
+  if (!name) throw new Error('Usage: jonggrang design show <name>');
+  const t = design.loadTemplate(name);
+  if (!pretty) { console.log(JSON.stringify({ key: t.key, manifest: t.manifest, components: t.components.map(c => ({ id: c.id, variants: c.variants })) })); return; }
+  console.log(`${t.key}  ${DIM}${t.manifest.intent || ''}${NC}`);
+  console.log(`  dir:        ${t.dir}`);
+  console.log(`  shapes:     ${(t.manifest.product_shapes || []).join(', ')}`);
+  console.log(`  components:  ${t.components.length ? t.components.map(c => c.id).join(', ') : '(none)'}`);
+  const sections = uiContext.markdownSections(t.guideFragment).sections.filter(s => s.level === 2).map(s => s.title);
+  console.log(`  guide:      ${sections.length} sections`);
+  const v = design.validateTemplate(name);
+  console.log(`  valid:      ${v.valid ? `${GREEN}yes${NC}` : `${RED}no — ${v.errors.join('; ')}${NC}`}`);
+  if (v.warnings.length) console.log(`  warnings:   ${YELLOW}${v.warnings.join('; ')}${NC}`);
+}
+
+function designValidate(name, pretty) {
+  if (!name) throw new Error('Usage: jonggrang design validate <name>');
+  const v = design.validateTemplate(name);
+  if (!pretty) { console.log(JSON.stringify(v)); if (!v.valid) process.exit(1); return; }
+  if (v.valid) logSuccess(`${name} is valid`);
+  else { logError(`${name} invalid:`); v.errors.forEach(e => console.log(`  - ${e}`)); }
+  if (v.warnings.length) { console.log(`${YELLOW}warnings:${NC}`); v.warnings.forEach(w => console.log(`  - ${w}`)); }
+  if (!v.valid) process.exit(1);
+}
+
+function designRemove(name, pretty) {
+  if (!name) throw new Error('Usage: jonggrang design remove <name>');
+  design.removeTemplate(name);
+  if (pretty) logSuccess(`Removed design template ${name}`);
+  else console.log(JSON.stringify({ removed: name }));
+}
+
+// design <name> get <tokens|guide|manifest|component>  — RAW output (agent-facing)
+function designGet(name, what, flags) {
+  if (!name || !what) throw new Error('Usage: jonggrang design <name> get <tokens|guide|manifest|component-id>');
+  process.stdout.write(design.getArtifact(name, what, { variant: flags.variant }));
+  if (process.stdout.isTTY) process.stdout.write('\n');
+}
+
+function cmdDesignHelp() {
+  console.log(`jonggrang design — global, reusable design templates (~/.jonggrang/design/<name>)
+
+A design template is a superset of a UI baseline pack: manifest.yml + guide-fragment.md
++ tokens.css.template + framework-agnostic HTML/token components. Personal templates are
+selectable in \`plan\` exactly like built-in baseline packs.
+
+Usage: jonggrang design <subcommand> [options]
+
+Subcommands:
+  list                          List templates in ~/.jonggrang/design
+  new <name> [--intent "..."]   Scaffold a new template (--shapes a,b --keywords a,b)
+  promote <name> [--from <dir>] Build a template from a project's .jonggrang/UI.md + tokens
+  show <name>                   Show manifest, components, guide sections, validity
+  validate <name>               Validate against the pack + component contract
+  <name> get <what>             Emit tokens | guide | manifest | <component-id> (raw, agent-facing)
+  remove <name>                 Delete a template
+
+Options: --from <dir>  --intent  --shapes a,b  --keywords a,b  --variant <v>  --force  --json
+
+Examples:
+  jonggrang design new acme --intent "Acme brand" --shapes dashboard
+  jonggrang design promote acme --from ~/work/acme-app
+  jonggrang design acme get button
+  jonggrang design acme get tokens > acme-tokens.css
+  jonggrang design list
+`);
+}
+
+// ============================================================
 // HELP
 // ============================================================
 
@@ -4758,6 +4909,7 @@ Commands:
   task <subcommand>       Manage tasks (list, add, update, done, block, remove, show, next)
   memory <subcommand>     Repo-tracked memory (read, recall, fragment add, compact, promote) (#79)
   manifest [sub]          Inspect output-file manifests (list, show, add)
+  design <sub>            Global design templates (list, new, promote, show, get, validate, remove)
   codemap [opts]          Show/refresh deterministic codebase map (LLM-free)
   agent                   Start interactive chat with the AI agent (Pi TUI)
   login                   Add provider credentials (OAuth subscription or API key)
@@ -4968,6 +5120,11 @@ async function main() {
 
   if (command === 'issues') {
     await cmdIssues(rest);
+    return;
+  }
+
+  if (command === 'design') {
+    cmdDesign(rest);
     return;
   }
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -8,6 +8,7 @@
       <div class="nav-links">
         <RouterLink to="/" class="nav-link">projects</RouterLink>
         <RouterLink to="/issues" class="nav-link">issues</RouterLink>
+        <RouterLink to="/design" class="nav-link">design</RouterLink>
         <RouterLink to="/secrets" class="nav-link">secrets</RouterLink>
         <RouterLink to="/settings" class="nav-link">settings</RouterLink>
       </div>

--- a/client/src/components/plan/PlanView.vue
+++ b/client/src/components/plan/PlanView.vue
@@ -20,30 +20,43 @@
           @keydown.ctrl.enter="generatePlan"
         />
         <div class="plan-form-footer">
-          <label class="deep-label">
-            <input type="checkbox" v-model="deep" />
-            Deep analysis
-          </label>
-          <label class="deep-label" style="gap:6px" title="Branch the worktree is cut from (fetched fresh from origin)">
-            base:
-            <Select v-model="selectedBase" :options="availableBranches" filter resetFilterOnHide
-                    filterPlaceholder="search branch…" scrollHeight="240px"
-                    placeholder="base branch" class="base-select" />
-          </label>
-          <div style="flex:1" />
-          <button class="tool-config-btn" @click="triggerFileInput" title="Upload BRD/PRD source file">
-            <i class="pi pi-upload" /> BRD/PRD
-          </button>
-          <input ref="fileInputRef" type="file" style="display:none" @change="onFileChange" />
-          <button class="tool-config-btn" @click="openToolModal">
-            <span>{{ TOOLS.find(t => t.value === selectedTool)?.label || 'Configure' }}</span>
-            <span v-if="selectedModel" class="tool-config-extra">· {{ selectedModel }}</span>
-            <span v-if="selectedEffort" class="tool-config-extra">· {{ selectedEffort }}</span>
-            <i class="pi pi-cog" />
-          </button>
-          <Button :disabled="(!description.trim() && !uploadedFile) || generating" @click="generatePlan">
-            <i class="pi pi-sparkles" /> {{ generating ? 'Generating...' : 'Generate Plan' }}
-          </Button>
+          <div class="plan-footer-config">
+            <label class="deep-label">
+              <input type="checkbox" v-model="deep" />
+              Deep analysis
+            </label>
+            <label class="deep-label" title="Branch the worktree is cut from (fetched fresh from origin)">
+              base:
+              <Select v-model="selectedBase" :options="availableBranches" filter resetFilterOnHide
+                      filterPlaceholder="search branch…" scrollHeight="240px"
+                      placeholder="base branch" class="base-select" />
+            </label>
+            <label v-if="baselineOptions.length" class="deep-label" title="Design template / UI baseline to style this plan from (skips the design question)">
+              design:
+              <Select v-model="selectedBaseline" :options="baselineOptions" optionLabel="label" optionValue="value"
+                      filter resetFilterOnHide filterPlaceholder="search design…" scrollHeight="240px"
+                      showClear placeholder="auto" class="base-select" />
+            </label>
+          </div>
+          <div class="plan-footer-actions">
+            <button v-if="storageConfigured" class="tool-config-btn" @click="triggerUpload" :disabled="uploading" title="Upload a file to storage — inserts a shareable link into the description">
+              <i :class="uploading ? 'pi pi-spin pi-spinner' : 'pi pi-cloud-upload'" /> {{ uploading ? 'Uploading…' : 'Upload' }}
+            </button>
+            <input ref="uploadInputRef" type="file" style="display:none" @change="onUploadChange" />
+            <button class="tool-config-btn" @click="triggerFileInput" title="Upload BRD/PRD source file">
+              <i class="pi pi-upload" /> BRD/PRD
+            </button>
+            <input ref="fileInputRef" type="file" style="display:none" @change="onFileChange" />
+            <button class="tool-config-btn" @click="openToolModal">
+              <span>{{ TOOLS.find(t => t.value === selectedTool)?.label || 'Configure' }}</span>
+              <span v-if="selectedModel" class="tool-config-extra">· {{ selectedModel }}</span>
+              <span v-if="selectedEffort" class="tool-config-extra">· {{ selectedEffort }}</span>
+              <i class="pi pi-cog" />
+            </button>
+            <Button class="plan-generate-btn" :disabled="(!description.trim() && !uploadedFile) || generating" @click="generatePlan">
+              <i class="pi pi-sparkles" /> {{ generating ? 'Generating...' : 'Generate Plan' }}
+            </Button>
+          </div>
         </div>
         <div v-if="genError" class="error-text">{{ genError }}</div>
       </div>
@@ -164,23 +177,34 @@
               @keydown.ctrl.enter="generatePlan"
             />
             <div class="plan-new-footer">
-              <label class="deep-label">
-                <input type="checkbox" v-model="deep" />
-                Deep analysis
-              </label>
-              <label class="deep-label" style="gap:6px" title="Branch the worktree is cut from (fetched fresh from origin)">
-                base:
-                <Select v-model="selectedBase" :options="availableBranches" filter resetFilterOnHide
-                        filterPlaceholder="search branch…" scrollHeight="240px"
-                        placeholder="base branch" class="base-select" />
-              </label>
-              <div style="flex:1" />
-              <div style="display:flex;gap:8px">
+              <div class="plan-footer-config">
+                <label class="deep-label">
+                  <input type="checkbox" v-model="deep" />
+                  Deep analysis
+                </label>
+                <label class="deep-label" title="Branch the worktree is cut from (fetched fresh from origin)">
+                  base:
+                  <Select v-model="selectedBase" :options="availableBranches" filter resetFilterOnHide
+                          filterPlaceholder="search branch…" scrollHeight="240px"
+                          placeholder="base branch" class="base-select" />
+                </label>
+                <label v-if="baselineOptions.length" class="deep-label" title="Design template / UI baseline to style this plan from (skips the design question)">
+                  design:
+                  <Select v-model="selectedBaseline" :options="baselineOptions" optionLabel="label" optionValue="value"
+                          filter resetFilterOnHide filterPlaceholder="search design…" scrollHeight="240px"
+                          showClear placeholder="auto" class="base-select" />
+                </label>
+              </div>
+              <div class="plan-footer-actions">
+                <button v-if="storageConfigured" class="tool-config-btn" @click="triggerUpload" :disabled="uploading" title="Upload a file to storage — inserts a shareable link into the description">
+                  <i :class="uploading ? 'pi pi-spin pi-spinner' : 'pi pi-cloud-upload'" /> {{ uploading ? 'Uploading…' : 'Upload' }}
+                </button>
+                <input ref="uploadInputRef" type="file" style="display:none" @change="onUploadChange" />
                 <button class="tool-config-btn" @click="triggerFileInput" title="Upload BRD/PRD source file">
                   <i class="pi pi-upload" /> BRD/PRD
                 </button>
                 <Button severity="secondary" @click="cancelNewPlan">Cancel</Button>
-                <Button :disabled="!description.trim() && !uploadedFile" @click="generatePlan">
+                <Button class="plan-generate-btn" :disabled="!description.trim() && !uploadedFile" @click="generatePlan">
                   <i class="pi pi-sparkles" /> Generate Plan
                 </Button>
               </div>
@@ -468,9 +492,25 @@ const showNewPlanForm = ref(false);
 const uploadedFile = ref(null);
 const fileInputRef = ref(null);
 
+// File → object storage (S3). When configured, an "Upload" button uploads a file
+// and inserts its shareable link into the description textbox.
+const storageConfigured = ref(false);
+const uploadInputRef = ref(null);
+const uploading = ref(false);
+
 // Base branch the worktree is cut from (fetched fresh from origin at run time)
 const selectedBase = ref('');
 const availableBranches = ref([]);
+
+// UI design baseline/template (built-in packs + personal ~/.jonggrang/design/*).
+// Picking one here selects it up front so the planner styles from it and never
+// asks the "which starter?" question (passed as `plan --baseline <key>`).
+const selectedBaseline = ref('');
+const availableBaselines = ref([]);
+const baselineOptions = computed(() => availableBaselines.value.map(b => ({
+  value: b.key,
+  label: b.source === 'design' ? `${b.key} · your design` : b.key,
+})));
 
 // Tool / model / effort
 const selectedTool = ref(null);
@@ -665,6 +705,17 @@ async function loadBranches() {
   } catch {}
 }
 
+// Selectable UI baselines (built-in packs + personal design templates) for the
+// New Plan "Design" picker. Empty list simply hides the picker.
+async function loadBaselines() {
+  try {
+    const res = await fetch('/api/baselines');
+    if (!res.ok) return;
+    const data = await res.json();
+    availableBaselines.value = data.baselines || [];
+  } catch {}
+}
+
 async function pushBase() {
   pushingBase.value = true; baseNotice.value = ''; baseError.value = '';
   try {
@@ -815,6 +866,28 @@ function clearFile() {
   uploadedFile.value = null;
 }
 
+async function loadStorageConfig() {
+  try { const r = await fetch('/api/storage/config'); if (r.ok) storageConfigured.value = !!(await r.json()).configured; } catch {}
+}
+function triggerUpload() { uploadInputRef.value?.click(); }
+async function onUploadChange(e) {
+  const file = e.target.files?.[0];
+  e.target.value = '';
+  if (!file || uploading.value) return;
+  uploading.value = true; genError.value = '';
+  try {
+    const buf = await file.arrayBuffer();
+    const r = await fetch(`/api/storage/upload?filename=${encodeURIComponent(file.name)}`, {
+      method: 'POST', headers: { 'Content-Type': file.type || 'application/octet-stream' }, body: buf,
+    });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(d.error || 'Upload failed');
+    // Drop the shareable link straight into the description textbox.
+    description.value = description.value ? `${description.value.replace(/\s+$/, '')}\n${d.url}` : d.url;
+  } catch (err) { genError.value = `Upload failed: ${err.message}`; }
+  finally { uploading.value = false; }
+}
+
 async function generatePlan() {
   if ((!description.value.trim() && !uploadedFile.value) || generating.value) return;
   genError.value = '';
@@ -829,6 +902,7 @@ async function generatePlan() {
     if (selectedModel.value)  body.model  = selectedModel.value;
     if (selectedEffort.value) body.effort = selectedEffort.value;
     if (selectedBase.value)   body.base   = selectedBase.value;
+    if (selectedBaseline.value) body.baseline = selectedBaseline.value;
 
     if (uploadedFile.value) {
       // Read file as base64 in chunks to avoid blowing the call stack on
@@ -897,6 +971,7 @@ async function submitAnswers() {
   if (selectedModel.value)  body.model  = selectedModel.value;
   if (selectedEffort.value) body.effort = selectedEffort.value;
   if (selectedBase.value)   body.base   = selectedBase.value;
+  if (selectedBaseline.value) body.baseline = selectedBaseline.value;
   try {
     const res = await fetch(`/api/projects/${projectId.value}/plan/answers`, {
       method: 'POST',
@@ -995,6 +1070,8 @@ onMounted(async () => {
   await loadProjectTool();
   loadBase();
   loadBranches();
+  loadBaselines();
+  loadStorageConfig();
   applyPickupPrefill();
 
   // Restore the active plan-op spinner + log region from server truth. The
@@ -1098,7 +1175,7 @@ onUnmounted(() => {
 .plan-empty-icon { font-size: 40px; color: var(--jg-green); }
 .plan-empty-title { font-size: 16px; color: var(--jg-text); font-weight: 600; }
 .plan-empty-desc { font-size: 12px; color: var(--jg-text-muted); }
-.plan-form { width: 100%; max-width: 560px; margin-top: 12px; }
+.plan-form { width: 100%; max-width: 640px; margin-top: 12px; }
 .plan-form-footer { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
 
 /* SPLIT LAYOUT */
@@ -1187,10 +1264,15 @@ onUnmounted(() => {
 
 /* New plan form */
 .plan-new-wrap { display: flex; align-items: center; justify-content: center; flex: 1; padding: 20px; }
-.plan-new-inner { width: 100%; max-width: 560px; display: flex; flex-direction: column; gap: 12px; }
+.plan-new-inner { width: 100%; max-width: 640px; display: flex; flex-direction: column; gap: 12px; }
 .plan-new-title { font-size: 13px; font-weight: 600; color: var(--jg-text); }
-.plan-form-footer { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
-.plan-new-footer { display: flex; align-items: center; gap: 8px; }
+.plan-form-footer { display: flex; flex-wrap: wrap; justify-content: flex-start; align-items: center; gap: 10px 12px; margin-top: 8px; }
+.plan-new-footer { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 12px; }
+/* Footer splits into a config group (left) and an actions group (pinned right via
+   margin-left:auto). flex-wrap lets the actions drop to their own right-aligned row
+   on narrow widths instead of crushing the controls. */
+.plan-footer-config { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; }
+.plan-footer-actions { display: flex; align-items: center; gap: 8px; margin-left: auto; flex-shrink: 0; }
 
 /* Draft editor */
 .plan-editor-wrap { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
@@ -1289,8 +1371,11 @@ onUnmounted(() => {
 .file-badge-clear .pi { font-size: 10px; }
 
 /* Shared */
-.deep-label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--jg-text-faint); }
-.base-select { min-width: 150px; font-size: 12px; }
+.deep-label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--jg-text-faint); white-space: nowrap; }
+.base-select { min-width: 144px; font-size: 12px; }
+/* Keep the primary action on one line — never let "Generate Plan" wrap. */
+.plan-generate-btn { white-space: nowrap; flex-shrink: 0; }
+.plan-generate-btn :deep(.p-button-label) { white-space: nowrap; }
 .error-text { font-size: 11px; color: var(--jg-red); margin-top: 8px; }
 
 /* Tool config button */

--- a/client/src/composables/useInteractiveTerminal.js
+++ b/client/src/composables/useInteractiveTerminal.js
@@ -155,11 +155,20 @@ export function useInteractiveTerminal({ projectId: _projectId, session, getSock
     termInstance.value?.dispose();
   });
 
+  // Inject text into the pty as if typed (used to drop an uploaded file's link
+  // straight onto the agent's prompt line).
+  function sendInput(data) {
+    const socket = getS();
+    if (!socket || !data) return;
+    socket.emit('pty.input', { project_id: getId(), session, data });
+  }
+
   return {
     terminalRef,
     isRunning,
     markRunning,
     markStopped,
     fit,
+    sendInput,
   };
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -33,6 +33,8 @@ const routes = [
     ],
   },
   { path: '/issues',   component: () => import('../views/IssuesView.vue') },
+  { path: '/design',        component: () => import('../views/DesignListView.vue') },
+  { path: '/design/:name',  component: () => import('../views/DesignStudioView.vue') },
   { path: '/settings', component: () => import('../views/SettingsView.vue') },
   { path: '/secrets',  component: () => import('../views/SecretsView.vue') },
   // Legacy single-project route — keep old UI accessible

--- a/client/src/views/DesignListView.vue
+++ b/client/src/views/DesignListView.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="design-list">
+    <header class="dl-head">
+      <div>
+        <h1>Design</h1>
+        <p class="dl-sub">Global design templates · {{ root }}</p>
+      </div>
+      <div class="dl-actions">
+        <Button size="small" @click="showNew = !showNew"><i class="pi pi-plus" /> New template</Button>
+        <Button size="small" severity="secondary" @click="showPromote = !showPromote"><i class="pi pi-upload" /> Promote from project</Button>
+      </div>
+    </header>
+
+    <div v-if="showNew" class="dl-form">
+      <input v-model="nf.name" placeholder="template-name (kebab-case)" />
+      <input v-model="nf.intent" placeholder="intent (optional)" />
+      <input v-model="nf.shapes" placeholder="shapes: dashboard,landing-page (optional)" />
+      <Button size="small" @click="createTemplate">Create</Button>
+    </div>
+    <div v-if="showPromote" class="dl-form">
+      <input v-model="pf.name" placeholder="template-name (kebab-case)" />
+      <input v-model="pf.from" placeholder="project path (with .jonggrang/UI.md)" />
+      <Button size="small" @click="promote">Promote</Button>
+    </div>
+    <p v-if="error" class="dl-error">{{ error }}</p>
+
+    <div v-if="!templates.length" class="dl-empty">No templates yet — create one, or promote a project's design.</div>
+    <div class="dl-grid">
+      <div v-for="t in templates" :key="t.key" class="dl-card">
+        <RouterLink :to="`/design/${t.id}`" class="dl-card-main">
+          <div class="dl-card-top">
+            <span class="dl-name">{{ t.id }}</span>
+            <span class="dl-badge" :class="t.valid ? 'ok' : 'bad'">{{ t.valid ? t.key : 'invalid' }}</span>
+          </div>
+          <p class="dl-intent">{{ t.intent || '—' }}</p>
+          <p class="dl-meta">{{ (t.components || []).length }} components · {{ (t.product_shapes || []).join(', ') || 'any' }}</p>
+        </RouterLink>
+        <button class="dl-del" title="Delete" @click="remove(t.id)"><i class="pi pi-trash" /></button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { RouterLink } from 'vue-router';
+import Button from 'primevue/button';
+
+const templates = ref([]);
+const root = ref('');
+const error = ref('');
+const showNew = ref(false);
+const showPromote = ref(false);
+const nf = ref({ name: '', intent: '', shapes: '' });
+const pf = ref({ name: '', from: '' });
+
+async function load() {
+  error.value = '';
+  const res = await fetch('/api/design');
+  const data = await res.json();
+  templates.value = data.templates || [];
+  root.value = data.root || '';
+}
+
+async function createTemplate() {
+  error.value = '';
+  const body = { name: nf.value.name.trim(), intent: nf.value.intent.trim() || undefined,
+    product_shapes: nf.value.shapes ? nf.value.shapes.split(',').map(s => s.trim()).filter(Boolean) : undefined };
+  const res = await fetch('/api/design', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  if (!res.ok) { error.value = (await res.json()).error; return; }
+  showNew.value = false; nf.value = { name: '', intent: '', shapes: '' }; await load();
+}
+
+async function promote() {
+  error.value = '';
+  const res = await fetch('/api/design/promote', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: pf.value.name.trim(), fromProjectPath: pf.value.from.trim() }) });
+  if (!res.ok) { error.value = (await res.json()).error; return; }
+  showPromote.value = false; pf.value = { name: '', from: '' }; await load();
+}
+
+async function remove(name) {
+  if (!window.confirm(`Delete design template "${name}"?`)) return;
+  await fetch(`/api/design/${encodeURIComponent(name)}`, { method: 'DELETE' });
+  await load();
+}
+
+onMounted(load);
+</script>
+
+<style scoped>
+.design-list { padding: 1.5rem 2rem; color: var(--text, #ebe5db); }
+.dl-head { display: flex; justify-content: space-between; align-items: flex-start; }
+.dl-head h1 { font-size: 1.4rem; }
+.dl-sub { color: var(--text-muted, #8a8f98); font-size: .8rem; margin-top: .25rem; }
+.dl-actions { display: flex; gap: .5rem; }
+.dl-form { display: flex; gap: .5rem; margin-top: 1rem; flex-wrap: wrap; }
+.dl-form input { flex: 1; min-width: 180px; padding: .4rem .6rem; background: #141b24; border: 1px solid #2d3748; border-radius: 6px; color: inherit; }
+.dl-error { color: #f87171; margin-top: .5rem; }
+.dl-empty { color: var(--text-muted, #8a8f98); margin-top: 2rem; }
+.dl-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.25rem; }
+.dl-card { position: relative; border: 1px solid #2d3748; border-radius: 8px; background: #141b24; }
+.dl-card-main { display: block; padding: 1rem; color: inherit; text-decoration: none; }
+.dl-card-top { display: flex; justify-content: space-between; align-items: center; }
+.dl-name { font-weight: 600; }
+.dl-badge { font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; }
+.dl-badge.ok { background: rgba(74,222,128,.15); color: #4ade80; }
+.dl-badge.bad { background: rgba(248,113,113,.15); color: #f87171; }
+.dl-intent { color: var(--text-muted, #8a8f98); font-size: .8rem; margin-top: .5rem; }
+.dl-meta { color: #5b6472; font-size: .72rem; margin-top: .4rem; }
+.dl-del { position: absolute; top: .6rem; right: .6rem; background: none; border: none; color: #5b6472; cursor: pointer; opacity: 0; transition: opacity .15s; }
+.dl-card:hover .dl-del { opacity: 1; }
+.dl-del:hover { color: #f87171; }
+</style>

--- a/client/src/views/DesignStudioView.vue
+++ b/client/src/views/DesignStudioView.vue
@@ -8,7 +8,10 @@
       </span>
       <span v-if="validation.warnings && validation.warnings.length" class="st-warn">{{ validation.warnings.length }} warnings</span>
       <div class="st-spacer" />
-      <select v-model="tool" class="st-select" title="Backend for the studio TUI (unsafe)">
+      <label class="st-toggle" title="Run the TUI in a sandbox container (mounts harness + design store)">
+        <input type="checkbox" v-model="sandbox" :disabled="isRunning" /> sandbox
+      </label>
+      <select v-model="tool" class="st-select" :disabled="isRunning" title="Backend for the studio TUI (unsafe)">
         <option value="shell">shell</option>
         <option value="claude">claude</option>
         <option value="opencode">opencode</option>
@@ -18,13 +21,19 @@
       <Button v-if="!isRunning" size="small" :disabled="starting" @click="startTerminal">
         <i class="pi pi-play" /> {{ starting ? 'Starting…' : 'Start TUI' }}
       </Button>
-      <Button v-else size="small" severity="danger" @click="stopTerminal"><i class="pi pi-stop" /> Stop</Button>
+      <template v-else>
+        <Button size="small" severity="danger" @click="stopTerminal"><i class="pi pi-stop" /> Stop</Button>
+        <Button size="small" severity="secondary" title="Restart TUI" @click="restartTerminal"><i class="pi pi-refresh" /></Button>
+      </template>
+      <Button v-if="sandbox" size="small" severity="secondary" :disabled="rebuilding" title="Recreate the sandbox container fresh" @click="rebuild">
+        <i class="pi pi-box" /> {{ rebuilding ? 'Rebuilding…' : 'Rebuild' }}
+      </Button>
     </header>
 
     <div class="st-body">
       <!-- Left: the tool's native interactive TUI (unsafe) -->
       <section class="st-pane st-left">
-        <div class="st-pane-label">TUI · {{ tool }} <span class="dim">(unsafe · cwd = template)</span></div>
+        <div class="st-pane-label">TUI · {{ tool }} · {{ sandbox ? 'sandbox' : 'host' }} <span class="dim">(unsafe · cwd = template)</span></div>
         <div ref="terminalRef" class="st-terminal" />
       </section>
 
@@ -78,6 +87,8 @@ const components = ref([]);
 const validation = ref({ valid: true, errors: [], warnings: [] });
 const tokenText = ref('');
 const tool = ref('shell');
+const sandbox = ref(true);
+const rebuilding = ref(false);
 const component = ref('');
 const theme = ref('light');
 const width = ref(1024);
@@ -130,7 +141,7 @@ async function startTerminal() {
     const rows = el ? Math.floor(el.clientHeight / 17) : 24;
     const res = await fetch(`/api/design/${encodeURIComponent(name.value)}/terminal/start`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cols, rows, tool: tool.value }),
+      body: JSON.stringify({ cols, rows, tool: tool.value, sandbox: sandbox.value }),
     });
     if (res.ok) markRunning();
   } catch { /* ignore */ }
@@ -140,6 +151,22 @@ async function startTerminal() {
 async function stopTerminal() {
   await fetch(`/api/design/${encodeURIComponent(name.value)}/terminal/stop`, { method: 'POST' });
   markStopped();
+}
+
+async function restartTerminal() {
+  await stopTerminal();
+  await new Promise(r => setTimeout(r, 300));
+  await startTerminal();
+}
+
+async function rebuild() {
+  rebuilding.value = true;
+  try {
+    await stopTerminal();
+    await fetch('/api/design/sandbox/rebuild', { method: 'POST' });
+    await startTerminal();
+  } catch { /* ignore */ }
+  rebuilding.value = false;
 }
 
 onMounted(() => {
@@ -161,6 +188,7 @@ onMounted(() => {
 .st-warn { font-size: .65rem; color: #fbbf24; }
 .st-spacer { flex: 1; }
 .st-select { background: #141b24; border: 1px solid #2d3748; color: inherit; border-radius: 6px; padding: .25rem .4rem; font-size: .8rem; }
+.st-toggle { display: inline-flex; align-items: center; gap: .3rem; font-size: .8rem; color: var(--text-muted, #8a8f98); cursor: pointer; }
 .st-body { flex: 1; display: flex; min-height: 0; }
 .st-pane { display: flex; flex-direction: column; min-width: 0; }
 .st-left { width: 46%; border-right: 1px solid #2d3748; }

--- a/client/src/views/DesignStudioView.vue
+++ b/client/src/views/DesignStudioView.vue
@@ -24,7 +24,11 @@
       <template v-else>
         <Button size="small" severity="danger" @click="stopTerminal"><i class="pi pi-stop" /> Stop</Button>
         <Button size="small" severity="secondary" title="Restart TUI" @click="restartTerminal"><i class="pi pi-refresh" /></Button>
+        <Button v-if="storageConfigured" size="small" severity="secondary" :disabled="uploading" title="Upload a file — types its link into the terminal" @click="triggerUpload">
+          <i :class="uploading ? 'pi pi-spin pi-spinner' : 'pi pi-cloud-upload'" /> {{ uploading ? 'Uploading…' : 'Upload' }}
+        </Button>
       </template>
+      <input ref="uploadInputRef" type="file" style="display:none" @change="onUploadChange" />
       <Button v-if="sandbox" size="small" severity="secondary" :disabled="rebuilding" title="Recreate the sandbox container fresh" @click="rebuild">
         <i class="pi pi-box" /> {{ rebuilding ? 'Rebuilding…' : 'Rebuild' }}
       </Button>
@@ -101,11 +105,38 @@ const previewSrc = computed(() =>
   `/api/design/${encodeURIComponent(name.value)}/preview?theme=${theme.value}&width=${width.value}` +
   (component.value ? `&component=${encodeURIComponent(component.value)}` : '') + `&_=${nonce.value}`);
 
-const { terminalRef, isRunning, markRunning, markStopped } = useInteractiveTerminal({
+const { terminalRef, isRunning, markRunning, markStopped, sendInput } = useInteractiveTerminal({
   projectId: computed(() => `design:${name.value}`),
   session: 'design',
   getSocket: () => ws.socket,
 });
+
+// File → object storage (S3). When configured, an Upload button uploads a file and
+// types its shareable link into the running TUI.
+const storageConfigured = ref(false);
+const uploadInputRef = ref(null);
+const uploading = ref(false);
+async function loadStorageConfig() {
+  try { const r = await fetch('/api/storage/config'); if (r.ok) storageConfigured.value = !!(await r.json()).configured; } catch {}
+}
+function triggerUpload() { uploadInputRef.value?.click(); }
+async function onUploadChange(e) {
+  const file = e.target.files?.[0];
+  e.target.value = '';
+  if (!file || uploading.value) return;
+  uploading.value = true;
+  try {
+    const buf = await file.arrayBuffer();
+    const r = await fetch(`/api/storage/upload?filename=${encodeURIComponent(file.name)}`, {
+      method: 'POST', headers: { 'Content-Type': file.type || 'application/octet-stream' }, body: buf,
+    });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(d.error || 'Upload failed');
+    // Type the link into the TUI so the agent (or user) can use it right away.
+    sendInput(d.url + ' ');
+  } catch (err) { lintMsg.value = 'Upload failed: ' + err.message; }
+  finally { uploading.value = false; }
+}
 
 async function load() {
   const res = await fetch(`/api/design/${encodeURIComponent(name.value)}`);
@@ -172,6 +203,7 @@ async function rebuild() {
 onMounted(() => {
   ws.connect();
   load();
+  loadStorageConfig();
   const s = ws.socket;
   if (s) s.on('design.changed', (p) => { if (p && p.name === name.value) { load(); reloadPreview(); } });
 });

--- a/client/src/views/DesignStudioView.vue
+++ b/client/src/views/DesignStudioView.vue
@@ -1,0 +1,178 @@
+<template>
+  <div class="studio">
+    <header class="st-head">
+      <RouterLink to="/design" class="st-back"><i class="pi pi-arrow-left" /> Design</RouterLink>
+      <span class="st-name">{{ name }}</span>
+      <span class="st-badge" :class="validation.valid ? 'ok' : 'bad'">
+        {{ validation.valid ? 'valid' : (validation.errors || []).length + ' errors' }}
+      </span>
+      <span v-if="validation.warnings && validation.warnings.length" class="st-warn">{{ validation.warnings.length }} warnings</span>
+      <div class="st-spacer" />
+      <select v-model="tool" class="st-select" title="Backend for the studio TUI (unsafe)">
+        <option value="shell">shell</option>
+        <option value="claude">claude</option>
+        <option value="opencode">opencode</option>
+        <option value="codex">codex</option>
+        <option value="jonggrang">jonggrang</option>
+      </select>
+      <Button v-if="!isRunning" size="small" :disabled="starting" @click="startTerminal">
+        <i class="pi pi-play" /> {{ starting ? 'Starting…' : 'Start TUI' }}
+      </Button>
+      <Button v-else size="small" severity="danger" @click="stopTerminal"><i class="pi pi-stop" /> Stop</Button>
+    </header>
+
+    <div class="st-body">
+      <!-- Left: the tool's native interactive TUI (unsafe) -->
+      <section class="st-pane st-left">
+        <div class="st-pane-label">TUI · {{ tool }} <span class="dim">(unsafe · cwd = template)</span></div>
+        <div ref="terminalRef" class="st-terminal" />
+      </section>
+
+      <!-- Right: live preview + token editor + components -->
+      <section class="st-pane st-right">
+        <div class="st-preview-bar">
+          <span class="st-pane-label">Preview</span>
+          <select v-model="component" class="st-select">
+            <option value="">all components</option>
+            <option v-for="c in components" :key="c.id" :value="c.id">{{ c.id }}</option>
+          </select>
+          <select v-model="theme" class="st-select">
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
+          <select v-model.number="width" class="st-select">
+            <option :value="375">375</option>
+            <option :value="768">768</option>
+            <option :value="1024">1024</option>
+            <option :value="1280">1280</option>
+          </select>
+        </div>
+        <iframe :src="previewSrc" class="st-preview" sandbox="allow-same-origin" title="preview" />
+
+        <div class="st-editor">
+          <div class="st-editor-head">
+            <span class="st-pane-label">tokens.css.template</span>
+            <Button size="small" :disabled="saving" @click="saveTokens">{{ saving ? 'Saving…' : 'Save' }}</Button>
+          </div>
+          <textarea v-model="tokenText" class="st-textarea" spellcheck="false" />
+          <p v-if="lintMsg" class="st-lint" :class="validation.valid ? 'ok' : 'bad'">{{ lintMsg }}</p>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, RouterLink } from 'vue-router';
+import Button from 'primevue/button';
+import '@xterm/xterm/css/xterm.css';
+import { useWsStore } from '../stores/ws.js';
+import { useInteractiveTerminal } from '../composables/useInteractiveTerminal.js';
+
+const route = useRoute();
+const name = computed(() => route.params.name);
+const ws = useWsStore();
+
+const components = ref([]);
+const validation = ref({ valid: true, errors: [], warnings: [] });
+const tokenText = ref('');
+const tool = ref('shell');
+const component = ref('');
+const theme = ref('light');
+const width = ref(1024);
+const nonce = ref(0);
+const starting = ref(false);
+const saving = ref(false);
+const lintMsg = ref('');
+
+const previewSrc = computed(() =>
+  `/api/design/${encodeURIComponent(name.value)}/preview?theme=${theme.value}&width=${width.value}` +
+  (component.value ? `&component=${encodeURIComponent(component.value)}` : '') + `&_=${nonce.value}`);
+
+const { terminalRef, isRunning, markRunning, markStopped } = useInteractiveTerminal({
+  projectId: computed(() => `design:${name.value}`),
+  session: 'design',
+  getSocket: () => ws.socket,
+});
+
+async function load() {
+  const res = await fetch(`/api/design/${encodeURIComponent(name.value)}`);
+  if (!res.ok) return;
+  const t = await res.json();
+  components.value = t.components || [];
+  tokenText.value = t.tokenTemplate || '';
+  validation.value = t.validation || { valid: true, errors: [], warnings: [] };
+}
+
+function reloadPreview() { nonce.value = Date.now(); }
+
+async function saveTokens() {
+  saving.value = true; lintMsg.value = '';
+  try {
+    const res = await fetch(`/api/design/${encodeURIComponent(name.value)}/file`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: 'tokens.css.template', content: tokenText.value }),
+    });
+    const body = await res.json();
+    if (body.validation) validation.value = body.validation;
+    lintMsg.value = body.validation && body.validation.valid ? 'Saved · valid' : 'Saved · ' + ((body.validation && body.validation.errors) || []).join('; ');
+    reloadPreview();
+  } catch (e) { lintMsg.value = String(e); }
+  saving.value = false;
+}
+
+async function startTerminal() {
+  starting.value = true;
+  try {
+    const el = terminalRef.value;
+    const cols = el ? Math.floor(el.clientWidth / 7.5) : 80;
+    const rows = el ? Math.floor(el.clientHeight / 17) : 24;
+    const res = await fetch(`/api/design/${encodeURIComponent(name.value)}/terminal/start`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cols, rows, tool: tool.value }),
+    });
+    if (res.ok) markRunning();
+  } catch { /* ignore */ }
+  starting.value = false;
+}
+
+async function stopTerminal() {
+  await fetch(`/api/design/${encodeURIComponent(name.value)}/terminal/stop`, { method: 'POST' });
+  markStopped();
+}
+
+onMounted(() => {
+  ws.connect();
+  load();
+  const s = ws.socket;
+  if (s) s.on('design.changed', (p) => { if (p && p.name === name.value) { load(); reloadPreview(); } });
+});
+</script>
+
+<style scoped>
+.studio { display: flex; flex-direction: column; height: calc(100vh - 48px); color: var(--text, #ebe5db); }
+.st-head { display: flex; align-items: center; gap: .6rem; padding: .6rem 1rem; border-bottom: 1px solid #2d3748; }
+.st-back { color: var(--text-muted, #8a8f98); text-decoration: none; font-size: .85rem; }
+.st-name { font-weight: 600; }
+.st-badge { font-size: .65rem; padding: .1rem .45rem; border-radius: 4px; }
+.st-badge.ok { background: rgba(74,222,128,.15); color: #4ade80; }
+.st-badge.bad { background: rgba(248,113,113,.15); color: #f87171; }
+.st-warn { font-size: .65rem; color: #fbbf24; }
+.st-spacer { flex: 1; }
+.st-select { background: #141b24; border: 1px solid #2d3748; color: inherit; border-radius: 6px; padding: .25rem .4rem; font-size: .8rem; }
+.st-body { flex: 1; display: flex; min-height: 0; }
+.st-pane { display: flex; flex-direction: column; min-width: 0; }
+.st-left { width: 46%; border-right: 1px solid #2d3748; }
+.st-right { flex: 1; }
+.st-pane-label { font: 600 .68rem/1.4 system-ui; letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted, #8a8f98); }
+.dim { color: #5b6472; text-transform: none; letter-spacing: 0; }
+.st-terminal { flex: 1; min-height: 0; background: #0f1520; padding: .4rem; }
+.st-preview-bar { display: flex; align-items: center; gap: .5rem; padding: .5rem .75rem; border-bottom: 1px solid #2d3748; }
+.st-preview { flex: 1; min-height: 0; border: 0; background: #fff; }
+.st-editor { border-top: 1px solid #2d3748; display: flex; flex-direction: column; height: 40%; }
+.st-editor-head { display: flex; align-items: center; justify-content: space-between; padding: .4rem .75rem; }
+.st-textarea { flex: 1; resize: none; background: #0f1520; color: #ebe5db; border: 0; padding: .5rem .75rem; font-family: "JetBrains Mono", monospace; font-size: .78rem; }
+.st-lint { padding: .3rem .75rem; font-size: .72rem; }
+.st-lint.ok { color: #4ade80; } .st-lint.bad { color: #f87171; }
+</style>

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -182,6 +182,47 @@
       <Button :disabled="issrcSaving" @click="saveIssueSources" :icon="issrcSaving ? 'pi pi-spin pi-spinner' : 'pi pi-check'" :label="issrcSaving ? 'Saving…' : 'Save sources'" />
     </div>
 
+    <!-- Object storage (S3-compatible) -->
+    <div class="settings-card">
+      <div class="card-title"><i class="pi pi-cloud-upload" /> File Storage (S3)</div>
+      <p class="hint">S3-compatible storage for file uploads in <strong>Plan mode</strong> and the <strong>Design studio</strong>. Works with Cloudflare R2, MinIO, AWS S3, or any custom provider — an uploaded file's link is inserted for you. Keys are stored in <code>~/.jonggrang/web/storage.json</code> and never returned by the API.</p>
+      <div class="stor-grid">
+        <label class="stor-field">Provider
+          <select v-model="storage.provider" @change="applyProviderDefaults">
+            <option value="none">Disabled</option>
+            <option value="r2">Cloudflare R2</option>
+            <option value="minio">MinIO</option>
+            <option value="custom">Custom (S3-compatible)</option>
+          </select>
+        </label>
+        <label class="stor-field">Endpoint URL
+          <input v-model="storage.endpoint" placeholder="https://<account>.r2.cloudflarestorage.com" autocapitalize="off" spellcheck="false" />
+        </label>
+        <label class="stor-field">Bucket
+          <input v-model="storage.bucket" placeholder="my-bucket" autocapitalize="off" spellcheck="false" />
+        </label>
+        <label class="stor-field">Region
+          <input v-model="storage.region" placeholder="auto" autocapitalize="off" spellcheck="false" />
+        </label>
+        <label class="stor-field">Access Key ID
+          <input type="password" v-model="akInput" :placeholder="storage.has_access_key ? '•••••• (set — leave blank to keep)' : ''" autocomplete="off" spellcheck="false" />
+        </label>
+        <label class="stor-field">Secret Access Key
+          <input type="password" v-model="skInput" :placeholder="storage.has_secret_key ? '•••••• (set — leave blank to keep)' : ''" autocomplete="off" spellcheck="false" />
+        </label>
+        <label class="stor-field stor-wide">Public URL base <span class="stor-opt">(optional — else a 7-day presigned link is used)</span>
+          <input v-model="storage.publicUrl" placeholder="https://cdn.example.com" autocapitalize="off" spellcheck="false" />
+        </label>
+        <label class="stor-check"><input type="checkbox" v-model="storage.forcePathStyle" /> Path-style URLs (needed for MinIO / most custom endpoints)</label>
+      </div>
+      <div v-if="storError" class="error-text"><i class="pi pi-times-circle" /> {{ storError }}</div>
+      <div v-if="storOk" class="ok-text"><i class="pi pi-check-circle" /> {{ storOkMsg }}</div>
+      <div class="stor-actions">
+        <Button :disabled="storSaving" @click="saveStorage" :icon="storSaving ? 'pi pi-spin pi-spinner' : 'pi pi-check'" :label="storSaving ? 'Saving…' : 'Save'" />
+        <Button severity="secondary" :disabled="storTesting || !storage.configured" @click="testStorage" :icon="storTesting ? 'pi pi-spin pi-spinner' : 'pi pi-link'" label="Test connection" />
+      </div>
+    </div>
+
     <!-- About -->
     <div class="settings-card">
       <div class="card-title"><i class="pi pi-info-circle" /> About</div>
@@ -218,6 +259,48 @@ const workspacePath = ref('');
 const saving = ref(false);
 const saveError = ref('');
 const saveOk = ref(false);
+
+// ── Object storage (S3-compatible) ──
+const storage = reactive({ provider: 'none', endpoint: '', bucket: '', region: 'auto', publicUrl: '', forcePathStyle: true, has_access_key: false, has_secret_key: false, configured: false });
+const akInput = ref('');
+const skInput = ref('');
+const storSaving = ref(false);
+const storTesting = ref(false);
+const storError = ref('');
+const storOk = ref(false);
+const storOkMsg = ref('');
+function applyProviderDefaults() {
+  if (storage.provider === 'r2') { storage.region = storage.region || 'auto'; storage.forcePathStyle = true; }
+  else if (storage.provider === 'minio') { storage.forcePathStyle = true; }
+}
+async function loadStorage() {
+  try { const r = await fetch('/api/storage/config'); if (r.ok) Object.assign(storage, await r.json()); } catch {}
+}
+async function saveStorage() {
+  storSaving.value = true; storError.value = ''; storOk.value = false;
+  try {
+    const body = {
+      provider: storage.provider, endpoint: storage.endpoint.trim(), bucket: storage.bucket.trim(),
+      region: (storage.region || '').trim(), publicUrl: (storage.publicUrl || '').trim(), forcePathStyle: storage.forcePathStyle,
+    };
+    if (akInput.value) body.accessKeyId = akInput.value.trim();
+    if (skInput.value) body.secretAccessKey = skInput.value.trim();
+    const r = await fetch('/api/storage/config', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    const d = await r.json();
+    if (!r.ok) throw new Error(d.error || 'Save failed');
+    Object.assign(storage, d); akInput.value = ''; skInput.value = '';
+    storOkMsg.value = 'Saved!'; storOk.value = true; setTimeout(() => { storOk.value = false; }, 3000);
+  } catch (e) { storError.value = e.message; } finally { storSaving.value = false; }
+}
+async function testStorage() {
+  storTesting.value = true; storError.value = ''; storOk.value = false;
+  try {
+    const r = await fetch('/api/storage/test', { method: 'POST' });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok || !d.ok) throw new Error(d.error || 'Connection failed');
+    storOkMsg.value = 'Connection OK — bucket reachable'; storOk.value = true; setTimeout(() => { storOk.value = false; }, 3000);
+  } catch (e) { storError.value = e.message; } finally { storTesting.value = false; }
+}
 
 const sbx = reactive({ image: '', shell: '', network: '', volumes: [] });
 const sbxSaving = ref(false);
@@ -321,6 +404,7 @@ onMounted(async () => {
     if (r.ok) Object.assign(gitTok, await r.json());
   } catch {}
   await loadIssueConnections();
+  await loadStorage();
 });
 
 async function saveGitTokens() {
@@ -513,6 +597,16 @@ async function saveWorkspace() {
 }
 .input-row { display: flex; gap: 8px; }
 .hint { font-size: 11px; color: var(--jg-text-faint); margin-top: 8px; }
+/* Object-storage config grid */
+.stor-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 14px; margin: 12px 0; }
+.stor-field { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--jg-text-faint); }
+.stor-field.stor-wide { grid-column: 1 / -1; }
+.stor-field input, .stor-field select { background: var(--jg-bg); border: 1px solid var(--jg-border); border-radius: var(--radius); color: var(--jg-text); font-family: monospace; font-size: 12px; padding: 6px 8px; outline: none; }
+.stor-field input:focus, .stor-field select:focus { border-color: var(--jg-green); }
+.stor-opt { color: var(--jg-text-faint); font-weight: 400; opacity: 0.7; }
+.stor-check { grid-column: 1 / -1; display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--jg-text-faint); }
+.stor-check input { accent-color: var(--jg-green); }
+.stor-actions { display: flex; gap: 8px; margin-top: 8px; }
 .ok-text { color: var(--jg-green); font-size: 12px; margin-top: 4px; display: flex; align-items: center; gap: 4px; }
 .ssh-status { font-size: 12px; color: var(--jg-text-muted); margin: 8px 0 4px; }
 .ssh-status strong { color: var(--jg-text); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -364,6 +364,7 @@ Persistent orchestration state for a feature run. Located at:
 | `JONGGRANG_EFFORT` | Override default effort/thinking level | from config |
 | `JONGGRANG_PROJECT_ROOT` | Explicit project root for hook resolution | `process.cwd()` |
 | `JONGGRANG_DESIGN_HOME` | Design-template store location (see [DESIGN.md](DESIGN.md)) | `~/.jonggrang/design` |
+| `JONGGRANG_AGENT_IMAGE` | Agent image for the Design studio sandbox container | `ghcr.io/porcupine-md/jonggrang-agent:dev` |
 | `JONGGRANG_HOOKS_DIR` | Path to hooks/ directory | auto-resolved |
 | `JONGGRANG_COMPACTION_THRESHOLD` | Override block threshold (0-1) | 0.85 |
 | `JONGGRANG_WEB_PORT` | `jonggrang web` dashboard port (also `--port`) | `7777` |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -412,3 +412,32 @@ CLI dependency). The created plan references its source issue via a marker comme
 (`<!-- jonggrang-source: {…} -->`) plus a visible `Imported from issue owner/repo#N`
 link in the plan body; the plans list parses either to show a link on the plan card.
 See [`docs/UI.md`](UI.md) for the menu/flow.
+
+---
+
+## File storage — `~/.jonggrang/web/storage.json`
+
+S3-compatible object storage for **file uploads** in Plan mode and the Design studio.
+Configured under **Settings ▸ File Storage (S3)** (web dashboard). Works with Cloudflare
+R2, MinIO, AWS S3, or any custom S3 endpoint. Secrets live only in this file (user home,
+never the repo); the `GET /api/storage/config` endpoint returns whether keys are set, never
+the values.
+
+```jsonc
+{
+  "provider": "r2",                 // r2 | minio | custom | none (label only)
+  "endpoint": "https://<acct>.r2.cloudflarestorage.com/",
+  "bucket": "my-bucket",
+  "region": "auto",                 // R2 = "auto"
+  "forcePathStyle": true,           // required for MinIO / most custom endpoints
+  "publicUrl": "",                  // optional CDN/base URL; blank ⇒ 7-day presigned link
+  "accessKeyId": "…",               // secret — masked by the API
+  "secretAccessKey": "…"            // secret — masked by the API
+}
+```
+
+Endpoints (all global): `GET/PUT /api/storage/config`, `POST /api/storage/test`,
+`POST /api/storage/upload` (raw body; `?filename=` + `Content-Type`) → `{ key, url, filename }`.
+An upload returns a shareable link: the `publicUrl` base when set, else a 7-day presigned
+GET URL. **Plan mode** inserts the link into the description textbox; the **Design studio**
+types it into the running TUI.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -363,6 +363,7 @@ Persistent orchestration state for a feature run. Located at:
 | `JONGGRANG_MODEL` | Override default model (backend-specific format) | from config |
 | `JONGGRANG_EFFORT` | Override default effort/thinking level | from config |
 | `JONGGRANG_PROJECT_ROOT` | Explicit project root for hook resolution | `process.cwd()` |
+| `JONGGRANG_DESIGN_HOME` | Design-template store location (see [DESIGN.md](DESIGN.md)) | `~/.jonggrang/design` |
 | `JONGGRANG_HOOKS_DIR` | Path to hooks/ directory | auto-resolved |
 | `JONGGRANG_COMPACTION_THRESHOLD` | Override block threshold (0-1) | 0.85 |
 | `JONGGRANG_WEB_PORT` | `jonggrang web` dashboard port (also `--port`) | `7777` |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,116 @@
+# Design Studio & Global Design Templates
+
+Jonggrang lets you turn a design into a **reusable global template** stored at
+`~/.jonggrang/design/<name>/`, author it in a web **Design studio** (the tool's own
+interactive TUI on the left, a live preview on the right), pull tokens or a component
+from the CLI, and reuse it in any `plan` — exactly like a built-in UI baseline pack.
+
+Related: [UI planning context](UI_CONTEXT.md) · [UI baseline packs](UI_BASELINES.md).
+
+---
+
+## Storage format — `~/.jonggrang/design/<name>/`
+
+A design template is a **superset of a UI baseline pack**, so it validates and loads
+through the same machinery:
+
+```
+~/.jonggrang/design/<name>/
+  manifest.yml          # pack manifest + a `components:` list
+  guide-fragment.md     # guide body using the 8 canonical section headings
+  tokens.css.template   # semantic --ui-* token contract (OKLCH)
+  components/
+    button.html         # framework-agnostic HTML fragment using --ui-* tokens
+    ...
+  .meta.json            # provenance (created_by, promoted_from, …)
+```
+
+`manifest.yml` adds a `components:` array to the [baseline manifest](UI_BASELINES.md):
+
+```yaml
+id: acme
+version: 1
+intent: Acme brand system
+product_shapes: [dashboard]
+guide_fragment: guide-fragment.md
+token_template: tokens.css.template
+components:
+  - id: button
+    file: components/button.html
+    variants: [primary, quiet]
+```
+
+Templates are pinned `id@version`; bump `version` to fork a new pinned id.
+
+---
+
+## CLI — `jonggrang design`
+
+```bash
+jonggrang design new <name> [--intent "..."] [--shapes a,b] [--keywords a,b]
+jonggrang design list
+jonggrang design promote <name> [--from <project-path>]   # from a project's .jonggrang/UI.md + tokens
+jonggrang design show <name>
+jonggrang design <name> get <tokens|guide|manifest|component-id>   # raw, agent-facing
+jonggrang design validate <name>
+jonggrang design remove <name>
+```
+
+- **`promote`** builds a template from a project's `.jonggrang/UI.md` (guide body →
+  `guide-fragment.md`) and its token source (→ `tokens.css.template`).
+- **`get`** prints the raw artifact so a coding agent can consume it, e.g.
+  `jonggrang design acme get button` → the HTML fragment; `… get tokens > acme.css`.
+- **`validate`** checks the pack contract + that every component file resolves and uses
+  `--ui-*` tokens (raw colors are warnings, not errors).
+
+---
+
+## Reuse in `plan`
+
+`~/.jonggrang/design/*` is merged into the baseline catalog, so a personal template is
+selectable in any `plan` **by its `id@version`** — the audit recommends it, and its
+`guide-fragment` + `tokens.css.template` feed the agent's `.jonggrang/UI.md`. Built-in
+packs win on a key collision. Nothing about the plan/consent flow changes; see
+[UI planning context](UI_CONTEXT.md).
+
+---
+
+## Web Design studio (`/design`)
+
+The **Design** top-nav tab lists templates and opens a studio per template:
+
+- **Left — the tool's native TUI, in unsafe mode.** A pty-backed xterm runs the selected
+  backend's own interactive harness (`claude --dangerously-skip-permissions`, `opencode`,
+  `codex`, `jonggrang agent`, or a plain `shell`) with **CWD = the template dir**, so the
+  agent edits `manifest.yml` / `tokens.css.template` / `components/*` directly. Jonggrang
+  does not wrap the chat — you use the tool's own harness.
+- **Right — live preview.** A sandboxed `<iframe>` renders the template's components with
+  its tokens; toggles for component, light/dark, and viewport width. A **tokens editor**
+  saves `tokens.css.template` and lints on save. File changes emit `design.changed`, which
+  refreshes the preview live.
+
+### Execution mode (default: sandbox)
+
+The studio agent is intended to run **sandboxed** (a container from the agent image, with
+`IS_SANDBOX=1`, the auth mounts, and the template dir mounted) so it runs as root without
+the host `~/.claude/session-env` permission issue and its writes are isolated. A per-studio
+toggle can switch to host execution (faster; `opencode` works on the host, `claude` is
+subject to host perms). *v1 ships the host-spawn path; the sandbox-container path is a
+small follow-up.*
+
+---
+
+## Environment
+
+- **`JONGGRANG_DESIGN_HOME`** — override the design store location (default
+  `~/.jonggrang/design`). Useful for testing or a shared team store.
+
+---
+
+## Prior art
+
+The engine shape mirrors [open-design](https://github.com/nexu-io/open-design) (an
+open-source Claude-Design alternative): a design contract (`DESIGN.md` there,
+`guide-fragment` + tokens here) drives a coding-agent CLI spawned in a managed project
+cwd, writing real files. Jonggrang scopes outputs to HTML/CSS + token components so a
+template is directly reusable as a `plan` baseline.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -68,10 +68,23 @@ jonggrang design remove <name>
 ## Reuse in `plan`
 
 `~/.jonggrang/design/*` is merged into the baseline catalog, so a personal template is
-selectable in any `plan` **by its `id@version`** — the audit recommends it, and its
-`guide-fragment` + `tokens.css.template` feed the agent's `.jonggrang/UI.md`. Built-in
-packs win on a key collision. Nothing about the plan/consent flow changes; see
-[UI planning context](UI_CONTEXT.md).
+selectable in any `plan` **by its `id@version`** — its `guide-fragment` +
+`tokens.css.template` feed the agent's `.jonggrang/UI.md`. Built-in packs win on a key
+collision. There are three ways to select it:
+
+1. **`plan --baseline <id>`** (CLI) — pre-selects the design, e.g.
+   `jonggrang plan "…" --baseline helo@1`. A bare id (`--baseline helo`) resolves to its
+   single `id@version`. Because it counts as an explicit choice, the planner uses it
+   directly and **never asks the "which starter?" question**.
+2. **Web New Plan → "design:" picker** — the New Plan form lists every built-in pack and
+   personal template (from `GET /api/baselines`; personal ones tagged *· your design*).
+   Choosing one sends `--baseline <id>` for you, so the design question is skipped — you
+   still answer any scope questions. Leave it on **auto** to let the agent recommend.
+3. **Name it in the description** — mentioning the `id@version` in the request text also
+   counts as explicit selection.
+
+If none of these is used, the audit *recommends* a baseline and the plan-ask flow asks
+for consent first. See [UI planning context](UI_CONTEXT.md).
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -89,14 +89,25 @@ The **Design** top-nav tab lists templates and opens a studio per template:
   saves `tokens.css.template` and lints on save. File changes emit `design.changed`, which
   refreshes the preview live.
 
-### Execution mode (default: sandbox)
+### Execution mode (sandbox toggle, default on)
 
-The studio agent is intended to run **sandboxed** (a container from the agent image, with
-`IS_SANDBOX=1`, the auth mounts, and the template dir mounted) so it runs as root without
-the host `~/.claude/session-env` permission issue and its writes are isolated. A per-studio
-toggle can switch to host execution (faster; `opencode` works on the host, `claude` is
-subject to host perms). *v1 ships the host-spawn path; the sandbox-container path is a
-small follow-up.*
+The studio TUI runs in one of two modes, toggled in the studio header:
+
+- **Sandbox (default):** `docker exec` into a shared container (`jonggrang-design-studio`)
+  from the agent image with `IS_SANDBOX=1` and the project-sandbox mounts —
+  `~/.jonggrang → /root/.jonggrang` (carries the **design store + templates**) plus the
+  tool config dirs (`~/.claude`, `~/.claude.json`, `~/.opencode`, `~/.config/opencode`,
+  `~/.local/share/opencode`, `~/.codex`). Because these mirror the project sandbox
+  `DEFAULT_VOLUMES`, the **tool's session/auth carries over** and the agent runs as root
+  without the host `~/.claude/session-env` permission issue. CWD inside the container is
+  `/root/.jonggrang/design/<name>`.
+- **Host:** spawn the tool directly on the host in the template dir. Faster; uses the
+  host's own config/session directly.
+
+**Restart** stops and respawns the TUI. **Rebuild** (sandbox only) removes and recreates
+the container fresh from the image, then restarts the TUI — a clean-environment reset.
+Override the image with `JONGGRANG_AGENT_IMAGE` (default
+`ghcr.io/porcupine-md/jonggrang-agent:dev`).
 
 ---
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -70,6 +70,7 @@ Phase 2 — jonggrang approve   (or `jonggrang approve --session <id>` / auto-tr
 | `jonggrang plan "feat" --yes` | Plan + auto-approve + tasks (no interactive prompt) |
 | `jonggrang plan "feat" --deep` | Deep mode: 3-phase analysis → enriched plan.md |
 | `jonggrang plan "feat" --deep --yes` | Deep mode + auto-approve in one shot |
+| `jonggrang plan "feat" --baseline helo@1` | Pre-select a UI design template / baseline pack (built-in or `~/.jonggrang/design/*`) — planner styles from it and skips the "which starter?" question. Bare id (`--baseline helo`) resolves to `helo@1`. In the web New Plan form this is the **"design:"** picker. |
 | `jonggrang plan` | No description → picker: list all pending + archived plans |
 | `jonggrang work "feat" --yes` | Full pipeline: plan → approve → execute |
 | `jonggrang work --ignore-plan` | Skip pending plan warning, run existing tasks |

--- a/docs/plans/2026-08-15-jonggrang-design-studio.md
+++ b/docs/plans/2026-08-15-jonggrang-design-studio.md
@@ -29,6 +29,13 @@ self-contained: manifest + tokens + components + live preview, all local.
   recommends them — full reuse of PR #93 selection/validation/bounded-context.
 - **v1 scope:** the **full studio** ships in v1 — CLI + storage format + plan
   integration + the interactive Design tab (chat + live preview + agent authoring).
+- **Studio chat = each tool's native interactive TUI, in UNSAFE mode.** The left
+  pane is NOT a custom chat UI — it embeds the selected backend's own interactive
+  harness as a **pty-backed xterm terminal** (reusing `apis/projects/pty.js` +
+  `TerminalView`/xterm), launched with skip-permissions/yolo so the agent edits the
+  template freely: `claude --dangerously-skip-permissions`, `opencode` TUI, `codex`
+  (full-auto), `jonggrang agent` (Pi TUI). CWD = the template dir. Unsafe is
+  acceptable because it runs sandboxed by default (below).
 - **Execution mode:** the studio agent runs in a **sandbox (Docker) by default**,
   with a per-studio toggle to run on the host. Sandbox default matches the rest of
   jonggrang, isolates agent writes to the template dir, and avoids the host
@@ -107,10 +114,12 @@ projects/issues/secrets/settings), not a project sub-tab.
 - **`DesignListView.vue`:** gallery of templates (name, thumbnail preview,
   source badge built-in|personal), "New template", "Promote from project…".
 - **`DesignStudioView.vue`** (`/design/:name`) — the studio, two panes:
-  - **Left — Chat** (reuse the `PlanDiscuss.vue` streaming pattern + backend
-    selection like Plan/Work): user describes/edits; the agent edits
-    manifest/tokens/components. Tool = the project/global selected backend
-    (claude|opencode|jonggrang|codex).
+  - **Left — Tool TUI** (pty-backed xterm, reusing `apis/projects/pty.js` +
+    `TerminalView`): embeds the selected backend's **native interactive TUI in
+    unsafe mode** (`claude --dangerously-skip-permissions`, `opencode`, `codex`
+    full-auto, `jonggrang agent`), CWD = the template dir. The user talks to the
+    tool's own harness; jonggrang does not wrap the chat. Backend picker + a
+    "Sandbox on/off" toggle sit in the studio header.
   - **Right — Live preview** (sandboxed `<iframe>`): renders the template's
     components with its `tokens.css.template`; toolbar for light/dark, viewport
     width, and a component picker (button/card/…); a Tokens editor drawer.
@@ -126,18 +135,21 @@ projects/issues/secrets/settings), not a project sub-tab.
 | `POST /api/design/:name` | Create/update template files. |
 | `DELETE /api/design/:name` | Remove template. |
 | `GET /api/design/:name/preview?component=&theme=&width=` | Return a self-contained HTML doc (tokens + component) for the iframe. |
-| `POST /api/design/:name/chat` | One studio turn: spawn the selected backend with a **design-authoring** prompt/skill; stream output; agent writes to the template dir. |
+| `pty` (socket.io, reuse `apis/projects/pty.js`) | Design scope: spawn the selected backend's interactive TUI in **unsafe** mode, CWD = template dir (host or container). Streams `pty.data`/`pty.input`/`pty.resize`. This replaces a custom chat endpoint. |
 | `POST /api/design/promote` | `{ name, fromProjectPath }` → build template from a project's UI.md/tokens/components. |
 | `GET /api/design/:name/events` (WS) | Push file-change events → preview refresh. |
 
-## Agent authoring (studio chat)
+## Agent authoring (via the tool's own TUI)
 
-- New skill `skills/core/authoring-design-template` (or a prompt in `lib/design.js`)
-  that instructs the agent: work only inside `~/.jonggrang/design/<name>/`, keep the
-  8 canonical guide sections, use `--ui-*` token roles only, write components as
-  HTML fragments, keep `manifest.components` in sync, never inline raw hex.
-- Reuse `runAgent()` (backend-agnostic) with the design dir as CWD; stream to the
-  chat pane; the preview refreshes on file writes.
+The user drives the selected tool's **native interactive TUI** (unsafe) in the left
+pane; jonggrang does not wrap the conversation. To steer it toward the template
+contract, seed the tool's CWD (`~/.jonggrang/design/<name>/`) with an `AGENTS.md`
+(and a `.claude/` skill stub) written by `design new`/`promote`, instructing: work
+only inside this dir, keep the 8 canonical guide sections, use `--ui-*` token roles
+only, write components as HTML fragments referenced from `manifest.components`, never
+inline raw hex. The preview refreshes on file writes (watch → WS). Because the TUI is
+the tool's own harness, per-tool features (claude skills, opencode agents) work
+natively; jonggrang only provides the seeded contract + sandboxed CWD.
 
 ## Sandbox vs host execution (default: sandbox)
 

--- a/docs/plans/2026-08-15-jonggrang-design-studio.md
+++ b/docs/plans/2026-08-15-jonggrang-design-studio.md
@@ -1,0 +1,224 @@
+---
+title: jonggrang design — global design templates + design studio
+date: 2026-08-15
+status: proposed
+branch: feat/design-studio
+base: feat/ui-design-context   # builds on PR #93 baseline-pack machinery
+---
+
+# Plan — `jonggrang design`: global design templates + a design studio
+
+## Goal
+
+Let a user turn a design into a **reusable global template** stored at
+`~/.jonggrang/design/<template_name>/`, author/edit it in a **web "Design" studio**
+(chat on the left, live preview on the right), pull tokens or a component with
+`jonggrang design <name> get <what>`, and have `plan` reuse it — exactly like a
+built-in baseline pack. Conceptually similar to claude.com/product/design, but
+self-contained: manifest + tokens + components + live preview, all local.
+
+## Decisions (confirmed)
+
+- **Component format:** framework-agnostic **HTML + CSS using `--ui-*` tokens**
+  (canonical). Preview renders directly; `get` returns markup+tokens; project
+  agents adapt it to the project's framework (React/Vue). Reuses PR #93's token
+  contract (`templates/ui-baselines/core/semantic-token-contract.md`).
+- **Plan integration:** design templates are **personal baseline packs**.
+  `~/.jonggrang/design/*` becomes a second catalog merged into
+  `listBaselinePacks()`, so `plan` selects them by `id@version` and the audit
+  recommends them — full reuse of PR #93 selection/validation/bounded-context.
+- **v1 scope:** the **full studio** ships in v1 — CLI + storage format + plan
+  integration + the interactive Design tab (chat + live preview + agent authoring).
+- **Execution mode:** the studio agent runs in a **sandbox (Docker) by default**,
+  with a per-studio toggle to run on the host. Sandbox default matches the rest of
+  jonggrang, isolates agent writes to the template dir, and avoids the host
+  `~/.claude/session-env` EACCES that blocks claude on the host. Host mode is the
+  opt-out (faster; claude is subject to host perms, opencode works on host).
+
+## Storage format — `~/.jonggrang/design/<template_name>/`
+
+A superset of the baseline-pack format (so it validates as a pack):
+
+```
+~/.jonggrang/design/<template_name>/
+  manifest.yml            # pack manifest + `components:` list (see below)
+  guide-fragment.md       # guide body using the canonical section headings
+  tokens.css.template     # semantic --ui-* token contract (OKLCH)
+  components/
+    button.html           # HTML fragment using --ui-* tokens (+ scoped <style>)
+    input.html
+    card.html
+    ...
+  preview/
+    index.html            # optional composed preview page (auto-generated)
+  .meta.json              # provenance: promoted_from, created_at, tool, version
+```
+
+`manifest.yml` extends the pack manifest with:
+```yaml
+id: <template_name>
+version: 1
+components:                       # NEW — enumerates gettable components
+  - id: button
+    file: components/button.html
+    variants: [primary, quiet, danger]
+  - id: card
+    file: components/card.html
+```
+Design templates are pinned `id@version`; bumping `version` forks a new pinned id.
+
+## CLI — `jonggrang design <subcommand>`
+
+Wired in `bin/jonggrang.js` `main()` like `task`/`memory` (`if (command === 'design') return cmdDesign(rest)`), backed by `lib/design.js`.
+
+| Command | Behavior |
+|---|---|
+| `design list` | List `~/.jonggrang/design/*` templates (+ built-in packs, tagged source). |
+| `design new <name>` | Scaffold an empty template (manifest + core token/guide stubs). |
+| `design promote <name> [--from <project-path>] [--force]` | Build a template from a project's `.jonggrang/UI.md` + token source + representative components. Fulfils "promote my design". |
+| `design show <name>` | Print manifest + guide + token/component summary. |
+| `design <name> get <what>` | Emit for an agent/user: `get tokens` / `get guide` / `get manifest` / `get <component>` (HTML+CSS) / `get component <id> --variant primary`. Stdout is the raw artifact (agent-facing). |
+| `design validate <name>` | Validate against pack + design contract (sections, token roles, component refs resolve). |
+| `design remove <name>` | Delete a template (confirm; `--force` for headless). |
+
+`get` is the "design token or code generate per component" path — it resolves the
+component file, inlines its `--ui-*` usage, and prints markup ready to hand to a
+coding agent, or the token block for the guide.
+
+## Plan / UI-context integration (PR #93)
+
+- `lib/ui-context.js`: `baselineCatalogPath()` stays for built-ins; add
+  `designCatalogPath() = ~/.jonggrang/design`. `listBaselinePacks()` merges both
+  (built-in + personal), personal tagged `source: 'design'`. `findExplicitBaseline`
+  / `recommendBaseline` / consent already operate on the merged pack list — no flow
+  change. A user's `design` template is now selectable in any `plan` by its
+  `id@version`, and its `guide-fragment` + tokens feed the agent's `.jonggrang/UI.md`.
+- Selection order gains: personal `design` templates rank with built-in packs
+  (after project evidence + explicit reference, alongside product-shape match).
+
+## Web "Design" studio — new **top-level** tab
+
+Design templates are global, so "Design" is a top-level nav item (next to
+projects/issues/secrets/settings), not a project sub-tab.
+
+- **Router/nav:** add `/design` and `/design/:name` routes in
+  `client/src/router/index.js`; add the nav link in the top bar
+  (`client/src/components/app/TopBar.vue`).
+- **`DesignListView.vue`:** gallery of templates (name, thumbnail preview,
+  source badge built-in|personal), "New template", "Promote from project…".
+- **`DesignStudioView.vue`** (`/design/:name`) — the studio, two panes:
+  - **Left — Chat** (reuse the `PlanDiscuss.vue` streaming pattern + backend
+    selection like Plan/Work): user describes/edits; the agent edits
+    manifest/tokens/components. Tool = the project/global selected backend
+    (claude|opencode|jonggrang|codex).
+  - **Right — Live preview** (sandboxed `<iframe>`): renders the template's
+    components with its `tokens.css.template`; toolbar for light/dark, viewport
+    width, and a component picker (button/card/…); a Tokens editor drawer.
+  - Save writes to `~/.jonggrang/design/<name>/`; a WebSocket/file-watch pushes
+    updates so the preview refreshes as the agent writes files.
+
+## Backend APIs — `apis/design.js` (global, registered in `server.js`)
+
+| Route | Purpose |
+|---|---|
+| `GET /api/design` | List templates (personal + built-in). |
+| `GET /api/design/:name` | manifest + guide + tokens + components. |
+| `POST /api/design/:name` | Create/update template files. |
+| `DELETE /api/design/:name` | Remove template. |
+| `GET /api/design/:name/preview?component=&theme=&width=` | Return a self-contained HTML doc (tokens + component) for the iframe. |
+| `POST /api/design/:name/chat` | One studio turn: spawn the selected backend with a **design-authoring** prompt/skill; stream output; agent writes to the template dir. |
+| `POST /api/design/promote` | `{ name, fromProjectPath }` → build template from a project's UI.md/tokens/components. |
+| `GET /api/design/:name/events` (WS) | Push file-change events → preview refresh. |
+
+## Agent authoring (studio chat)
+
+- New skill `skills/core/authoring-design-template` (or a prompt in `lib/design.js`)
+  that instructs the agent: work only inside `~/.jonggrang/design/<name>/`, keep the
+  8 canonical guide sections, use `--ui-*` token roles only, write components as
+  HTML fragments, keep `manifest.components` in sync, never inline raw hex.
+- Reuse `runAgent()` (backend-agnostic) with the design dir as CWD; stream to the
+  chat pane; the preview refreshes on file writes.
+
+## Sandbox vs host execution (default: sandbox)
+
+The studio chat turn (`POST /api/design/:name/chat`) runs the authoring agent in one
+of two modes; **sandbox is the default**, toggled per-studio (persisted in the
+template's `.meta.json` and defaulted from `~/.jonggrang/settings.json`
+`design.sandbox` — default `true`).
+
+- **Sandbox (default):** spawn/reuse a container from the agent image (reuse
+  `lib/sandbox.js` + `web-state` `DEFAULT_VOLUMES`), with `IS_SANDBOX=1`, the auth
+  mounts (`~/.claude`, `~/.claude.json`, `~/.opencode`, …), and the template dir
+  mounted (e.g. `~/.jonggrang/design/<name>` → `/workspace`). The agent runs
+  `node …/bin/jonggrang.js` design-authoring in-container as root, so claude's Bash
+  works (no host `session-env` EACCES). Writes land on the host mount → the host
+  preview server serves the updated files.
+- **Host (opt-out):** run the agent directly on the host with the template dir as
+  CWD. Faster, no container; but claude is subject to host perms (use opencode, or
+  the user fixes `~/.claude` ownership). Surfaced in the UI as "Sandbox: off".
+
+Container lifecycle mirrors project sandboxes: lazily started, reused across turns,
+torn down with the studio session. The toggle lives next to the backend picker in the
+studio header.
+
+## Preview rendering
+
+`GET /api/design/:name/preview` composes a minimal HTML doc: `<style>` from
+`tokens.css.template` + the requested component fragment (or the composed
+`preview/index.html`), wrapped with a theme attribute and a max-width container.
+Served into a **sandboxed iframe** (`sandbox="allow-same-origin"`, no scripts) so
+untrusted markup can't script the dashboard. Light/dark via `data-theme`; width via
+the container. No build step — pure HTML/CSS with tokens.
+
+## Build phases (verifiable increments; all land in v1)
+
+1. **Storage + lib** — `lib/design.js`: paths, list/load/save/validate/get/promote;
+   extend `manifest` schema with `components`. Unit tests. `scripts/qa-design.sh`.
+2. **CLI** — `cmdDesign` in `bin/jonggrang.js` (list/new/promote/show/get/validate/remove) + `--help`.
+3. **Plan integration** — merge `~/.jonggrang/design` into `listBaselinePacks`; audit/recommend; a smoke that a personal template is selectable + reused in a plan (fake backend).
+4. **APIs** — `apis/design.js` + register in `server.js`; preview endpoint; promote endpoint.
+5. **Studio UI** — `DesignListView`, `DesignStudioView`, top-nav + routes; live preview iframe; tokens editor; component picker.
+6. **Studio chat/agent** — `/api/design/:name/chat` streaming + design-authoring skill; file-watch → preview refresh.
+7. **Docs + seed** — see below; ship one seeded example personal template via `design new`/promote demo.
+
+## Docs to update (Iron Rule)
+
+- `README.md` (Commands at a Glance: `jonggrang design`), `docs/QUICKSTART.md`,
+  `docs/EXAMPLE.md` (a promote→reuse walkthrough).
+- `docs/CONFIG.md` (new `~/.jonggrang/design/` store), `docs/JONGGRANG.md` (state
+  section), `docs/UI_CONTEXT.md` + `docs/UI_BASELINES.md` (personal templates as
+  packs), `docs/SKILLS.md` (authoring-design-template skill).
+- `templates/CLAUDE.md.template` / `AGENTS.md.template` if agents should know
+  `jonggrang design <t> get <component>`.
+
+## Verification
+
+- `lib/design.js` unit tests; `scripts/qa-design.sh` (contract: promote, validate,
+  get, catalog merge, plan selects a personal template).
+- E2E: `design promote` a real project → template appears in `design list` and in a
+  `plan` baseline selection; studio renders live preview; chat edits a token and the
+  preview updates. Browser-validate the Design tab (agent-browser/claude-in-chrome).
+- Deterministic guide/token validation reuses PR #93's `validateUiGuide`.
+
+## Risks / open questions
+
+- **Preview fidelity** for framework-specific components (we store framework-agnostic
+  HTML; project agents adapt). Acceptable per the format decision; flag in docs.
+- **Studio agent write scope** — must be sandboxed to the template dir (enforce in
+  the API/skill). Security: iframe is script-sandboxed.
+- **Sandbox root-ownership** — in sandbox mode the container writes template files as
+  root on the bind mount, so later host-side edits (UI token editor, `design` CLI as
+  the host user) can hit EACCES. Mitigate by routing ALL writes through one owner:
+  either always write via the container in sandbox mode, or `chown`/`--user` the
+  mount to the host uid. Same class as the known sandbox root-ownership issue; decide
+  the write-path in Phase 4.
+- **Component taxonomy** — start with a small canonical set (button, input, card,
+  nav, section) and let `manifest.components` grow.
+- **Versioning UX** — how a user bumps `version` (fork) vs edits in place; propose:
+  edit-in-place for drafts, explicit `design <name> bump` to pin a new `id@version`.
+
+## Out of scope (v1)
+
+- Publishing/sharing templates to a remote registry (local-only for now).
+- Auto-generating framework-specific component code (agents do that per project).
+- Figma/DTCG import.

--- a/docs/plans/2026-08-15-jonggrang-design-studio.md
+++ b/docs/plans/2026-08-15-jonggrang-design-studio.md
@@ -229,6 +229,25 @@ the container. No build step — pure HTML/CSS with tokens.
 - **Versioning UX** — how a user bumps `version` (fork) vs edits in place; propose:
   edit-in-place for drafts, explicit `design <name> bump` to pin a new `id@version`.
 
+## Prior art — open-design (nexu-io/open-design)
+
+"Open-source Claude Design alternative"; strongly validates our direction and adds ideas:
+- **`DESIGN.md` = a brand contract that shapes every output.** Confirms our approach —
+  our seeded per-template contract (guide-fragment 8 sections + tokens + AGENTS.md rules)
+  should read like a strong DESIGN.md the TUI agent obeys.
+- **`spawn(cli, [...], { cwd: managed project cwd })`** — they spawn each backend CLI in a
+  managed project cwd. Exactly our pty-in-template-dir decision; confirms it.
+- **Backend-agnostic, 26+ CLIs (Claude Code/Codex/OpenCode/Cursor/Gemini/Qwen/Pi…)**,
+  BYOK — mirrors our tool-agnostic pty/runAgent.
+- **`/api/artifacts/{save,lint}`** — a lint pass on generated artifacts. Adopt: run
+  `validateTemplate` on save in the studio and surface warnings (raw colors, missing
+  component refs, non-canonical sections).
+- **`od mcp install <agent>`** exposes design ops to the agent via MCP. Enhancement (v2):
+  expose `jonggrang design get/save/lint` as an MCP tool so the studio agent pulls
+  tokens/components and self-lints natively — complements the `design … get` CLI.
+- Their outputs span slides/PDF/MP4; we deliberately scope to HTML/CSS+token components
+  so a template is reusable as a `plan` baseline. Different goal, same engine shape.
+
 ## Out of scope (v1)
 
 - Publishing/sharing templates to a remote registry (local-only for now).

--- a/docs/plans/2026-08-15-jonggrang-design-studio.md
+++ b/docs/plans/2026-08-15-jonggrang-design-studio.md
@@ -1,7 +1,7 @@
 ---
 title: jonggrang design — global design templates + design studio
 date: 2026-08-15
-status: proposed
+status: implemented (Phases 1-7) — see docs/DESIGN.md
 branch: feat/design-studio
 base: feat/ui-design-context   # builds on PR #93 baseline-pack machinery
 ---

--- a/lib/design.js
+++ b/lib/design.js
@@ -1,0 +1,246 @@
+// Design templates — global, reusable design packs stored at ~/.jonggrang/design/<name>/.
+// A design template is a superset of a UI baseline pack (manifest.yml + guide-fragment.md
+// + tokens.css.template) that additionally ships framework-agnostic HTML+token components.
+// It loads through the same pack machinery as built-in baselines (lib/ui-context.js), so a
+// personal template is selectable in `plan` exactly like a built-in baseline pack.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const ui = require('./ui-context');
+
+const DESIGN_FORMAT = 'jonggrang-ui-guide/v1'; // shares the guide format
+const DEFAULT_COMPONENTS = ['button', 'input', 'card', 'nav', 'section'];
+
+function jonggrangHome() {
+  return process.env.JONGGRANG_HOME || path.join(os.homedir(), '.jonggrang');
+}
+
+function designRoot() {
+  return path.join(jonggrangHome(), 'design');
+}
+
+function templateDir(root, name) {
+  return path.join(root, name);
+}
+
+// The pack loader reads shared core/ files from the catalog dir. Seed them from the
+// built-in baseline catalog so ~/.jonggrang/design behaves like a pack catalog.
+function ensureCore(root = designRoot()) {
+  const core = path.join(root, 'core');
+  fs.mkdirSync(core, { recursive: true });
+  const src = path.join(ui.baselineCatalogPath(), 'core');
+  for (const file of ['guide-sections.md', 'semantic-token-contract.md']) {
+    const dst = path.join(core, file);
+    const from = path.join(src, file);
+    if (!fs.existsSync(dst) && fs.existsSync(from)) fs.copyFileSync(from, dst);
+  }
+  return root;
+}
+
+// ── Listing / lookup ──────────────────────────────────────────────────────────
+
+function listTemplates() {
+  const root = designRoot();
+  if (!fs.existsSync(root)) return [];
+  ensureCore(root);
+  return ui.listBaselinePacks(root).map(pack => ({ ...pack, source: 'design' }));
+}
+
+function findPack(nameOrKey) {
+  const root = designRoot();
+  if (!fs.existsSync(root)) return null;
+  ensureCore(root);
+  const packs = ui.listBaselinePacks(root);
+  return packs.find(p => p.key === nameOrKey || p.id === nameOrKey) || null;
+}
+
+function loadTemplate(nameOrKey) {
+  const pack = findPack(nameOrKey);
+  if (!pack) throw new Error(`design template not found: ${nameOrKey}`);
+  if (!pack.valid) throw new Error(`design template invalid: ${pack.errors.join('; ')}`);
+  const dir = path.dirname(pack.path);
+  const loaded = ui.loadBaselinePack(pack.key, designRoot());
+  const components = (pack.components || []).map(c => ({
+    id: c.id,
+    variants: Array.isArray(c.variants) ? c.variants : [],
+    file: c.file,
+    html: fs.readFileSync(path.resolve(dir, c.file), 'utf8'),
+  }));
+  return { ...loaded, dir, components };
+}
+
+// ── Validation (pack contract + component refs) ─────────────────────────────────
+
+function validateTemplate(nameOrKey) {
+  const pack = findPack(nameOrKey);
+  if (!pack) return { valid: false, errors: [`design template not found: ${nameOrKey}`], warnings: [] };
+  const errors = [...(pack.errors || [])];
+  const warnings = [];
+  const dir = path.dirname(pack.path);
+  const root = path.resolve(dir);
+  const components = pack.components;
+  if (components !== undefined && !Array.isArray(components)) {
+    errors.push('components must be an array when present');
+  } else {
+    for (const c of components || []) {
+      if (!c || !c.id || !c.file) { errors.push('each component needs an id and a file'); continue; }
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(c.id)) errors.push(`component id must be kebab-case: ${c.id}`);
+      let resolved;
+      try { resolved = path.resolve(root, c.file); } catch { errors.push(`bad component path: ${c.file}`); continue; }
+      if (!resolved.startsWith(root + path.sep)) errors.push(`component escapes template dir: ${c.file}`);
+      else if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) errors.push(`component file missing: ${c.file}`);
+      else if (/hsl\(|rgb\(|#[0-9a-fA-F]{3,8}\b/.test(fs.readFileSync(resolved, 'utf8'))) {
+        warnings.push(`component ${c.id} uses raw color values; prefer --ui-* tokens`);
+      }
+    }
+  }
+  return { valid: errors.length === 0, errors: [...new Set(errors)], warnings: [...new Set(warnings)] };
+}
+
+// ── get: emit an artifact for an agent or the user ──────────────────────────────
+
+function getArtifact(nameOrKey, what, opts = {}) {
+  const t = loadTemplate(nameOrKey);
+  if (what === 'tokens') return t.tokenTemplate;
+  if (what === 'guide') return t.guideFragment;
+  if (what === 'manifest') return yaml.dump(t.manifest);
+  const comp = t.components.find(c => c.id === what || c.id === (opts.component || what));
+  if (comp) {
+    if (opts.variant && comp.variants.length && !comp.variants.includes(opts.variant)) {
+      throw new Error(`unknown variant '${opts.variant}' for ${comp.id} (have: ${comp.variants.join(', ') || 'none'})`);
+    }
+    return comp.html;
+  }
+  const ids = t.components.map(c => c.id).join(', ') || '(none)';
+  throw new Error(`unknown artifact: ${what}. Try: tokens, guide, manifest, or a component id [${ids}]`);
+}
+
+// ── Scaffold a new template ─────────────────────────────────────────────────────
+
+function newTemplate(name, opts = {}) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) throw new Error('template name must be kebab-case');
+  const root = ensureCore(designRoot());
+  const dir = templateDir(root, name);
+  if (fs.existsSync(dir) && !opts.force) throw new Error(`template already exists: ${name} (use --force)`);
+  fs.mkdirSync(path.join(dir, 'components'), { recursive: true });
+
+  const manifest = {
+    id: name,
+    version: 1,
+    intent: opts.intent || `Design template ${name}.`,
+    product_shapes: opts.product_shapes || ['any'],
+    recommend_keywords: opts.recommend_keywords || [],
+    recommend_priority: 10,
+    framework_targets: ['css', 'any'],
+    guide_fragment: 'guide-fragment.md',
+    token_template: 'tokens.css.template',
+    components: [],
+  };
+  fs.writeFileSync(path.join(dir, 'manifest.yml'), yaml.dump(manifest), 'utf8');
+  fs.writeFileSync(path.join(dir, 'guide-fragment.md'), scaffoldGuide(name), 'utf8');
+  fs.writeFileSync(path.join(dir, 'tokens.css.template'), scaffoldTokens(), 'utf8');
+  fs.writeFileSync(path.join(dir, '.meta.json'), JSON.stringify({ created_by: 'design new', tool: opts.tool || null }, null, 2), 'utf8');
+  return { name, dir };
+}
+
+function scaffoldGuide(name) {
+  return ui.REQUIRED_GUIDE_SECTIONS.reduce(
+    (acc, section) => acc + `## ${section}\n\nTODO: describe ${section.toLowerCase()} for ${name}.\n\n`,
+    `# ${name} design template\n\n`,
+  );
+}
+
+function scaffoldTokens() {
+  return [
+    ':root {',
+    '  --ui-canvas: oklch(0.985 0.006 85);',
+    '  --ui-surface: oklch(1 0 0);',
+    '  --ui-text: oklch(0.19 0.018 255);',
+    '  --ui-text-muted: oklch(0.46 0.018 255);',
+    '  --ui-border: oklch(0.86 0.012 85);',
+    '  --ui-action: oklch(0.38 0.16 255);',
+    '  --ui-action-hover: oklch(0.31 0.15 255);',
+    '  --ui-focus: oklch(0.62 0.17 255);',
+    '  --ui-space-1: 0.25rem; --ui-space-2: 0.5rem; --ui-space-3: 0.75rem; --ui-space-4: 1rem;',
+    '  --ui-space-6: 1.5rem; --ui-space-8: 2rem; --ui-space-12: 3rem; --ui-space-16: 4rem;',
+    '  --ui-radius-control: 0.25rem; --ui-radius-panel: 0.5rem;',
+    '  --ui-content: 68rem; --ui-copy: 42rem;',
+    '}',
+    '',
+  ].join('\n');
+}
+
+// ── Promote a project's design into a global template ───────────────────────────
+
+function promoteFromProject(name, projectRoot, opts = {}) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) throw new Error('template name must be kebab-case');
+  const guidePath = ui.projectGuidePath(projectRoot);
+  if (!fs.existsSync(guidePath)) throw new Error(`no .jonggrang/UI.md in project: ${projectRoot}`);
+  const guide = fs.readFileSync(guidePath, 'utf8');
+  const fm = ui.parseFrontmatter(guide);
+
+  const root = ensureCore(designRoot());
+  const dir = templateDir(root, name);
+  if (fs.existsSync(dir) && !opts.force) throw new Error(`template already exists: ${name} (use --force)`);
+  fs.mkdirSync(path.join(dir, 'components'), { recursive: true });
+
+  // guide body without frontmatter → guide-fragment.md
+  fs.writeFileSync(path.join(dir, 'guide-fragment.md'), fm.body != null ? fm.body.trim() + '\n' : guide, 'utf8');
+
+  // token source → tokens.css.template (or scaffold if missing/planned)
+  const tokenSource = fm.data && fm.data.token_source;
+  let tokenWritten = false;
+  if (tokenSource && !['none', 'planned'].includes(String(tokenSource))) {
+    const src = path.resolve(projectRoot, String(tokenSource));
+    if (src.startsWith(path.resolve(projectRoot) + path.sep) && fs.existsSync(src) && fs.statSync(src).isFile()) {
+      fs.copyFileSync(src, path.join(dir, 'tokens.css.template'));
+      tokenWritten = true;
+    }
+  }
+  if (!tokenWritten) fs.writeFileSync(path.join(dir, 'tokens.css.template'), scaffoldTokens(), 'utf8');
+
+  const manifest = {
+    id: name,
+    version: 1,
+    intent: (fm.data && fm.data.description) || `Promoted from ${path.basename(projectRoot)}.`,
+    product_shapes: opts.product_shapes || ['any'],
+    recommend_keywords: opts.recommend_keywords || [],
+    recommend_priority: 10,
+    framework_targets: ['css', 'any'],
+    guide_fragment: 'guide-fragment.md',
+    token_template: 'tokens.css.template',
+    components: [],
+  };
+  fs.writeFileSync(path.join(dir, 'manifest.yml'), yaml.dump(manifest), 'utf8');
+  fs.writeFileSync(path.join(dir, '.meta.json'), JSON.stringify({
+    created_by: 'design promote', promoted_from: projectRoot, baseline: fm.data && fm.data.baseline || null,
+  }, null, 2), 'utf8');
+  return { name, dir, tokenSource: tokenWritten ? tokenSource : null };
+}
+
+function removeTemplate(name) {
+  const root = designRoot();
+  const dir = templateDir(root, name);
+  if (!fs.existsSync(dir)) throw new Error(`design template not found: ${name}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+  return { name };
+}
+
+module.exports = {
+  DESIGN_FORMAT,
+  DEFAULT_COMPONENTS,
+  jonggrangHome,
+  designRoot,
+  ensureCore,
+  listTemplates,
+  findPack,
+  loadTemplate,
+  validateTemplate,
+  getArtifact,
+  newTemplate,
+  scaffoldTokens,
+  promoteFromProject,
+  removeTemplate,
+};

--- a/lib/design.js
+++ b/lib/design.js
@@ -18,7 +18,7 @@ function jonggrangHome() {
 }
 
 function designRoot() {
-  return path.join(jonggrangHome(), 'design');
+  return process.env.JONGGRANG_DESIGN_HOME || path.join(jonggrangHome(), 'design');
 }
 
 function templateDir(root, name) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,0 +1,105 @@
+'use strict';
+
+// S3-compatible object storage for file uploads (plan mode + design studio).
+// Works with any S3 API: Cloudflare R2, MinIO, AWS S3, or a custom provider —
+// the only difference is the endpoint (+ region/path-style). Config + secrets
+// live in ~/.jonggrang/web/storage.json (user home, never the repo, never git).
+// Uploads return a shareable link: a public URL when `publicUrl` is set, else a
+// presigned GET URL (works even for private buckets like a default R2 bucket).
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function configFile() {
+  return path.join(os.homedir(), '.jonggrang', 'web', 'storage.json');
+}
+
+function loadConfig() {
+  try { return JSON.parse(fs.readFileSync(configFile(), 'utf8')); } catch { return {}; }
+}
+
+// Patch semantics mirror git-tokens: undefined = leave as-is; '' = clear.
+function saveConfig(patch) {
+  const next = { ...loadConfig() };
+  for (const [k, v] of Object.entries(patch || {})) {
+    if (v === undefined) continue;
+    if (v === '') delete next[k];
+    else next[k] = v;
+  }
+  fs.mkdirSync(path.dirname(configFile()), { recursive: true });
+  fs.writeFileSync(configFile(), JSON.stringify(next, null, 2));
+  return next;
+}
+
+function isConfigured() {
+  const c = loadConfig();
+  return Boolean(c.endpoint && c.bucket && c.accessKeyId && c.secretAccessKey);
+}
+
+// Non-secret view for the Settings UI — never leaks the keys, only whether set.
+function publicConfig() {
+  const c = loadConfig();
+  return {
+    provider: c.provider || 'none',            // 'r2' | 'minio' | 'custom' | 'none'
+    endpoint: c.endpoint || '',
+    bucket: c.bucket || '',
+    region: c.region || 'auto',
+    publicUrl: c.publicUrl || '',
+    forcePathStyle: c.forcePathStyle !== false, // default true (MinIO/custom-safe; R2 ok too)
+    has_access_key: !!c.accessKeyId,
+    has_secret_key: !!c.secretAccessKey,
+    configured: isConfigured(),
+  };
+}
+
+function client() {
+  const c = loadConfig();
+  if (!isConfigured()) throw new Error('storage is not configured');
+  const { S3Client } = require('@aws-sdk/client-s3');
+  return new S3Client({
+    region: c.region || 'auto',
+    endpoint: c.endpoint,
+    forcePathStyle: c.forcePathStyle !== false,
+    credentials: { accessKeyId: c.accessKeyId, secretAccessKey: c.secretAccessKey },
+  });
+}
+
+function sanitizeName(name) {
+  return String(name || 'file').replace(/[^\w.\-]+/g, '_').replace(/^_+/, '').slice(-120) || 'file';
+}
+
+// Upload a buffer and return { key, url, filename }. url is a public URL when a
+// publicUrl base is configured, otherwise a 7-day presigned GET URL.
+async function upload(buffer, filename, contentType) {
+  const c = loadConfig();
+  if (!isConfigured()) throw new Error('storage is not configured');
+  const { PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
+  const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+  const safe = sanitizeName(filename);
+  const stamp = new Date().toISOString().slice(0, 10);
+  const rand = Math.random().toString(36).slice(2, 10);
+  const key = `uploads/${stamp}/${rand}-${safe}`;
+  const s3 = client();
+  await s3.send(new PutObjectCommand({
+    Bucket: c.bucket, Key: key, Body: buffer,
+    ContentType: contentType || 'application/octet-stream',
+  }));
+  let url;
+  if (c.publicUrl) {
+    url = `${String(c.publicUrl).replace(/\/+$/, '')}/${key}`;
+  } else {
+    url = await getSignedUrl(s3, new GetObjectCommand({ Bucket: c.bucket, Key: key }), { expiresIn: 60 * 60 * 24 * 7 });
+  }
+  return { key, url, filename: safe };
+}
+
+// Cheap connectivity check for the Settings "Test" button.
+async function testConnection() {
+  const c = loadConfig();
+  const { HeadBucketCommand } = require('@aws-sdk/client-s3');
+  await client().send(new HeadBucketCommand({ Bucket: c.bucket }));
+  return true;
+}
+
+module.exports = { configFile, loadConfig, saveConfig, isConfigured, publicConfig, upload, testConnection };

--- a/lib/ui-context.js
+++ b/lib/ui-context.js
@@ -423,7 +423,7 @@ function validateUiGuide(projectRoot, guideOrPath, opts = {}) {
   return { valid: errors.length === 0, errors: [...new Set(errors)], warnings: [...new Set(warnings)], frontmatter: fm.data, content, path: guidePath };
 }
 
-function validateUiTaskContext(projectRoot, task, featureId, guideDigest) {
+function validateUiTaskContext(projectRoot, task, featureId, guideDigest, ownedTargets) {
   const errors = [];
   const context = task && task.ui_context;
   if (!context || typeof context !== 'object') return { valid: false, errors: [`${task && task.id ? task.id : 'task'} has no ui_context`] };
@@ -439,10 +439,14 @@ function validateUiTaskContext(projectRoot, task, featureId, guideDigest) {
   else if (context.guide_sections.length === 0) errors.push(`${task.id} guide_sections must select at least one guide section`);
   if (!Array.isArray(context.source_files)) errors.push(`${task.id} source_files must be an array`);
   else {
+    // A source file is "owned" if ANY task in the plan creates it, not only this task —
+    // a UI task legitimately consumes files a preceding task (e.g. the token foundation)
+    // will create. Callers pass the plan-wide owned set; fall back to this task's files.
+    const owned = ownedTargets instanceof Set ? ownedTargets : new Set(task.files || []);
     for (const source of context.source_files) {
       const status = pathStatus(projectRoot, source);
       if (path.isAbsolute(String(source)) || status === 'outside-project') errors.push(`${task.id} source file escapes project root: ${source}`);
-      else if (status !== 'ready' && !(task.files || []).includes(source)) errors.push(`${task.id} source file does not exist and is not an owned target: ${source}`);
+      else if (status !== 'ready' && !owned.has(source)) errors.push(`${task.id} source file does not exist and is not an owned target: ${source}`);
     }
   }
   if (!Array.isArray(context.states)) errors.push(`${task.id} states must be an array`);
@@ -465,9 +469,12 @@ function validateUiHandoff(projectRoot, handoffPath, tasks, opts = {}) {
   const guideContent = opts.guideContent || '';
   const guideHeadings = new Set(markdownSections(guideContent).sections.map(section => normalizeHeading(section.title)));
   const uiTasks = (tasks || []).filter(task => task.ui_context);
+  // Plan-wide owned targets: any file any task declares it will create.
+  const ownedTargets = new Set();
+  for (const t of (tasks || [])) for (const f of (t.files || [])) ownedTargets.add(f);
   for (const task of uiTasks) {
     if (!extractMarkdownSection(content, `Task ${task.id}`)) errors.push(`missing handoff section: Task ${task.id}`);
-    const result = validateUiTaskContext(projectRoot, task, opts.featureId, opts.guideDigest);
+    const result = validateUiTaskContext(projectRoot, task, opts.featureId, opts.guideDigest, ownedTargets);
     errors.push(...result.errors);
     for (const section of task.ui_context.guide_sections || []) {
       if (guideContent && !guideHeadings.has(normalizeHeading(section))) errors.push(`${task.id} references missing guide section: ${section}`);

--- a/lib/ui-context.js
+++ b/lib/ui-context.js
@@ -446,7 +446,13 @@ function validateUiTaskContext(projectRoot, task, featureId, guideDigest, ownedT
     for (const source of context.source_files) {
       const status = pathStatus(projectRoot, source);
       if (path.isAbsolute(String(source)) || status === 'outside-project') errors.push(`${task.id} source file escapes project root: ${source}`);
-      else if (status !== 'ready' && !owned.has(source)) errors.push(`${task.id} source file does not exist and is not an owned target: ${source}`);
+      else {
+        // A bare directory source (e.g. src/components) is satisfied when the plan
+        // owns files UNDER it, even though the directory itself does not exist yet.
+        const dir = String(source).replace(/\/+$/, '');
+        const ownsUnder = owned.has(source) || [...owned].some(t => t === source || t.startsWith(dir + '/'));
+        if (status !== 'ready' && !ownsUnder) errors.push(`${task.id} source file does not exist and is not an owned target: ${source}`);
+      }
     }
   }
   if (!Array.isArray(context.states)) errors.push(`${task.id} states must be an array`);
@@ -753,11 +759,16 @@ function resolveUiPreference(planning, answers) {
   throw new Error('UI preference answer must select a starter, decline starters, or provide a custom direction');
 }
 
-function buildPlanningContext(projectRoot, sessionId, description, audit) {
+function buildPlanningContext(projectRoot, sessionId, description, audit, chosenBaseline = null) {
   const availablePacks = validBaselinePacks();
   const availableBaselines = availablePacks.map(pack => pack.key);
-  const explicitBaseline = findExplicitBaseline(description, availablePacks);
-  const recommendation = recommendBaseline(description, audit, availablePacks);
+  // An explicitly chosen baseline (e.g. `plan --baseline helo@1`, or the web
+  // New Plan design picker) counts as an explicit selection just like naming the
+  // id in the description — it is selected outright, so no consent question is
+  // asked. Ignore an unknown id and fall back to description/keyword inference.
+  const validChosen = chosenBaseline && availableBaselines.includes(chosenBaseline) ? chosenBaseline : null;
+  const explicitBaseline = validChosen || findExplicitBaseline(description, availablePacks);
+  const recommendation = validChosen || recommendBaseline(description, audit, availablePacks);
   // A personal guide is already an explicit preference input and outranks a
   // keyword-selected built-in pack. An exact pack id in the request outranks it.
   const baseline = audit.user_guide && !explicitBaseline ? 'existing-project' : recommendation;

--- a/lib/ui-context.js
+++ b/lib/ui-context.js
@@ -42,6 +42,19 @@ function baselineCatalogPath() {
   return path.join(__dirname, '..', 'templates', 'ui-baselines');
 }
 
+// Personal, user-authored design templates (see lib/design.js) live here and act as
+// additional baseline packs — a `plan` can select them by id@version like a built-in.
+function designCatalogPath() {
+  const home = process.env.JONGGRANG_HOME || path.join(os.homedir(), '.jonggrang');
+  return path.join(home, 'design');
+}
+
+// Catalogs to merge when no explicit catalogDir is passed: built-ins first, then the
+// personal design store when it exists. Built-ins win on a key collision.
+function catalogDirs() {
+  return [baselineCatalogPath(), designCatalogPath()].filter(dir => fs.existsSync(dir));
+}
+
 function contentDigest(content) {
   return `sha256:${crypto.createHash('sha256').update(String(content || '')).digest('hex')}`;
 }
@@ -135,6 +148,28 @@ function listBaselinePacks(catalogDir = baselineCatalogPath()) {
   return packs.sort((a, b) => String(a.key).localeCompare(String(b.key)));
 }
 
+// Merge built-in packs with personal design templates. Each pack records the catalog
+// it came from (so its shared core/ files resolve). On a duplicate key across catalogs,
+// the first (built-in) wins and the later one is marked invalid.
+function listAllBaselinePacks() {
+  const merged = [];
+  const seen = new Map();
+  for (const dir of catalogDirs()) {
+    const source = dir === baselineCatalogPath() ? 'builtin' : 'design';
+    for (const pack of listBaselinePacks(dir)) {
+      const tagged = { ...pack, catalogDir: dir, source };
+      if (seen.has(tagged.key)) {
+        tagged.valid = false;
+        tagged.errors = [...(tagged.errors || []), `duplicate key with ${seen.get(tagged.key).source} pack: ${tagged.key}`];
+      } else {
+        seen.set(tagged.key, tagged);
+      }
+      merged.push(tagged);
+    }
+  }
+  return merged.sort((a, b) => String(a.key).localeCompare(String(b.key)));
+}
+
 function resolvePackFile(packDir, relativePath) {
   if (!relativePath || path.isAbsolute(relativePath)) throw new Error(`baseline file must be relative: ${relativePath || '(empty)'}`);
   const root = path.resolve(packDir);
@@ -172,32 +207,43 @@ function validateBaselineManifest(manifest, packDir) {
   return { valid: errors.length === 0, errors };
 }
 
-function validBaselinePacks(catalogDir = baselineCatalogPath()) {
-  return listBaselinePacks(catalogDir).filter(pack => pack.valid);
+function validBaselinePacks(catalogDir) {
+  const packs = catalogDir ? listBaselinePacks(catalogDir) : listAllBaselinePacks();
+  return packs.filter(pack => pack.valid);
 }
 
-function baselineKeys(catalogDir = baselineCatalogPath()) {
+function baselineKeys(catalogDir) {
   return validBaselinePacks(catalogDir).map(pack => pack.key);
 }
 
-function isBaselineKey(key, catalogDir = baselineCatalogPath()) {
+function isBaselineKey(key, catalogDir) {
   return baselineKeys(catalogDir).includes(String(key));
 }
 
-function loadBaselinePack(key, catalogDir = baselineCatalogPath()) {
-  const pack = listBaselinePacks(catalogDir).find(item => item.key === key);
+function loadBaselinePack(key, catalogDir) {
+  const packs = catalogDir
+    ? listBaselinePacks(catalogDir).map(pack => ({ ...pack, catalogDir }))
+    : listAllBaselinePacks();
+  const pack = packs.find(item => item.key === key);
   if (!pack) throw new Error(`baseline pack not found: ${key}`);
   if (!pack.valid) throw new Error(`baseline pack invalid: ${pack.errors.join('; ')}`);
   const packDir = path.dirname(pack.path);
+  const packCatalog = pack.catalogDir || catalogDir || baselineCatalogPath();
   const readPackFile = relativePath => fs.readFileSync(resolvePackFile(packDir, relativePath), 'utf8');
-  const coreDir = path.join(catalogDir, 'core');
+  // shared core/ files live in the pack's own catalog; fall back to the built-in catalog.
+  const readCore = file => {
+    const local = path.join(packCatalog, 'core', file);
+    const builtin = path.join(baselineCatalogPath(), 'core', file);
+    return fs.readFileSync(fs.existsSync(local) ? local : builtin, 'utf8');
+  };
   return {
-    manifest: Object.fromEntries(Object.entries(pack).filter(([field]) => !['key', 'path', 'valid', 'errors'].includes(field))),
+    manifest: Object.fromEntries(Object.entries(pack).filter(([field]) => !['key', 'path', 'valid', 'errors', 'catalogDir', 'source'].includes(field))),
     key: pack.key,
+    source: pack.source || 'builtin',
     guideFragment: readPackFile(pack.guide_fragment),
     tokenTemplate: readPackFile(pack.token_template),
-    guideSections: fs.readFileSync(path.join(coreDir, 'guide-sections.md'), 'utf8'),
-    semanticTokenContract: fs.readFileSync(path.join(coreDir, 'semantic-token-contract.md'), 'utf8'),
+    guideSections: readCore('guide-sections.md'),
+    semanticTokenContract: readCore('semantic-token-contract.md'),
   };
 }
 
@@ -771,6 +817,9 @@ module.exports = {
   draftHandoffPath,
   featureHandoffPath,
   baselineCatalogPath,
+  designCatalogPath,
+  catalogDirs,
+  listAllBaselinePacks,
   contentDigest,
   updateFrontmatter,
   parseFrontmatter,

--- a/lib/ui-context.js
+++ b/lib/ui-context.js
@@ -45,6 +45,7 @@ function baselineCatalogPath() {
 // Personal, user-authored design templates (see lib/design.js) live here and act as
 // additional baseline packs — a `plan` can select them by id@version like a built-in.
 function designCatalogPath() {
+  if (process.env.JONGGRANG_DESIGN_HOME) return process.env.JONGGRANG_DESIGN_HOME;
   const home = process.env.JONGGRANG_HOME || path.join(os.homedir(), '.jonggrang');
   return path.join(home, 'design');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jonggrang",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jonggrang",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1111.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.15.6",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1111.0",
+        "@aws-sdk/s3-request-presigner": "^3.1111.0",
         "@clack/prompts": "^0.7.0",
-        "@earendil-works/pi-coding-agent": "^0.74.2",
+        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
         "chokidar": "^4.0.3",
         "cors": "^2.8.5",
         "express": "^4.21.2",
@@ -29,108 +32,38 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.28.tgz",
+      "integrity": "sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1111.0.tgz",
+      "integrity": "sha512-VnLT6aSTN8tWl/NsXUysXNZor7wQBp9CRwufo7kt8cwGXvHLZ0S/cV1K9WFcREGboVYSo3NGQ3ZvU7LRidh2aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1053.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1053.0.tgz",
-      "integrity": "sha512-I5dua8y1logE+Mx6r5kvI1tjM+XyC3H42KDCpEqmhrJfanor/x/AdOavyv3HnS4sBqUxx2IrjLP3ouEumjeTzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-node": "^3.972.44",
-        "@aws-sdk/eventstream-handler-node": "^3.972.17",
-        "@aws-sdk/middleware-eventstream": "^3.972.13",
-        "@aws-sdk/middleware-websocket": "^3.972.21",
-        "@aws-sdk/token-providers": "3.1053.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/checksums": "^3.1000.28",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -138,17 +71,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
-      "integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.25",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -157,15 +90,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
-      "integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -173,17 +106,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
-      "integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -191,23 +124,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
-      "integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-env": "^3.972.39",
-        "@aws-sdk/credential-provider-http": "^3.972.41",
-        "@aws-sdk/credential-provider-login": "^3.972.43",
-        "@aws-sdk/credential-provider-process": "^3.972.39",
-        "@aws-sdk/credential-provider-sso": "^3.972.43",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -215,16 +148,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
-      "integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -232,21 +165,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
-      "integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.39",
-        "@aws-sdk/credential-provider-http": "^3.972.41",
-        "@aws-sdk/credential-provider-ini": "^3.972.43",
-        "@aws-sdk/credential-provider-process": "^3.972.39",
-        "@aws-sdk/credential-provider-sso": "^3.972.43",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.43",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -254,15 +187,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
-      "integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -270,34 +203,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
-      "integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/token-providers": "3.1052.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
-      "integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -305,85 +221,69 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
-      "integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
-      "integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.74.tgz",
+      "integrity": "sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
-      "integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
-      "integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
-      "integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1111.0.tgz",
+      "integrity": "sha512-ACp/VtDTw6AjFW5Q3M59uAMrBbAHeQS0UBIOIgUROO98Z3uhpiy37k9RmvxbXYVugmTcdNTy4DPVQtLG8sDy6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -391,15 +291,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
-      "integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -407,16 +306,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1053.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1053.0.tgz",
-      "integrity": "sha512-laSwHLYMMrXQRl2mFDXszF43m/F4pKWyGr7hCLfJmV8rn8c6CnI/hp/bf/Gn7gLcjz0SY4evd7SBpqtnIhzA/A==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/nested-clients": "^3.997.11",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -424,24 +323,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -449,14 +336,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
-      "integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.2",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -464,21 +349,12 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@clack/core": {
@@ -517,94 +393,563 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.2.tgz",
-      "integrity": "sha512-RPlB3bi2z+VQK0HRhBK73kXOQI1fFmRgWzzT6+ihB7JYfh29jb7eAfYvpx8rlf248gUAYaLQ8JYa+43l09rPmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.74.2",
-        "ignore": "^7.0.5",
-        "typebox": "^1.1.24",
-        "yaml": "^2.8.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-ai": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.2.tgz",
-      "integrity": "sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "typebox": "^1.1.24"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.2.tgz",
-      "integrity": "sha512-4Ey/ZgKw8Rq/cLhKtam7ze+LrTg+cNGRMCcAm0HCteHyVbYGbYqbbV8KzXW6fD/X64+213E9PJvIiPfpKJ1kOw==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
+      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.74.2",
-        "@earendil-works/pi-ai": "^0.74.2",
-        "@earendil-works/pi-tui": "^0.74.2",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "diff": "^8.0.2",
-        "glob": "^13.0.1",
-        "highlight.js": "^10.7.3",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "jiti": "^2.7.0",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "yaml": "^2.8.2"
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
       },
       "bin": {
         "pi": "dist/cli.js"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=22.19.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.6"
+        "@mariozechner/clipboard": "0.3.9"
       }
     },
-    "node_modules/@earendil-works/pi-tui": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.2.tgz",
-      "integrity": "sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12"
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
       }
     },
-    "node_modules/@google/genai": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
       "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
@@ -628,32 +973,32 @@
         }
       }
     },
-    "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
       "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
-        "@mariozechner/clipboard-darwin-universal": "0.3.6",
-        "@mariozechner/clipboard-darwin-x64": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
       "cpu": [
         "arm64"
       ],
@@ -666,10 +1011,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,10 +1024,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
       "cpu": [
         "x64"
       ],
@@ -695,10 +1040,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
       "cpu": [
         "arm64"
       ],
@@ -711,10 +1056,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
       ],
@@ -727,10 +1072,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
       "cpu": [
         "riscv64"
       ],
@@ -743,10 +1088,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
       "cpu": [
         "x64"
       ],
@@ -759,10 +1104,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
       ],
@@ -775,10 +1120,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
       "cpu": [
         "arm64"
       ],
@@ -791,10 +1136,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
       "cpu": [
         "x64"
       ],
@@ -807,18 +1152,7 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      }
-    },
-    "node_modules/@nodable/entities": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
@@ -830,31 +1164,40 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@protobufjs/aspromise": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/base64": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/codegen": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/eventemitter": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/fetch": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
@@ -863,46 +1206,40 @@
         "@protobufjs/aspromise": "^1.1.1"
       }
     },
-    "node_modules/@protobufjs/float": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/pool": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/utf8": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@silvia-odwyer/photon-node": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -913,13 +1250,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
-      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.3",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -927,13 +1264,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
-      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.3",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -941,7 +1278,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
@@ -953,13 +1290,13 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
-      "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.3",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -967,13 +1304,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/signature-v4": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
-      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.3",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -981,7 +1318,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/types": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
       "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
@@ -993,7 +1330,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/util-buffer-from": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
@@ -1006,7 +1343,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-utf8": {
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
@@ -1017,6 +1354,949 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
+      "integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -1043,12 +2323,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1069,15 +2343,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/anymatch": {
@@ -1110,30 +2375,11 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -1142,15 +2388,6 @@
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -1215,6 +2452,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1235,12 +2473,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1278,18 +2510,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -1360,15 +2580,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1405,15 +2616,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1426,15 +2628,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1594,72 +2787,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1726,18 +2853,6 @@
         }
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1778,34 +2893,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1857,23 +2944,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1887,32 +2957,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1924,12 +2968,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1963,27 +3001,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/http-errors": {
@@ -2020,32 +3037,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2056,15 +3047,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/ignore-by-default": {
@@ -2135,15 +3117,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2156,85 +3129,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2310,6 +3214,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -2319,15 +3224,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2350,44 +3246,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/node-pty": {
       "version": "1.1.0",
@@ -2509,40 +3367,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2550,43 +3374,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2612,50 +3399,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -2735,15 +3478,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2916,12 +3650,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -2991,18 +3719,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3048,12 +3764,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3073,27 +3783,12 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -3128,15 +3823,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -3156,54 +3842,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jonggrang",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deterministic AI orchestration platform — 16-phase workflow engine for autonomous software development",
   "license": "MIT",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,11 @@
     "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1111.0",
+    "@aws-sdk/s3-request-presigner": "^3.1111.0",
     "@clack/prompts": "^0.7.0",
-    "@earendil-works/pi-coding-agent": "^0.74.2",
+    "@earendil-works/pi-coding-agent": "^0.84.2",
+    "@earendil-works/pi-tui": "^0.84.2",
     "chokidar": "^4.0.3",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-plan-integration.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-plan-integration.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/scripts/qa-design.sh
+++ b/scripts/qa-design.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# E2E for `jonggrang design` — exercises the real CLI against an isolated store.
+set -u
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TMP=$(mktemp -d)
+export JONGGRANG_HOME="$TMP/home"; mkdir -p "$JONGGRANG_HOME"
+JG=(node "$ROOT/bin/jonggrang.js")
+fail=0
+ok(){ echo "  ✓ $1"; }
+bad(){ echo "  ✗ $1"; fail=1; }
+
+echo "== new / list / get / validate =="
+"${JG[@]}" design new acme --intent "Acme brand" --shapes dashboard,landing-page >/dev/null 2>&1 || bad "design new"
+[ -f "$JONGGRANG_HOME/design/acme/manifest.yml" ] && ok "scaffolded manifest+tokens+guide" || bad "scaffold files missing"
+"${JG[@]}" design list --json 2>/dev/null | grep -q '"id":"acme"' && ok "list shows acme" || bad "list"
+"${JG[@]}" design acme get tokens 2>/dev/null | grep -q -- '--ui-action' && ok "get tokens" || bad "get tokens"
+"${JG[@]}" design acme get guide 2>/dev/null | grep -q '## Source map' && ok "get guide has canonical sections" || bad "get guide"
+"${JG[@]}" design acme get manifest 2>/dev/null | grep -q 'id: acme' && ok "get manifest" || bad "get manifest"
+"${JG[@]}" design validate acme >/dev/null 2>&1 && ok "validate ok" || bad "validate"
+
+echo "== component get =="
+mkdir -p "$JONGGRANG_HOME/design/acme/components"
+printf '<button style="background:var(--ui-action);border-radius:var(--ui-radius-control)">Go</button>\n' > "$JONGGRANG_HOME/design/acme/components/button.html"
+node -e "const y=require('$ROOT/node_modules/js-yaml'),fs=require('fs');const p='$JONGGRANG_HOME/design/acme/manifest.yml';const m=y.load(fs.readFileSync(p,'utf8'));m.components=[{id:'button',file:'components/button.html',variants:['primary','quiet']}];fs.writeFileSync(p,y.dump(m))"
+"${JG[@]}" design acme get button 2>/dev/null | grep -q '<button' && ok "get component (design <name> get button)" || bad "get component"
+"${JG[@]}" design get acme button 2>/dev/null | grep -q '<button' && ok "get component (design get <name> button)" || bad "get component alt-syntax"
+
+echo "== promote from a project =="
+PROJ="$TMP/proj"; mkdir -p "$PROJ/.jonggrang" "$PROJ/src/theme"
+printf ':root{--ui-action:oklch(0.4 0.1 255)}\n' > "$PROJ/src/theme/tokens.css"
+node -e "const ui=require('$ROOT/lib/ui-context'),fs=require('fs');const g='---\nformat: jonggrang-ui-guide/v1\nbaseline: existing-project\ntoken_source: src/theme/tokens.css\ntoken_status: ready\ndescription: promoted brand\n---\n\n'+ui.REQUIRED_GUIDE_SECTIONS.map(s=>'## '+s+'\n\nbody').join('\n\n')+'\n';fs.writeFileSync('$PROJ/.jonggrang/UI.md',g)"
+"${JG[@]}" design promote promoted --from "$PROJ" >/dev/null 2>&1 && ok "promote --from" || bad "promote"
+"${JG[@]}" design validate promoted >/dev/null 2>&1 && ok "promoted validates" || bad "promoted invalid"
+"${JG[@]}" design promoted get tokens 2>/dev/null | grep -q -- '--ui-action' && ok "promoted carries project tokens" || bad "promoted tokens"
+
+echo "== show / remove =="
+"${JG[@]}" design show acme >/dev/null 2>&1 && ok "show" || bad "show"
+"${JG[@]}" design remove acme >/dev/null 2>&1 && ok "remove" || bad "remove"
+"${JG[@]}" design list --json 2>/dev/null | grep -q '"id":"acme"' && bad "acme still listed after remove" || ok "acme gone after remove"
+
+echo "== help =="
+"${JG[@]}" design --help 2>/dev/null | grep -q 'global, reusable design templates' && ok "help" || bad "help"
+
+echo
+if [ $fail -eq 0 ]; then echo "qa-design: ALL PASS"; else echo "qa-design: FAILURES"; fi
+rm -rf "$TMP"
+exit $fail

--- a/server.js
+++ b/server.js
@@ -57,6 +57,9 @@ const cleanupProjects = require('./apis/projects')(app, io, projectsCtx);
 // Global design-template studio API (~/.jonggrang/design)
 const cleanupDesign = require('./apis/design')(app, io, { JONGGRANG_HOME });
 
+// Global object-storage API (S3-compatible uploads: R2, MinIO, custom)
+const cleanupStorage = require('./apis/storage')(app, io, { JONGGRANG_HOME });
+
 // ── FRONTEND ──────────────────────────────────────────────────
 // Production (default): serve the built client from client/dist.
 // Development (NODE_ENV=development): run Vite in middleware mode so the

--- a/server.js
+++ b/server.js
@@ -54,6 +54,9 @@ webState.initVolumes();
 const projectsCtx = { JONGGRANG_HOME, webState, orchestration, server };
 const cleanupProjects = require('./apis/projects')(app, io, projectsCtx);
 
+// Global design-template studio API (~/.jonggrang/design)
+const cleanupDesign = require('./apis/design')(app, io, { JONGGRANG_HOME });
+
 // ── FRONTEND ──────────────────────────────────────────────────
 // Production (default): serve the built client from client/dist.
 // Development (NODE_ENV=development): run Vite in middleware mode so the

--- a/test/design-api.test.js
+++ b/test/design-api.test.js
@@ -1,0 +1,97 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const express = require('express');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-api-'));
+process.env.JONGGRANG_HOME = TMP;
+const registerDesign = require('../apis/design');
+const ui = require('../lib/ui-context');
+
+let server, base;
+const events = [];
+const io = { emit: (name, payload) => events.push({ name, payload }) };
+
+before(async () => {
+  const app = express();
+  app.use(express.json({ limit: '4mb' }));
+  registerDesign(app, io, {});
+  await new Promise(resolve => { server = app.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; resolve(); }); });
+});
+after(() => { if (server) server.close(); });
+
+async function req(method, url, body) {
+  return fetch(base + url, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+test('POST create + GET list', async () => {
+  let res = await req('POST', '/api/design', { name: 'acme', intent: 'Acme', product_shapes: ['dashboard'] });
+  assert.equal(res.status, 201);
+  res = await req('GET', '/api/design');
+  const { templates } = await res.json();
+  assert.ok(templates.some(t => t.id === 'acme' && t.valid), 'acme listed and valid');
+});
+
+test('PUT component + manifest registers it; lints on save; emits change', async () => {
+  let res = await req('PUT', '/api/design/acme/file', {
+    file: 'components/button.html', content: '<button style="background:var(--ui-action)">Go</button>',
+  });
+  assert.equal(res.status, 200);
+  const manifest = 'id: acme\nversion: 1\nintent: Acme\nproduct_shapes: [dashboard]\n' +
+    'guide_fragment: guide-fragment.md\ntoken_template: tokens.css.template\n' +
+    'components:\n  - id: button\n    file: components/button.html\n    variants: [primary]\n';
+  res = await req('PUT', '/api/design/acme/file', { file: 'manifest.yml', content: manifest });
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.validation.valid, true);
+  assert.ok(events.some(e => e.name === 'design.changed'), 'change event emitted');
+});
+
+test('PUT path guard rejects directory escape', async () => {
+  const res = await req('PUT', '/api/design/acme/file', { file: '../evil.txt', content: 'x' });
+  assert.equal(res.status, 400);
+});
+
+test('GET one + preview injects tokens and renders the component', async () => {
+  let res = await req('GET', '/api/design/acme');
+  const t = await res.json();
+  assert.ok(t.components.some(c => c.id === 'button'));
+  res = await req('GET', '/api/design/acme/preview?component=button&theme=dark&width=800');
+  const html = await res.text();
+  assert.match(res.headers.get('content-type') || '', /html/);
+  assert.ok(html.includes('--ui-action'), 'tokens injected into preview');
+  assert.ok(html.includes('<button'), 'component rendered');
+  assert.ok(html.includes('data-theme="dark"'), 'theme applied');
+});
+
+test('validate endpoint returns valid', async () => {
+  const v = await (await req('GET', '/api/design/acme/validate')).json();
+  assert.equal(v.valid, true);
+});
+
+test('promote from a project via API', async () => {
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-p-'));
+  fs.mkdirSync(path.join(proj, '.jonggrang'), { recursive: true });
+  fs.mkdirSync(path.join(proj, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(proj, 'src', 'tokens.css'), ':root{--ui-action:oklch(0.4 0.1 255)}');
+  const guide = '---\nformat: jonggrang-ui-guide/v1\nbaseline: existing-project\ntoken_source: src/tokens.css\ntoken_status: ready\ndescription: promoted\n---\n\n' +
+    ui.REQUIRED_GUIDE_SECTIONS.map(s => '## ' + s + '\n\nb').join('\n\n') + '\n';
+  fs.writeFileSync(path.join(proj, '.jonggrang', 'UI.md'), guide);
+  const res = await req('POST', '/api/design/promote', { name: 'promoted', fromProjectPath: proj });
+  assert.equal(res.status, 201);
+  const v = await (await req('GET', '/api/design/promoted/validate')).json();
+  assert.equal(v.valid, true);
+});
+
+test('DELETE removes the template', async () => {
+  const res = await req('DELETE', '/api/design/acme');
+  assert.equal(res.status, 200);
+  const { templates } = await (await req('GET', '/api/design')).json();
+  assert.ok(!templates.some(t => t.id === 'acme'), 'acme gone');
+});

--- a/test/design-api.test.js
+++ b/test/design-api.test.js
@@ -10,17 +10,17 @@ process.env.JONGGRANG_HOME = TMP;
 const registerDesign = require('../apis/design');
 const ui = require('../lib/ui-context');
 
-let server, base;
+let server, base, cleanup;
 const events = [];
 const io = { emit: (name, payload) => events.push({ name, payload }) };
 
 before(async () => {
   const app = express();
   app.use(express.json({ limit: '4mb' }));
-  registerDesign(app, io, {});
+  cleanup = registerDesign(app, io, {});
   await new Promise(resolve => { server = app.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; resolve(); }); });
 });
-after(() => { if (server) server.close(); });
+after(() => { if (cleanup) cleanup(); if (server) server.close(); });
 
 async function req(method, url, body) {
   return fetch(base + url, {

--- a/test/design-plan-integration.test.js
+++ b/test/design-plan-integration.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-di-'));
+process.env.JONGGRANG_HOME = TMP;
+const design = require('../lib/design');
+const ui = require('../lib/ui-context');
+
+const KEY = 'acme-brand@1';
+
+test('a personal design template is discoverable + loadable via the plan pack API', () => {
+  design.newTemplate('acme-brand', { intent: 'Acme brand', product_shapes: ['dashboard'], recommend_keywords: ['acme', 'brand'] });
+
+  // merged catalog: personal template + built-ins both present
+  const keys = ui.baselineKeys();
+  assert.ok(keys.includes(KEY), 'baselineKeys() includes personal template');
+  assert.ok(keys.includes('landing-page-minimalist@1'), 'built-ins still present in merged catalog');
+  assert.ok(ui.isBaselineKey(KEY), 'isBaselineKey() true for personal template');
+
+  // explicit baseline in a request resolves to the personal template (the --yes/--no-ask path)
+  assert.equal(ui.recommendBaseline('please use acme-brand@1 for this'), KEY);
+
+  // loadable, with shared core/ resolved and design source tagged
+  const pack = ui.loadBaselinePack(KEY);
+  assert.equal(pack.source, 'design');
+  assert.ok(pack.tokenTemplate.includes('--ui-action'), 'token template loaded');
+  assert.ok(pack.guideSections.includes('UI guide sections'), 'shared core guide-sections resolved');
+  assert.ok(pack.semanticTokenContract.length > 0, 'shared core semantic-token-contract resolved');
+});
+
+test('explicit built-in catalog stays scoped (no personal leakage)', () => {
+  const builtins = ui.baselineKeys(ui.baselineCatalogPath());
+  assert.ok(builtins.includes('landing-page-minimalist@1'));
+  assert.ok(!builtins.includes(KEY), 'explicit built-in catalog excludes personal templates');
+});
+
+test('a broken personal template does not break built-in discovery', () => {
+  // create an invalid template (missing token file) directly
+  const dir = path.join(design.designRoot(), 'broken');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'manifest.yml'), 'id: broken\nversion: 1\nintent: x\nproduct_shapes: [any]\nguide_fragment: guide-fragment.md\ntoken_template: tokens.css.template\n');
+  // no guide/token files → invalid; merged listing must still expose valid built-ins
+  const validKeys = ui.baselineKeys();
+  assert.ok(validKeys.includes('landing-page-minimalist@1'));
+  assert.ok(!validKeys.includes('broken@1'), 'invalid personal template excluded from valid keys');
+});

--- a/test/design.test.js
+++ b/test/design.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Isolate the design store to a temp JONGGRANG_HOME before requiring the module.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-design-'));
+process.env.JONGGRANG_HOME = TMP;
+const design = require('../lib/design');
+const ui = require('../lib/ui-context');
+
+function setComponents(name, components) {
+  const dir = path.join(design.designRoot(), name);
+  const manifest = yaml.load(fs.readFileSync(path.join(dir, 'manifest.yml'), 'utf8'));
+  manifest.components = components;
+  fs.writeFileSync(path.join(dir, 'manifest.yml'), yaml.dump(manifest));
+  return dir;
+}
+
+test('newTemplate scaffolds a valid template with all 8 canonical guide sections', () => {
+  const { dir } = design.newTemplate('acme-brand', { intent: 'Acme brand system', product_shapes: ['dashboard'] });
+  assert.ok(fs.existsSync(path.join(dir, 'manifest.yml')));
+  assert.ok(fs.existsSync(path.join(dir, 'tokens.css.template')));
+  const v = design.validateTemplate('acme-brand');
+  assert.deepEqual(v.errors, []);
+  assert.ok(v.valid);
+  const guide = design.getArtifact('acme-brand', 'guide');
+  for (const s of ui.REQUIRED_GUIDE_SECTIONS) assert.ok(guide.includes('## ' + s), 'missing section: ' + s);
+});
+
+test('listTemplates + findPack resolve by name and key, tagged source=design', () => {
+  const list = design.listTemplates();
+  assert.ok(list.map(t => t.id).includes('acme-brand'));
+  assert.ok(list.every(t => t.source === 'design'));
+  assert.ok(design.findPack('acme-brand'));
+  assert.ok(design.findPack('acme-brand@1'));
+  assert.equal(design.findPack('nope'), null);
+});
+
+test('get tokens/guide/manifest and a component after registering it', () => {
+  const dir = path.join(design.designRoot(), 'acme-brand');
+  fs.writeFileSync(path.join(dir, 'components', 'button.html'),
+    '<button class="btn" style="background:var(--ui-action);border-radius:var(--ui-radius-control)">Go</button>\n');
+  setComponents('acme-brand', [{ id: 'button', file: 'components/button.html', variants: ['primary', 'quiet'] }]);
+
+  assert.ok(design.getArtifact('acme-brand', 'tokens').includes('--ui-action'));
+  assert.ok(design.getArtifact('acme-brand', 'guide').includes('## Source map'));
+  assert.ok(design.getArtifact('acme-brand', 'manifest').includes('acme-brand'));
+  assert.ok(design.getArtifact('acme-brand', 'button').includes('<button'));
+  assert.throws(() => design.getArtifact('acme-brand', 'button', { variant: 'nope' }), /unknown variant/);
+  assert.throws(() => design.getArtifact('acme-brand', 'ghost'), /unknown artifact/);
+  assert.equal(design.validateTemplate('acme-brand').valid, true);
+});
+
+test('validateTemplate flags a missing component file and warns on raw colors', () => {
+  const dir = path.join(design.designRoot(), 'acme-brand');
+  setComponents('acme-brand', [{ id: 'button', file: 'components/button.html' }, { id: 'ghost', file: 'components/ghost.html' }]);
+  const v = design.validateTemplate('acme-brand');
+  assert.ok(!v.valid);
+  assert.ok(v.errors.some(e => /component file missing/.test(e)));
+
+  fs.writeFileSync(path.join(dir, 'components', 'raw.html'), '<div style="color:#ffffff">x</div>');
+  setComponents('acme-brand', [{ id: 'button', file: 'components/button.html' }, { id: 'raw', file: 'components/raw.html' }]);
+  const v2 = design.validateTemplate('acme-brand');
+  assert.ok(v2.valid, 'valid despite raw color (only a warning)');
+  assert.ok(v2.warnings.some(w => /raw color/.test(w)));
+});
+
+test('promoteFromProject builds a template from a project UI.md + token source', () => {
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-proj-'));
+  fs.mkdirSync(path.join(proj, '.jonggrang'), { recursive: true });
+  fs.mkdirSync(path.join(proj, 'src', 'theme'), { recursive: true });
+  fs.writeFileSync(path.join(proj, 'src', 'theme', 'tokens.css'), ':root{--ui-action:oklch(0.4 0.1 255)}');
+  const guide = '---\nformat: jonggrang-ui-guide/v1\nbaseline: existing-project\ntoken_source: src/theme/tokens.css\ntoken_status: ready\ndescription: My promoted system\n---\n\n' +
+    ui.REQUIRED_GUIDE_SECTIONS.map(s => '## ' + s + '\n\nbody').join('\n\n') + '\n';
+  fs.writeFileSync(path.join(proj, '.jonggrang', 'UI.md'), guide);
+
+  const r = design.promoteFromProject('promoted-sys', proj);
+  assert.ok(fs.existsSync(path.join(r.dir, 'tokens.css.template')));
+  assert.equal(r.tokenSource, 'src/theme/tokens.css');
+  assert.ok(design.getArtifact('promoted-sys', 'tokens').includes('--ui-action'));
+  // guide-fragment is the body only (frontmatter stripped)
+  assert.ok(!design.getArtifact('promoted-sys', 'guide').includes('format: jonggrang-ui-guide'));
+  assert.equal(design.validateTemplate('promoted-sys').valid, true);
+});
+
+test('removeTemplate deletes it', () => {
+  design.newTemplate('temp-x');
+  assert.ok(design.findPack('temp-x'));
+  design.removeTemplate('temp-x');
+  assert.equal(design.findPack('temp-x'), null);
+});


### PR DESCRIPTION
## Summary
Turn a design into a **reusable global template** at `~/.jonggrang/design/<name>/`, author it in a web **Design studio** (the tool's own interactive TUI on the left, live preview on the right), pull tokens/components from the CLI, and reuse it in any `plan` like a built-in baseline pack.

> Stacked on #93 (feat/ui-design-context) — it reuses the baseline-pack machinery. Base is `feat/ui-design-context`; merge after #93.

## What's included (7 phases, each tested)
- **lib/design.js** — global templates (superset of a UI baseline pack: manifest + guide-fragment + tokens.css.template + HTML/token components). *6/6 unit tests.*
- **CLI `jonggrang design`** — `new / list / promote / show / get / validate / remove`; `<name> get <tokens|guide|manifest|component>` emits raw artifacts for agents. *`scripts/qa-design.sh` e2e.*
- **Plan integration** — `~/.jonggrang/design/*` merged into the baseline catalog; personal templates selectable in `plan` by `id@version` (built-in wins on collision; explicit catalogDir stays scoped). *3/3 integration tests.*
- **REST API `apis/design.js`** — list/read/create/promote/save/delete, `validate`, and a self-contained `/preview` HTML doc for a sandboxed iframe; `PUT /file` is path-guarded, lints on save, emits `design.changed`. *7/7 HTTP e2e.*
- **Web studio** — Design nav + `/design`, `/design/:name`; `DesignListView` + `DesignStudioView` (left = tool's native TUI **unsafe** via pty in the template dir; right = live preview iframe + component/theme/width picker + tokens editor with lint-on-save; WS `design.changed` auto-refreshes).
- **Docs** — `docs/DESIGN.md`, README, CONFIG (`JONGGRANG_DESIGN_HOME`).

## Verification
- Full `npm test`: **71/71** (design unit + plan-integration + HTTP API wired into the suite).
- **Browser e2e** (local `server.js` + Chrome via agent-browser): list renders, studio renders, preview iframe renders a component with tokens, editing `--ui-action` auto-refreshes the preview via WebSocket (blue→green), and the TUI shell spawns in the template dir.

## Notes
- Studio TUI v1 = host spawn; **sandbox-container mode** (IS_SANDBOX + mounts) is a small documented follow-up.
- `jonggrang design` is a shared CLI + global store, not an agent backend.

🤖 Generated with Claude Code