### PR TITLE
fix(design): don't OCI-crash starting the studio TUI when the template cwd is missing in the container

### DIFF
--- a/apis/design.js
+++ b/apis/design.js
@@ -256,6 +256,14 @@ module.exports = function register(app, io, _ctx) {
     if (sandbox) {
       ensureDesignContainer();
       const cwd = `/root/.jonggrang/design/${name}`;
+      // Ensure the working directory exists INSIDE the container before exec, so
+      // `docker exec --workdir` can never crash with an OCI "chdir … no such file
+      // or directory" error. The design store is bind-mounted (~/.jonggrang), so
+      // when the mount is live this is a no-op against the already-present template;
+      // it only materializes the dir when the container's mounted view lags/misses
+      // it (e.g. a just-created template, or a stale mount after ~/.jonggrang was
+      // recreated). Best-effort: a failure here just falls through to the exec.
+      try { execFileSync('docker', ['exec', DESIGN_CONTAINER, 'mkdir', '-p', cwd], { stdio: 'ignore' }); } catch { /* best-effort */ }
       proc = pty.spawn('docker', ['exec', '-it', '--workdir', cwd, DESIGN_CONTAINER, resolved.cmd, ...resolved.args],
         { name: 'xterm-256color', ...dims, cwd: os.homedir(), env: { ...process.env, TERM: 'xterm-256color' } });
     } else {


### PR DESCRIPTION
## Problem
Starting the design-studio TUI in **sandbox mode** runs `docker exec --workdir /root/.jonggrang/design/<name>`. When that directory isn't present in the container's mounted view, `docker exec` hard-crashes:

```
OCI runtime exec failed: exec failed: unable to start container process:
chdir to cwd ("/root/.jonggrang/design/<name>") set in config.json failed: no such file or directory
```

This happens for a just-created template whose dir the bind mount hasn't surfaced yet, or a stale `~/.jonggrang` mount after the store was recreated.

## Fix
`spawnDesign` now `mkdir -p`s the working directory **inside the container** before the exec (best-effort). With the live `~/.jonggrang` bind mount this is a no-op against an existing template; it only materializes the dir in the lag/stale-mount edge cases, so the TUI can never crash on chdir.

## Verification
- Reproduced the exact OCI `chdir` error with `--workdir` on a missing dir.
- Confirmed `mkdir -p <cwd>` + `--workdir <cwd>` succeeds (no crash).
- Full flow on the sandbox: create template → **Start TUI (sandbox)** → 0 OCI errors in the server log.

Branched from `main`. Co-authored with jonggrang-dev.
