### PR TITLE
fix(design): keep the design store out of the install directory

### DIFF
--- a/lib/design.js
+++ b/lib/design.js
@@ -13,12 +13,49 @@ const ui = require('./ui-context');
 const DESIGN_FORMAT = 'jonggrang-ui-guide/v1'; // shares the guide format
 const DEFAULT_COMPONENTS = ['button', 'input', 'card', 'nav', 'section'];
 
+// JONGGRANG_HOME carries two different meanings in this codebase: server.js and
+// bin/jonggrang.js resolve it to the INSTALL directory (the checkout that ships
+// `templates/`), while the design store is USER DATA that belongs in
+// ~/.jonggrang — the very path apis/design.js bind-mounts into the studio
+// container. Reading the install dir as a data dir scattered new templates into
+// the checkout: the studio then listed nothing (the real store was elsewhere)
+// and starting a session crashed on a container cwd that did not exist.
+//
+// An install directory is recognised the same way server.js recognises its own,
+// so an explicit JONGGRANG_HOME that points at a data dir (what the tests use to
+// isolate the store) keeps working.
+function isInstallDir(dir) {
+  try { return fs.existsSync(path.join(dir, 'templates', 'AGENTS.md.template')); } catch { return false; }
+}
+
 function jonggrangHome() {
-  return process.env.JONGGRANG_HOME || path.join(os.homedir(), '.jonggrang');
+  const env = process.env.JONGGRANG_HOME;
+  if (env && !isInstallDir(env)) return env;
+  return path.join(os.homedir(), '.jonggrang');
 }
 
 function designRoot() {
   return process.env.JONGGRANG_DESIGN_HOME || path.join(jonggrangHome(), 'design');
+}
+
+// Templates stranded in the old (install-dir) location would otherwise just
+// disappear from the studio with no explanation. Say where they are, once.
+let legacyNoticeShown = false;
+function warnStrandedTemplates() {
+  if (legacyNoticeShown) return;
+  const env = process.env.JONGGRANG_HOME;
+  if (!env || !isInstallDir(env)) return;
+  const stranded = path.join(env, 'design');
+  const canonical = designRoot();
+  if (stranded === canonical) return;
+  let names = [];
+  try {
+    names = fs.readdirSync(stranded).filter(n => n !== 'core' && fs.statSync(path.join(stranded, n)).isDirectory());
+  } catch { return; }
+  if (!names.length) return;
+  legacyNoticeShown = true;
+  console.warn(`[design] ${names.length} template(s) sit in ${stranded} (an install directory): ${names.join(', ')}`);
+  console.warn(`[design] the store is ${canonical} — move them there for the studio to see them`);
 }
 
 function templateDir(root, name) {
@@ -43,6 +80,7 @@ function ensureCore(root = designRoot()) {
 
 function listTemplates() {
   const root = designRoot();
+  warnStrandedTemplates();
   if (!fs.existsSync(root)) return [];
   ensureCore(root);
   return ui.listBaselinePacks(root).map(pack => ({ ...pack, source: 'design' }));

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1111.0",

--- a/test/design-store-path.test.js
+++ b/test/design-store-path.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+// Where the design store lives. JONGGRANG_HOME means the INSTALL directory to
+// server.js and bin/jonggrang.js, but the design store is user data under
+// ~/.jonggrang — the path the studio container bind-mounts. Conflating the two
+// scattered new templates into the checkout, so the studio listed none and
+// opening a session crashed on a container cwd that did not exist.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+// The module caches nothing about the home, but it is required fresh per case
+// so an env change cannot be masked by module state.
+function freshDesign() {
+  delete require.cache[require.resolve('../lib/design')];
+  return require('../lib/design');
+}
+
+function makeInstallDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-install-'));
+  fs.mkdirSync(path.join(dir, 'templates'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'templates', 'AGENTS.md.template'), '# marker\n');
+  return dir;
+}
+
+function withEnv(vars, fn) {
+  const prev = {};
+  for (const [k, v] of Object.entries(vars)) {
+    prev[k] = process.env[k];
+    if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  }
+  try { return fn(); } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  }
+}
+
+console.log('\ndesign store path — install dir vs data dir\n');
+
+test('an install directory is never used as the design store', () => {
+  const install = makeInstallDir();
+  withEnv({ JONGGRANG_HOME: install, JONGGRANG_DESIGN_HOME: undefined }, () => {
+    const root = freshDesign().designRoot();
+    assert.strictEqual(root, path.join(os.homedir(), '.jonggrang', 'design'),
+      `the store must fall back to the data home, got ${root}`);
+    assert.ok(!root.startsWith(install), 'the store must never land inside the checkout');
+  });
+});
+
+test('a JONGGRANG_HOME that is a data dir is still honoured', () => {
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-data-'));
+  withEnv({ JONGGRANG_HOME: data, JONGGRANG_DESIGN_HOME: undefined }, () => {
+    assert.strictEqual(freshDesign().designRoot(), path.join(data, 'design'));
+  });
+});
+
+test('no JONGGRANG_HOME → the data home', () => {
+  withEnv({ JONGGRANG_HOME: undefined, JONGGRANG_DESIGN_HOME: undefined }, () => {
+    assert.strictEqual(freshDesign().designRoot(), path.join(os.homedir(), '.jonggrang', 'design'));
+  });
+});
+
+test('JONGGRANG_DESIGN_HOME overrides everything', () => {
+  const install = makeInstallDir();
+  const explicit = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-design-'));
+  withEnv({ JONGGRANG_HOME: install, JONGGRANG_DESIGN_HOME: explicit }, () => {
+    assert.strictEqual(freshDesign().designRoot(), explicit);
+  });
+});
+
+test('a template created under an install-dir JONGGRANG_HOME lands in the real store', () => {
+  const install = makeInstallDir();
+  const store = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-store-'));
+  withEnv({ JONGGRANG_HOME: install, JONGGRANG_DESIGN_HOME: store }, () => {
+    const design = freshDesign();
+    const created = design.newTemplate('probe-template', { intent: 'regression probe', force: true });
+    assert.ok(created.dir.startsWith(store), `template landed outside the store: ${created.dir}`);
+    assert.ok(!created.dir.startsWith(install), 'template must not be written into the checkout');
+    assert.ok(fs.existsSync(created.dir), 'template directory should exist');
+    // …and it must be visible to the very next listing, which is what the studio reads.
+    assert.ok(design.listTemplates().some(t => t.key === 'probe-template' || t.id?.startsWith('probe-template')),
+      'a freshly created template must appear in the studio listing');
+  });
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Creating a template in the design studio looked like it did nothing: the new template never appeared in the list, and opening its session crashed the container with an OCI `chdir … no such file or directory` error.

## Cause

`JONGGRANG_HOME` carries two different meanings in this codebase:

- `server.js` and `bin/jonggrang.js` resolve it to the **install directory** — the checkout that ships `templates/`.
- `lib/design.js` read it as the **data directory** and put the design store under it.

Meanwhile `apis/design.js` bind-mounts `~/.jonggrang` into the studio container. So on any deployment where the launcher exports the install path, the three disagree:

| | Path |
|---|---|
| Server writes new templates to | `<checkout>/design/<name>` |
| Studio container looks in | `/root/.jonggrang/design/<name>` (from the `~/.jonggrang` mount) |
| Real store with the existing templates | `~/.jonggrang/design` |

Observed on the sandbox host, where the server process has `JONGGRANG_HOME=/home/ubuntu/jonggrang`:

- `GET /api/design` → `{"templates":[],"root":"/home/ubuntu/jonggrang/design"}` while `~/.jonggrang/design` holds `core`, `helo`, `studio-demo`
- a newly created template landed in the git checkout, showing up as an untracked `design/` directory
- its studio session then execs at a container path that does not exist

## Fix

The design store no longer resolves from `JONGGRANG_HOME` when that points at an install directory; it falls back to `~/.jonggrang`, the path the container already mounts. An install directory is recognised by probing for `templates/AGENTS.md.template` — the same marker `server.js` uses to find itself.

An explicit `JONGGRANG_HOME` naming a *data* directory still wins, so the three existing test files that isolate the store that way keep working, and `JONGGRANG_DESIGN_HOME` still overrides everything.

Templates already stranded in an install directory are not moved — they are reported once, by name and location, instead of silently vanishing from the studio.

## Verification

`test/design-store-path.test.js` covers install-dir rejection, the data-dir override, the no-env default, `JONGGRANG_DESIGN_HOME` precedence, and that a template created under an install-dir `JONGGRANG_HOME` both lands in the real store and appears in the very next listing.

The regression case fails on the current `main` code and passes with this change; `design`, `design-api` and `design-plan-integration` still pass, as does the full suite.

## Relationship to `fix/design-studio-new-template-cwd`

That branch adds a `mkdir -p` inside the container before `docker exec --workdir`, which stops the OCI crash. It is worth keeping as defence in depth, but it treats the symptom: with the store path corrected the directory exists in the container to begin with, because it is the same bind-mounted directory the server wrote to.
