### PR TITLE
feat(browser): swap agent-browser for anoa, and stop the design studio running a stale container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,10 +56,13 @@ jobs:
           cache-from: type=gha,scope=agent-dev
           cache-to: type=gha,mode=max,scope=agent-dev
 
-      - name: Smoke-test agent-browser
+      # Bounded: a browser that never comes up should fail the job, not hang it.
+      # The previous smoke step once sat at 22 minutes against a 4-6 minute norm.
+      - name: Smoke-test anoa
+        timeout-minutes: 8
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev-${{ github.sha }}
-        run: bash scripts/agent-browser-smoke.sh "$IMAGE"
+        run: bash scripts/anoa-smoke.sh "$IMAGE"
 
   # Pushes to main and release tags build & push latest + tunnel (multi-arch).
   # On a release tag (vX.Y.Z) the images are also tagged X.Y.Z and X.Y.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ jonggrang work --feature feat-abc123 # Target a specific approved feature (multi
   - Jonggrang (Pi SDK) → `npm install -g @earendil-works/pi-coding-agent`
 - [jq](https://jqlang.github.io/jq/) → `brew install jq`
 - git
-- *(optional)* [agent-browser](https://github.com/vercel-labs/agent-browser) → `npm install -g agent-browser && agent-browser install` — lets agents validate frontend design in a real headless browser. Preinstalled (with Chrome) in the Jonggrang sandbox image.
+- *(optional)* [anoa](https://github.com/porcupine-md/anoa-browser) → `curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh | bash` — lets agents validate frontend design in a real headless browser. A single self-contained binary that carries its own browser, so there is no second download; preinstalled in the Jonggrang sandbox image.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Project entry points: CLI binary, Pi TUI extension, web dashboard server. Hooks 
 
 ```bash
 # Quick flags
+jonggrang init --force               # Re-init: refresh AGENTS.md, CLAUDE.md, skills and sub-agents
 jonggrang plan "feature" --yes       # Skip review, auto-approve
 jonggrang work "feature" --yes       # Full pipeline in one command
 jonggrang plan "feature" --src docs/brd.md  # Reference source document for the agent to read

--- a/apis/design.js
+++ b/apis/design.js
@@ -252,8 +252,9 @@ module.exports = function register(app, io, _ctx) {
   }
 
   function ensureDesignContainer() {
-    if (containerRunning() && !containerImageDrifted()) return;
-    if (containerRunning()) {
+    const running = containerRunning();
+    if (running && !containerImageDrifted()) return;
+    if (running) {
       console.log(`[design] studio container is running an older ${AGENT_IMAGE} — recreating`);
       killAllPtys();                       // its ptys point into the container we are replacing
     }

--- a/apis/design.js
+++ b/apis/design.js
@@ -232,8 +232,31 @@ module.exports = function register(app, io, _ctx) {
     try { return execFileSync('docker', ['ps', '-q', '-f', `name=^${DESIGN_CONTAINER}$`], { encoding: 'utf8' }).trim().length > 0; }
     catch { return false; }
   }
+
+  // True when the running studio container was created from a different image
+  // than AGENT_IMAGE resolves to now. The studio container is long-lived — it
+  // outlives image updates — so without this check a container started before a
+  // tool landed in the image keeps running without it. That is exactly how the
+  // studio agent ended up with no browser: its container predated the browser
+  // being added, so the agent found nothing on PATH and installed its own.
+  function containerImageDrifted() {
+    try {
+      const running = execFileSync('docker', ['inspect', '--format', '{{.Image}}', DESIGN_CONTAINER],
+        { encoding: 'utf8' }).trim();
+      const current = execFileSync('docker', ['image', 'inspect', '--format', '{{.Id}}', AGENT_IMAGE],
+        { encoding: 'utf8' }).trim();
+      return Boolean(running && current && running !== current);
+    } catch {
+      return false;   // image not pulled yet, or container gone — nothing to compare
+    }
+  }
+
   function ensureDesignContainer() {
-    if (containerRunning()) return;
+    if (containerRunning() && !containerImageDrifted()) return;
+    if (containerRunning()) {
+      console.log(`[design] studio container is running an older ${AGENT_IMAGE} — recreating`);
+      killAllPtys();                       // its ptys point into the container we are replacing
+    }
     try { execFileSync('docker', ['rm', '-f', DESIGN_CONTAINER], { stdio: 'ignore' }); } catch { /* not present */ }
     execFileSync('docker', ['run', '-d', '--name', DESIGN_CONTAINER, '--env', 'IS_SANDBOX=1', ...designMounts(), AGENT_IMAGE, 'sleep', 'infinity'], { stdio: 'ignore' });
   }

--- a/apis/projects/sandbox-routes.js
+++ b/apis/projects/sandbox-routes.js
@@ -36,11 +36,28 @@ module.exports = function(deps) {
 
         startingSet.add(project.id);
         const running = await sandbox.isRunning(project.id);
-        // Reuse a running container only if its SSH-key mount AND editor port
-        // mapping still match the current config. If the key OR the code_editor
-        // setting changed after the container was created, fall through to
-        // recreate it (Docker can't remount/republish ports on start/restart).
-        if (running && !sandbox.sshMountDrifted(project.id) && !sandbox.editorMappingDrifted(project)) {
+        // Resolved here rather than further down because the fast path below
+        // needs it too: a running container used to be trusted on the strength
+        // of its mounts alone, so a republished image tag never reached the
+        // reconcile block and the container ran stale contents forever.
+        const globalConfig = webState.getSandboxConfig();
+        const sandboxConfig = {
+            image: project.sandbox?.image || globalConfig.image,
+            shell: project.sandbox?.shell || globalConfig.shell,
+            volumes: [...webState.getVolumes(), ...(project.sandbox?.volumes || [])],
+            network: project.sandbox?.network || globalConfig.network,
+        };
+        const configuredImage = sandboxConfig.image || sandbox.DEFAULT_AGENT_IMAGE;
+
+        // Reuse a running container only if its image build, SSH-key mount AND
+        // editor port mapping still match the current config. If the image tag
+        // moved, or the key OR the code_editor setting changed after the
+        // container was created, fall through to recreate it (Docker can't
+        // remount/republish ports, or swap an image, on start/restart).
+        if (running
+            && !(await sandbox.containerImageDrifted(project.id, configuredImage))
+            && !sandbox.sshMountDrifted(project.id)
+            && !sandbox.editorMappingDrifted(project)) {
             startingSet.delete(project.id);
             io.to(`project:${project.id}`).emit('sandbox.status', { project_id: project.id, status: 'running' });
             return res.json({ ok: true, status: 'running' });
@@ -51,14 +68,6 @@ module.exports = function(deps) {
 
         try {
             const secretVars = webState.getProjectSecretVars(project.id);
-            const globalConfig = webState.getSandboxConfig();
-            const sandboxConfig = {
-                image: project.sandbox?.image || globalConfig.image,
-                shell: project.sandbox?.shell || globalConfig.shell,
-                volumes: [...webState.getVolumes(), ...(project.sandbox?.volumes || [])],
-                network: project.sandbox?.network || globalConfig.network,
-            };
-            const configuredImage = sandboxConfig.image || sandbox.DEFAULT_AGENT_IMAGE;
 
             // Reconcile an existing container against the current config. Reuse it
             // only if the image, the SSH-key mount AND the editor port mapping all

--- a/apis/projects/sandbox-routes.js
+++ b/apis/projects/sandbox-routes.js
@@ -69,6 +69,7 @@ module.exports = function(deps) {
             if (containerStatus) {
                 const runningImage = await sandbox.getContainerImage(project.id);
                 const drifted = runningImage !== configuredImage
+                    || await sandbox.containerImageDrifted(project.id, configuredImage)
                     || sandbox.sshMountDrifted(project.id)
                     || sandbox.editorMappingDrifted(project);
                 if (!drifted) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,18 +44,29 @@ RUN npm install -g --no-fund --no-audit \
     jonggrang \
     @anthropic-ai/claude-code \
     opencode-ai \
-    @openai/codex \
-    agent-browser
+    @openai/codex
 
-# ── agent-browser Chrome (frontend design validation for every agent) ─────────
-# Bundles a headless Chromium + Linux system libs so `agent-browser` works
-# offline inside the sandbox. We use Playwright's Chromium build because it is
-# cross-arch (Chrome for Testing has no Linux arm64 build, and its --with-deps
-# path shells out to `sudo apt-get`, which is absent here). Playwright installs
-# the apt deps directly as root (no sudo) and agent-browser auto-detects the
-# resulting Chromium. All coding agents use this to validate frontend design
-# (see skills/library/frontend/validating-visual-design).
-RUN npx --yes playwright@latest install --with-deps chromium
+# ── anoa (the browser every agent drives) ─────────────────────────────────────
+# anoa ships as ONE self-contained binary with its own Chromium — no npm package
+# and no second download at run time. That is why it replaced agent-browser,
+# which needed `npm i -g agent-browser` plus a separate Playwright Chromium
+# install, and still fell back to Playwright's build on arm64 because Chrome for
+# Testing publishes no Linux arm64. anoa publishes native x86_64 and aarch64
+# builds, so both architectures get the same browser.
+#
+# Installed to /usr/local so it lands on PATH for every user in the container.
+# All coding agents use it to validate frontend design (see skills/core/anoa and
+# skills/library/frontend/validating-visual-design).
+RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
+    | bash -s -- --prefix /usr/local \
+    && anoa --version
+
+# Chromium refuses to start as root without --no-sandbox, and our containers run
+# as root so bind-mounted project files stay writable. Setting the flags here
+# rather than in every command keeps the agent-facing recipe plain
+# `anoa --headless --port 9222` — the same line that works on a laptop.
+# Mirrors what the anoa image itself sets.
+ENV QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu --no-sandbox"
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,23 @@ RUN npm install -g --no-fund --no-audit \
 # Installed to /usr/local so it lands on PATH for every user in the container.
 # All coding agents use it to validate frontend design (see skills/core/anoa and
 # skills/library/frontend/validating-visual-design).
+#
+# The bundle carries Chromium but NOT Chromium's system dependencies — those
+# must come from the distro. This list mirrors the one in anoa's own Dockerfile.
+# Missing any of them fails at *runtime* with a dlopen error, not at build: the
+# browser starts, answers on CDP, and then renders nothing. (This is what the
+# removed `playwright install --with-deps` used to pull in as a side effect.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 libnspr4 \
+    libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 libxkbfile1 libxshmfence1 \
+    libdrm2 libasound2t64 libcups2t64 \
+    libatk1.0-0t64 libatk-bridge2.0-0t64 libatspi2.0-0t64 \
+    libglib2.0-0t64 libdbus-1-3 \
+    libgl1 libglx-mesa0 libegl1 libgbm1 libopengl0 \
+    libfontconfig1 libfreetype6 \
+    fonts-liberation fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
     | bash -s -- --prefix /usr/local \
     && anoa --version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,8 +35,14 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/root/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
-# ── Rust (stable via rustup) ─────────────────────────────────────────────────
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path
+# ── Rust (stable via rustup, minimal profile) ────────────────────────────────
+# The default profile ships rust-docs: 902MB of offline HTML in an image where
+# nothing has a browser pointed at it. The minimal profile drops that, and
+# clippy + rustfmt are added back because Rust work needs a linter and a
+# formatter — jonggrang detects Cargo.toml as the `rust` stack and runs
+# `cargo test`, so the toolchain has to stay usable.
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path \
+    && /root/.cargo/bin/rustup component add clippy rustfmt
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ── AI tools + jonggrang ─────────────────────────────────────────────────────

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,9 +80,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation fonts-noto-color-emoji \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
-    | bash -s -- --prefix /usr/local \
-    && anoa --version
+COPY install-anoa.sh /tmp/install-anoa.sh
+RUN bash /tmp/install-anoa.sh \
+    && rm /tmp/install-anoa.sh
 
 # Chromium refuses to start as root without --no-sandbox, and our containers run
 # as root so bind-mounted project files stay writable. Setting the flags here

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -76,9 +76,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation fonts-noto-color-emoji \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
-    | bash -s -- --prefix /usr/local \
-    && anoa --version
+COPY docker/install-anoa.sh /tmp/install-anoa.sh
+RUN bash /tmp/install-anoa.sh \
+    && rm /tmp/install-anoa.sh
 
 # Chromium refuses to start as root without --no-sandbox, and our containers run
 # as root so bind-mounted project files stay writable. Setting the flags here

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -35,8 +35,14 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/root/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
-# ── Rust (stable via rustup) ─────────────────────────────────────────────────
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path
+# ── Rust (stable via rustup, minimal profile) ────────────────────────────────
+# The default profile ships rust-docs: 902MB of offline HTML in an image where
+# nothing has a browser pointed at it. The minimal profile drops that, and
+# clippy + rustfmt are added back because Rust work needs a linter and a
+# formatter — jonggrang detects Cargo.toml as the `rust` stack and runs
+# `cargo test`, so the toolchain has to stay usable.
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path \
+    && /root/.cargo/bin/rustup component add clippy rustfmt
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ── AI tools (jonggrang installed from local source, not npm) ────────────────

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -54,6 +54,22 @@ RUN npm install -g --no-fund --no-audit \
 # builds, so both architectures get the same browser.
 #
 # Installed to /usr/local so it lands on PATH for every user in the container.
+# The bundle carries Chromium but NOT Chromium's system dependencies — those
+# must come from the distro. This list mirrors the one in anoa's own Dockerfile.
+# Missing any of them fails at *runtime* with a dlopen error, not at build: the
+# browser starts, answers on CDP, and then renders nothing. (This is what the
+# removed `playwright install --with-deps` used to pull in as a side effect.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 libnspr4 \
+    libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 libxkbfile1 libxshmfence1 \
+    libdrm2 libasound2t64 libcups2t64 \
+    libatk1.0-0t64 libatk-bridge2.0-0t64 libatspi2.0-0t64 \
+    libglib2.0-0t64 libdbus-1-3 \
+    libgl1 libglx-mesa0 libegl1 libgbm1 libopengl0 \
+    libfontconfig1 libfreetype6 \
+    fonts-liberation fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
     | bash -s -- --prefix /usr/local \
     && anoa --version

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -43,18 +43,27 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN npm install -g --no-fund --no-audit \
     @anthropic-ai/claude-code \
     opencode-ai \
-    @openai/codex \
-    agent-browser
+    @openai/codex
 
-# ── agent-browser Chrome (frontend design validation for every agent) ─────────
-# Bundles a headless Chromium + Linux system libs so `agent-browser` works
-# offline inside the sandbox. We use Playwright's Chromium build because it is
-# cross-arch (Chrome for Testing has no Linux arm64 build, and its --with-deps
-# path shells out to `sudo apt-get`, which is absent here). Playwright installs
-# the apt deps directly as root (no sudo) and agent-browser auto-detects the
-# resulting Chromium. All coding agents use this to validate frontend design
-# (see skills/library/frontend/validating-visual-design).
-RUN npx --yes playwright@latest install --with-deps chromium
+# ── anoa (the browser every agent drives) ─────────────────────────────────────
+# anoa ships as ONE self-contained binary with its own Chromium — no npm package
+# and no second download at run time. That is why it replaced agent-browser,
+# which needed `npm i -g agent-browser` plus a separate Playwright Chromium
+# install, and still fell back to Playwright's build on arm64 because Chrome for
+# Testing publishes no Linux arm64. anoa publishes native x86_64 and aarch64
+# builds, so both architectures get the same browser.
+#
+# Installed to /usr/local so it lands on PATH for every user in the container.
+RUN curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh \
+    | bash -s -- --prefix /usr/local \
+    && anoa --version
+
+# Chromium refuses to start as root without --no-sandbox, and our containers run
+# as root so bind-mounted project files stay writable. Setting the flags here
+# rather than in every command keeps the agent-facing recipe plain
+# `anoa --headless --port 9222` — the same line that works on a laptop.
+# Mirrors what the anoa image itself sets.
+ENV QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu --no-sandbox"
 
 # ── openvscode-server (powers the "Full" code-editor mode in the dashboard) ───
 # Installed to /opt/openvscode-server, symlinked onto PATH. Latest stable tag is

--- a/docker/install-anoa.sh
+++ b/docker/install-anoa.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Install the AnoA bundle used by Jonggrang agent images.
+#
+# This is intentionally vendored rather than fetched and piped to bash at build
+# time. It resolves the latest AnoA release, then verifies the downloaded asset
+# against the digest published by GitHub's Releases API before unpacking it.
+set -euo pipefail
+
+REPO='porcupine-md/anoa-browser'
+PREFIX='/usr/local'
+
+case "$(uname -m)" in
+  x86_64|amd64) ASSET='anoa-linux-x86_64.tar.gz' ;;
+  aarch64|arm64) ASSET='anoa-linux-aarch64.tar.gz' ;;
+  *)
+    echo "Unsupported AnoA architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+ARCHIVE="$TMP_DIR/$ASSET"
+RELEASE_JSON="$TMP_DIR/release.json"
+
+curl --fail --location --silent --show-error --retry 3 \
+  --output "$RELEASE_JSON" "https://api.github.com/repos/${REPO}/releases/latest"
+ANOA_VERSION="$(jq -r '.tag_name // empty' "$RELEASE_JSON")"
+SHA256="$(jq -r --arg asset "$ASSET" '.assets[] | select(.name == $asset) | .digest // empty' "$RELEASE_JSON" | sed -n 's/^sha256://p')"
+[ -n "$ANOA_VERSION" ] || { echo 'AnoA release has no tag name' >&2; exit 1; }
+[ -n "$SHA256" ] || { echo "AnoA release has no SHA-256 digest for ${ASSET}" >&2; exit 1; }
+
+URL="https://github.com/${REPO}/releases/download/${ANOA_VERSION}/${ASSET}"
+curl --fail --location --silent --show-error --retry 3 --output "$ARCHIVE" "$URL"
+printf '%s  %s\n' "$SHA256" "$ARCHIVE" | sha256sum --check --status
+
+tar -xzf "$ARCHIVE" -C "$TMP_DIR"
+test -x "$TMP_DIR/anoa/anoa.sh"
+
+mkdir -p "$PREFIX/lib" "$PREFIX/bin"
+mv "$TMP_DIR/anoa" "$PREFIX/lib/anoa"
+ln -sfn "$PREFIX/lib/anoa/anoa.sh" "$PREFIX/bin/anoa"
+"$PREFIX/bin/anoa" --version

--- a/docs/AGENTTOOLS.md
+++ b/docs/AGENTTOOLS.md
@@ -4,12 +4,17 @@ This guide covers every file and function you must touch to integrate a new AI a
 
 > **Not every tool is a backend.** Some tools are *shared utilities* that agents call via
 > Bash rather than agent runtimes that drive the pipeline. For example
-> [`agent-browser`](https://github.com/vercel-labs/agent-browser) (frontend design
-> validation) is not integrated through this guide — it is installed in the sandbox image
-> (`docker/Dockerfile`) and surfaced to agents through a skill
-> (`skills/library/frontend/validating-visual-design`) plus the instruction templates. Use
+> [`anoa`](https://github.com/porcupine-md/anoa-browser) (the browser agents drive) is not
+> integrated through this guide — it is installed in the sandbox image
+> (`docker/Dockerfile`) and surfaced to agents through skills (`skills/core/anoa`,
+> `skills/library/frontend/validating-visual-design`) plus the instruction templates. Use
 > the skill + image route for shared CLIs; use the checklist below only for new agent
 > *backends* selected via `.jonggrang/jonggrang.json`.
+>
+> Prefer a shared CLI that carries what it needs. `anoa` replaced `agent-browser` because
+> the latter was an npm package that then had to download a browser at run time — two
+> installs, and on arm64 the download was a different browser than on amd64. A
+> self-contained binary removes the run-time step and the per-architecture divergence.
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -52,7 +52,7 @@ To keep this phase from overflowing a small context window, the agent is fed the
 The agent writes the tests, runs them, and verifies coverage. Tests are not an afterthought appended at the end; they are part of the definition of done for every task.
 
 ### Review
-A dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan? For frontend work the reviewer does not stop at the source — it drives the *rendered* UI in a real headless browser via the `agent-browser` CLI (preinstalled in the sandbox), checking layout, responsiveness, theming, and accessibility that code inspection and unit tests cannot see.
+A dedicated review pass reads the implementation as a future maintainer would. It asks: is this correct? is this maintainable? does it match the plan? For frontend work the reviewer does not stop at the source — it drives the *rendered* UI in a real headless browser via the `anoa` CLI (preinstalled in the sandbox), checking layout, responsiveness, theming, and accessibility that code inspection and unit tests cannot see.
 
 ### Compact Mode (the deliberate exception)
 Sometimes the loop *is* the point — you are iterating fast and the gates are a later, separate pass. Compact mode (`jonggrang work --compact`, or `orchestration.pipeline_mode: "compact"`) runs Plan → Implement and stops.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -42,7 +42,7 @@ skills/
     ├── frontend/
     │   ├── debugging-react-hooks/SKILL.md
     │   ├── optimizing-react-performance/SKILL.md
-    │   └── validating-visual-design/SKILL.md     ← anoa design validation        
+    │   └── validating-visual-design/SKILL.md     ← anoa design validation
     ├── testing/
     │   ├── unit-testing-patterns/SKILL.md
     │   └── fixing-flaky-tests/SKILL.md

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -42,7 +42,7 @@ skills/
     ├── frontend/
     │   ├── debugging-react-hooks/SKILL.md
     │   ├── optimizing-react-performance/SKILL.md
-    │   └── validating-visual-design/SKILL.md     ← agent-browser design validation
+    │   └── validating-visual-design/SKILL.md     ← anoa design validation        
     ├── testing/
     │   ├── unit-testing-patterns/SKILL.md
     │   └── fixing-flaky-tests/SKILL.md
@@ -112,7 +112,8 @@ The Gateway is the routing layer between agent intent and skill files. Instead o
 |----------|--------|-----------------------|
 | route, controller, service, endpoint, middleware | backend | developing-with-tdd, debugging-systematically, error-handling-patterns |
 | component, hook, render, state, UI | frontend | debugging-react-hooks, optimizing-react-performance |
-| visual, design check, screenshot, responsive, browser validation, agent-browser | frontend | validating-visual-design |
+| visual, design check, screenshot, responsive, browser validation | frontend | validating-visual-design |
+| browser, anoa, click, fill form, login flow, scrape, console errors | core | anoa |
 | REST, GraphQL, OpenAPI, validation | api | input-validation |
 | test, spec, coverage, mock, fixture | testing | unit-testing-patterns, fixing-flaky-tests |
 | migration, query, schema, ORM | database | safe-migrations |

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -401,7 +401,7 @@ The orchestrate command runs a deterministic 17-phase pipeline. Each phase is ex
 | 17 | Complete | Lead | Final summary, update `.jonggrang/.output/features/{id}/progress.txt`, MANIFEST → done | — |
 
 > **Frontend design validation.** In phases that touch the UI — Implement (8),
-> DesignVerify (10), and the interface-quality audit — agents use the `agent-browser`
+> DesignVerify (10), and the interface-quality audit — agents use the `anoa`
 > CLI (preinstalled in the sandbox, with Chrome) to open the running app in a real
 > headless browser and check the *rendered* result: layout, responsive behavior,
 > theming, and accessibility. Routed via the `validating-visual-design` skill. This

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -2654,6 +2654,12 @@ function generateConfig(options) {
 }
 
 function runInit(options, jonggrangHome, projectRoot, opts = {}) {
+  // `init --force` re-runs a project that is already set up. AGENTS.md and
+  // CLAUDE.md are rewritten unconditionally, but the skills and sub-agent
+  // definitions used to be skipped whenever the file already existed — so a
+  // project initialised before a tool changed kept instructing agents to use
+  // the old one forever. With force, jonggrang-managed copies are refreshed.
+  const refresh = Boolean(opts.force);
   const { name, type, stack, tool, testing, ci } = options;
   const paths = getProjectPaths(projectRoot);
   const testCmd = getTestCommand(testing);
@@ -2704,7 +2710,7 @@ function runInit(options, jonggrangHome, projectRoot, opts = {}) {
           if (!file.endsWith('.md')) continue;
           const src = path.join(agentsTemplateDir, file);
           const dest = path.join(claudeAgentsDir, file);
-          if (!fileExists(dest)) fs.copyFileSync(src, dest);
+          if (refresh || !fileExists(dest)) fs.copyFileSync(src, dest);
         }
       } catch { /* ignore */ }
     }
@@ -2792,7 +2798,7 @@ function runInit(options, jonggrangHome, projectRoot, opts = {}) {
 
         for (const targetBase of skillTargets) {
           const dest = path.join(targetBase, skillName, 'SKILL.md');
-          if (fileExists(dest)) continue;
+          if (!refresh && fileExists(dest)) continue;
           fs.mkdirSync(path.join(targetBase, skillName), { recursive: true });
           fs.copyFileSync(skillFile, dest);
         }

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -2734,7 +2734,7 @@ function runInit(options, jonggrangHome, projectRoot, opts = {}) {
           if (!file.endsWith('.md')) continue;
           const src = path.join(agentsTemplateDir, file);
           const dest = path.join(opencodeAgentsDir, file);
-          if (!fileExists(dest)) fs.copyFileSync(src, dest);
+          if (refresh || !fileExists(dest)) fs.copyFileSync(src, dest);
         }
       } catch { /* ignore */ }
     }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -390,6 +390,35 @@ function getContainerImage(projectId) {
     });
 }
 
+// Comparing image NAMES only catches a changed setting, never a moved tag: a
+// container started from `…:dev` keeps reporting `…:dev` after that tag has been
+// rebuilt and republished, so it runs old contents forever while looking current.
+// That is how project containers ended up without the browser the image had
+// gained. These two resolve IDs instead, so a republished tag reads as drift.
+function inspectId(args) {
+    return new Promise((resolve) => {
+        const proc = spawn('docker', args);
+        let out = '';
+        proc.stdout.on('data', d => { out += d.toString(); });
+        proc.stderr.on('data', () => {});
+        proc.on('error', () => resolve(null));
+        proc.on('close', (code) => resolve(code === 0 ? out.trim() : null));
+    });
+}
+
+/**
+ * True when the container is running a different image *build* than `image`
+ * currently resolves to locally. Unknown either way (image not pulled, no
+ * container) reports false — nothing to reconcile, and a wrong `true` would
+ * destroy a working container.
+ */
+async function containerImageDrifted(projectId, image) {
+    const running = await inspectId(['inspect', '--format', '{{.Image}}', getContainerName(projectId)]);
+    const current = await inspectId(['image', 'inspect', '--format', '{{.Id}}', image]);
+    if (!running || !current) return false;
+    return running !== current;
+}
+
 function remove(projectId) {
     return new Promise((resolve) => {
         const proc = spawn('docker', ['rm', '-f', getContainerName(projectId)]);
@@ -484,7 +513,7 @@ function editorMappingDrifted(project) {
 
 module.exports = {
     getContainerName, getContainerPath,
-    sshMountDrifted, editorMappingDrifted,
+    sshMountDrifted, editorMappingDrifted, containerImageDrifted,
     resolveProjectSshKey, projectSshKeyPath, sshKeyStatus,
     writeProjectSshKey, removeProjectSshKey,
     globalSshKeyPath, globalSshKeyStatus, writeGlobalSshKey, removeGlobalSshKey,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/init-refresh.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1111.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "README.md"
   ],
   "scripts": {
+    "ensure:pty-helper": "bash scripts/ensure-node-pty-helper.sh",
+    "prestart": "npm run ensure:pty-helper",
+    "pretest": "npm run ensure:pty-helper",
     "start": "bash scripts/ensure-build.sh && node server.js",
     "dev": "nodemon server.js",
     "build": "cd client && npm install && npm run build",

--- a/scripts/anoa-smoke.sh
+++ b/scripts/anoa-smoke.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Smoke-test agent-browser inside a Jonggrang agent image.
-# Verifies the packaged browser can open a page, read its accessibility tree,
-# resize the viewport, capture a valid PNG, and close cleanly.
+# Smoke-test anoa inside a Jonggrang agent image.
+# Verifies the packaged browser starts, opens a page, snapshots its interactive
+# elements, resizes the viewport and captures a valid PNG — the whole path an
+# agent takes when it validates a rendered UI.
 #
 # Usage:
-#   bash scripts/agent-browser-smoke.sh [image]
+#   bash scripts/anoa-smoke.sh [image]
 #
 # Default:
 #   ghcr.io/porcupine-md/jonggrang-agent:dev
 
 IMAGE="${1:-${IMAGE:-ghcr.io/porcupine-md/jonggrang-agent:dev}}"
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jg-agent-browser-smoke.XXXXXX")"
-CONTAINER_NAME="jg-agent-browser-smoke-$$"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jg-anoa-smoke.XXXXXX")"
+CONTAINER_NAME="jg-anoa-smoke-$$"
 
 cleanup() {
   docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -71,7 +72,7 @@ if (width !== 375 || height !== 812) {
 }
 JS
 
-printf 'Testing agent-browser in %s\n' "$IMAGE"
+printf 'Testing anoa in %s\n' "$IMAGE"
 docker run --name "$CONTAINER_NAME" --rm \
   -v "$TMP_DIR:/smoke" \
   "$IMAGE" \
@@ -79,15 +80,24 @@ docker run --name "$CONTAINER_NAME" --rm \
     set -euo pipefail
 
     cleanup() {
-      agent-browser close >/dev/null 2>&1 || true
+      kill "${BROWSER_PID:-}" >/dev/null 2>&1 || true
       kill "${SERVER_PID:-}" >/dev/null 2>&1 || true
     }
     trap cleanup EXIT INT TERM
 
-    command -v agent-browser >/dev/null
-    agent-browser --version
+    command -v anoa >/dev/null
+    anoa --version
 
-    node /smoke/server.js >/tmp/jg-agent-browser-smoke-server.log 2>&1 &
+    # anoa is a session: start one browser, everything else attaches to it.
+    anoa --headless --port 9222 >/tmp/jg-anoa-smoke-browser.log 2>&1 &
+    BROWSER_PID=$!
+    for _ in $(seq 1 50); do
+      anoa status >/dev/null 2>&1 && break
+      sleep 0.2
+    done
+    anoa status >/dev/null
+
+    node /smoke/server.js >/tmp/jg-anoa-smoke-server.log 2>&1 &
     SERVER_PID=$!
 
     for _ in $(seq 1 30); do
@@ -98,18 +108,15 @@ docker run --name "$CONTAINER_NAME" --rm \
     done
     curl -fsS http://127.0.0.1:4173 >/dev/null
 
-    agent-browser open http://127.0.0.1:4173 >/dev/null
-    agent-browser wait --load networkidle >/dev/null
+    anoa open http://127.0.0.1:4173 >/dev/null
+    anoa wait --text "Jonggrang browser smoke" >/dev/null
 
-    SNAPSHOT="$(agent-browser snapshot)"
-    grep -q "Jonggrang browser smoke" <<<"$SNAPSHOT"
-    grep -q "button" <<<"$SNAPSHOT"
+    grep -q "Jonggrang browser smoke" <<<"$(anoa get text)"
+    grep -q "button" <<<"$(anoa snapshot -i)"
 
-    agent-browser set viewport 375 812 >/dev/null
-    agent-browser screenshot /smoke/mobile.png >/dev/null
+    anoa set viewport 375 812 >/dev/null
+    anoa screenshot /smoke/mobile.png >/dev/null
     node /smoke/verify-png.js
-
-    agent-browser close >/dev/null
   '
 
-printf 'PASS: agent-browser open/snapshot/viewport/screenshot/close\n'
+printf 'PASS: anoa start/open/get text/snapshot/viewport/screenshot\n'

--- a/scripts/ensure-node-pty-helper.sh
+++ b/scripts/ensure-node-pty-helper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# node-pty launches a small spawn helper on Unix. Some package extractions lose
+# its executable bit, which turns every PTY launch into "posix_spawnp failed".
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM="$(node -p 'process.platform')"
+ARCH="$(node -p 'process.arch')"
+HELPER="$ROOT/node_modules/node-pty/prebuilds/${PLATFORM}-${ARCH}/spawn-helper"
+
+# Native builds and Windows do not use this packaged Unix helper.
+if [[ ! -e "$HELPER" ]]; then
+  exit 0
+fi
+
+if [[ -x "$HELPER" ]]; then
+  exit 0
+fi
+
+chmod u+x "$HELPER"
+printf '[node-pty] restored executable permission: %s\n' "$HELPER"

--- a/skills/core/anoa/SKILL.md
+++ b/skills/core/anoa/SKILL.md
@@ -9,9 +9,13 @@ trigger: "browser, anoa, screenshot, render, responsive, viewport, dark mode, co
 
 # anoa
 
-`anoa` is the browser every Jonggrang agent drives. It is preinstalled in the
-sandbox image as a single self-contained binary — there is **nothing to install
-at run time**, and no Playwright or Chrome download to wait for.
+`anoa` is the browser every Jonggrang agent drives — a single self-contained
+binary that carries its own browser, so there is **no Playwright or Chrome
+download to wait for**.
+
+In the sandbox it is preinstalled. On a bare host, install it once with
+`scripts/install-linux.sh` from the anoa repo; if `anoa` is not on PATH, install
+it rather than reaching for another tool.
 
 ## The one thing to know
 

--- a/skills/core/anoa/SKILL.md
+++ b/skills/core/anoa/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: anoa
+description: Drive a real browser from the command line — open pages, snapshot the interactive elements as refs, click and fill by ref, read text, run JS, screenshot. Use when a task needs a live browser: checking a page renders, walking a login or checkout flow, scraping something that only exists after JavaScript runs, or reproducing a UI bug.
+type: tool
+tier: core
+domains: [frontend, ui, testing, debugging]
+trigger: "browser, anoa, screenshot, render, responsive, viewport, dark mode, console errors, network requests, click, fill form, login flow, scrape, verify UI, visual check"
+---
+
+# anoa
+
+`anoa` is the browser every Jonggrang agent drives. It is preinstalled in the
+sandbox image as a single self-contained binary — there is **nothing to install
+at run time**, and no Playwright or Chrome download to wait for.
+
+## The one thing to know
+
+The browser is a **session**. Start it once; every later command attaches to the
+running browser and leaves it running, so the page, cookies and scroll position
+survive between commands.
+
+```bash
+anoa --headless --port 9222 &   # start it once
+anoa open example.com           # then drive it
+anoa snapshot -i                # see what is interactive, with @refs
+anoa click @e2                  # act by ref
+```
+
+`anoa status` reports whether a browser is listening; **exit code 3 means none
+is** — that, not a wrong command, is why `anoa open` would do nothing.
+
+## Load the full reference before working
+
+The binary carries its own documentation, which is always in step with the
+installed version:
+
+```bash
+anoa skills get core        # the workflow: start, snapshot, act by ref
+anoa skills get commands    # every command with its arguments
+```
+
+Read `core` before your first browser task in a session, and `commands` when you
+need exact syntax. Do not work from memory of another browser CLI — `anoa` is
+session-based, so one-shot recipes from other tools silently do nothing here.
+
+## What it is good for
+
+| Need | Reach for |
+|---|---|
+| Does the page render, and how does it look | `anoa open`, `anoa screenshot [file]` |
+| What can I interact with | `anoa snapshot -i` → `@refs` |
+| Responsive / dark mode check | `anoa set viewport <w> <h>`, `anoa set device`, `anoa set media dark\|light` |
+| Read what the page says | `anoa get text [@ref]` — cheaper than `get html` |
+| Walk a flow | `anoa fill @e3 "…"`, `anoa click @e7`, `anoa wait --url "/dashboard"` |
+| Why is the UI broken | `anoa console`, `anoa errors`, `anoa network` |
+
+`--json` on any command gives structured output. Exit codes: `0` ok, `1` failed,
+`2` bad usage, `3` no browser listening.
+
+## Rules
+
+- **Re-snapshot after anything that changes the page.** Refs are written onto DOM
+  nodes; a navigation or a submit replaces them. `no element for @e4` means the
+  snapshot is stale, not that the command is wrong.
+- **Prefer `wait --selector` / `--url` / `--text` over `wait --ms`.** They are
+  faster on a quick page and more reliable on a slow one.
+- **Prefer `get text` over `get html`.** HTML costs far more tokens and rarely
+  says more.
+- Any CSS selector works wherever a ref does: `anoa click "#submit"`.
+
+## Watching it happen
+
+`anoa terminal` renders the live page in the terminal and forwards clicks and
+typing, attached to the same running browser — useful in one pane while commands
+run in another.

--- a/skills/core/gateway-frontend/SKILL.md
+++ b/skills/core/gateway-frontend/SKILL.md
@@ -4,7 +4,7 @@ description: Route frontend tasks to the right library skill. Detects React/Vue/
 type: gateway
 tier: core
 domains: [frontend, ui, components]
-trigger: "React, Vue, Angular, component, JSX, TSX, CSS, Tailwind, frontend, UI, browser, DOM, Next.js, agent-browser, visual, design check, screenshot, responsive"
+trigger: "React, Vue, Angular, component, JSX, TSX, CSS, Tailwind, frontend, UI, browser, DOM, Next.js, anoa, visual, design check, screenshot, responsive"
 ---
 
 ## Purpose
@@ -24,7 +24,8 @@ You are the Frontend Gateway. Detect intent from the current task and return the
 | `accessibility`, `a11y`, `aria`, `screen reader` | `skills/library/frontend/accessibility/SKILL.md` |
 | `css`, `tailwind`, `styled-components`, `emotion` | `skills/library/frontend/styling-patterns/SKILL.md` |
 | `ssr`, `ssg`, `next.js`, `hydration`, `server component` | `skills/library/frontend/ssr-patterns/SKILL.md` |
-| `visual`, `design check`, `screenshot`, `responsive`, `contrast`, `browser validation`, `verify UI`, `agent-browser` | `skills/library/frontend/validating-visual-design/SKILL.md` |
+| `visual`, `design check`, `screenshot`, `responsive`, `contrast`, `browser validation`, `verify UI` | `skills/library/frontend/validating-visual-design/SKILL.md` |
+| `browser`, `anoa`, `click`, `fill form`, `login flow`, `scrape`, `console errors`, `network requests` | `skills/core/anoa/SKILL.md` |
 | `component`, `jsx`, `tsx`, `react` (general) | `skills/library/frontend/react-component-patterns/SKILL.md` |
 
 ## Output Format

--- a/skills/library/frontend/auditing-interface-quality/SKILL.md
+++ b/skills/library/frontend/auditing-interface-quality/SKILL.md
@@ -16,18 +16,22 @@ Perform a systematic audit of the interface quality across accessibility (A11y),
 ## Execution Steps
 
 1. **Discover Context:** Use `glob` and `read` to review the frontend components built or modified for the current feature.
-2. **Live Browser Check (agent-browser):** Whenever the app can be served, validate the
-   *rendered* UI — not just the source — with the `agent-browser` CLI (preinstalled in the
+2. **Live Browser Check (anoa):** Whenever the app can be served, validate the
+   *rendered* UI — not just the source — with the `anoa` CLI (preinstalled in the
    sandbox). It only observes the page, so it is safe under the read-only Reviewer role.
+   The browser is a session: start it once, then every command attaches to it.
    ```bash
-   agent-browser open <app-url> && agent-browser wait --load networkidle
-   agent-browser snapshot                       # a11y tree with roles/labels
-   agent-browser screenshot audit-desktop.png
-   agent-browser set viewport 375 812           # re-check responsive
-   agent-browser screenshot audit-mobile.png
-   agent-browser close
+   anoa --headless --port 9222 &                # once; `anoa status` exit 3 = not running
+   anoa open <app-url> && anoa wait --load
+   anoa snapshot -i                             # interactive elements with @refs
+   anoa screenshot audit-desktop.png
+   anoa set viewport 375 812                    # re-check responsive
+   anoa screenshot audit-mobile.png
+   anoa set media dark && anoa screenshot audit-dark.png
+   anoa errors                                  # a page can look right and still throw
    ```
    Save screenshots into the active feature directory. See
+   `skills/core/anoa/SKILL.md` for the tool and
    `skills/library/frontend/validating-visual-design/SKILL.md` for the full workflow.
 3. **Diagnostic Scan** (use the snapshot/screenshots as evidence):
    - **Accessibility (A11y):** Check for contrast issues, missing ARIA roles, poor keyboard navigation, semantic HTML, and alt text.

--- a/skills/library/frontend/validating-visual-design/SKILL.md
+++ b/skills/library/frontend/validating-visual-design/SKILL.md
@@ -15,8 +15,18 @@ This skill uses **`anoa`** — the browser CLI preinstalled in the Jonggrang san
 actually works.
 
 `anoa` is available to every agent backend (claude, opencode, codex, jonggrang).
-Call it via Bash. It is a single self-contained binary with its own browser:
-**nothing to install, in the sandbox or on a bare host.**
+Call it via Bash. In the sandbox it is already there — start with the session
+step below.
+
+On a bare host, install the binary once:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh | bash
+```
+
+That is one binary carrying its own browser, so there is **no second download
+for a browser** — but the binary itself does have to exist. If `anoa` is not on
+PATH, install it rather than reaching for another tool.
 
 ## The browser is a session
 

--- a/skills/library/frontend/validating-visual-design/SKILL.md
+++ b/skills/library/frontend/validating-visual-design/SKILL.md
@@ -1,22 +1,36 @@
 ---
 name: validating-visual-design
-description: Validate frontend design in a real browser using the agent-browser CLI — screenshots, accessibility snapshots, responsive and contrast checks.
+description: Validate frontend design in a real browser using the anoa CLI — screenshots, interactive snapshots, responsive, dark-mode and contrast checks.
 type: workflow
 tier: library
 domains: [frontend]
-trigger: "visual, design check, screenshot, responsive, contrast, layout, browser validation, agent-browser, verify UI, does it look right, render"
+trigger: "visual, design check, screenshot, responsive, contrast, layout, browser validation, anoa, verify UI, does it look right, render"
 ---
 
-# Validating Visual Design with agent-browser
+# Validating Visual Design with anoa
 
 Frontend code that typechecks and passes unit tests can still render broken.
-This skill uses **`agent-browser`** — a browser-automation CLI preinstalled in the
-Jonggrang sandbox — to open the running app in a real (headless) Chrome and verify
-the design actually works.
+This skill uses **`anoa`** — the browser CLI preinstalled in the Jonggrang sandbox
+— to open the running app in a real headless browser and verify the design
+actually works.
 
-`agent-browser` is available to every agent backend (claude, opencode, codex,
-jonggrang). Call it via Bash. Chrome for Testing is already installed in the sandbox
-image, so no setup is needed there. On a bare host, run `agent-browser install` once.
+`anoa` is available to every agent backend (claude, opencode, codex, jonggrang).
+Call it via Bash. It is a single self-contained binary with its own browser:
+**nothing to install, in the sandbox or on a bare host.**
+
+## The browser is a session
+
+This is the one thing to get right. Start the browser **once**; every command
+after that attaches to the running browser and leaves it running, so the page,
+cookies and scroll position survive between commands.
+
+```bash
+anoa --headless --port 9222 &     # start once, in the background
+anoa status                       # exit code 3 = nothing listening
+```
+
+A command that seems to do nothing almost always means no browser is running —
+check `anoa status` before assuming the command is wrong.
 
 ## When to use
 
@@ -27,55 +41,69 @@ image, so no setup is needed there. On a bare host, run `agent-browser install` 
 ## Core commands
 
 ```bash
-agent-browser open http://localhost:3000       # open a URL (starts the browser)
-agent-browser snapshot                          # accessibility tree with @refs (a11y check)
-agent-browser screenshot design.png             # capture the rendered page (PNG)
-agent-browser set viewport 375 812              # resize (e.g. mobile) before capturing
-agent-browser get text @e1                       # read text by ref from snapshot
-agent-browser click @e2                          # interact by ref
-agent-browser fill @e3 "value"                   # fill an input by ref
-agent-browser wait --load networkidle            # wait until the page settles
-agent-browser close                              # shut the browser down
+anoa open http://localhost:3000    # go to a url (scheme optional)
+anoa wait --load                   # or --text/--url/<css>: name what you expect
+anoa screenshot design.png         # PNG of the viewport
+anoa snapshot -i                   # interactive elements, each with an @ref
+anoa get text                      # all visible text (cheaper than get html)
+anoa click @e2                     # act by ref — or by any CSS selector
+anoa fill @e3 "value"              # fires input/change, so React sees it
+anoa set viewport 375 812          # resize the page
+anoa set media dark                # emulate prefers-color-scheme
+anoa console                       # what the page logged
+anoa errors                        # uncaught exceptions
 ```
+
+Run `anoa skills get commands` for the full reference — it ships with the binary
+and is always in step with the installed version.
 
 ## Workflow
 
 1. **Start the dev server** for the app (e.g. `npm run dev &`) and note its URL.
-   Wait until it is reachable before opening the browser.
-2. **Open the page:** `agent-browser open <url>` then `agent-browser wait --load networkidle`.
-3. **Capture evidence:** `agent-browser screenshot <feature>.png`. Read the screenshot
-   back to inspect layout, spacing, alignment, colors, and dark mode.
-4. **Check accessibility & structure:** `agent-browser snapshot` — verify semantic
-   roles, labels, and that key elements are present and reachable.
-5. **Check responsiveness:** resize to a narrow viewport and screenshot again to
-   catch horizontal scroll, overflow, and touch-target sizing.
+   Wait until it is reachable.
+2. **Start the browser once:** `anoa --headless --port 9222 &`.
+3. **Open the page:** `anoa open <url>` then `anoa wait --load`. When you know what
+   should appear, `anoa wait --text "…"` is faster and more honest than `--load`.
+4. **Capture evidence:** `anoa screenshot <feature>.png`. Read the screenshot back
+   to inspect layout, spacing, alignment and colour.
+5. **Check structure:** `anoa snapshot -i` — verify the key elements are present,
+   labelled and reachable. Re-snapshot after anything that changes the page.
+6. **Check responsiveness:**
    ```bash
-   agent-browser set viewport 375 812        # mobile portrait
-   agent-browser screenshot mobile.png
-   agent-browser set viewport 1280 800       # back to desktop
+   anoa set viewport 375 812        # mobile portrait
+   anoa screenshot mobile.png
+   anoa set viewport 1280 800       # back to desktop
    ```
-6. **Exercise interactions** the task depends on (`click`/`fill`) and confirm the
-   resulting state via `snapshot`/`screenshot`.
-7. **Tear down:** `agent-browser close` and stop the dev server.
+7. **Check dark mode:** `anoa set media dark` → screenshot → `anoa set media light`.
+8. **Exercise interactions** the task depends on (`click` / `fill`) and confirm the
+   resulting state via `snapshot` / `screenshot`.
+9. **Check the console:** `anoa errors` and `anoa console` — a page can look right
+   and still be throwing.
+
+Leave the browser running; the next task attaches to it. There is no teardown
+step to forget.
 
 ## What to look for
 
 - **Layout:** no overlap, no unintended overflow/horizontal scroll, correct alignment.
 - **Responsive:** usable at mobile (375px) and desktop widths; touch targets ≥ 44px.
-- **Theming:** dark mode renders; colors come from design tokens, not hard-coded values.
-- **Accessibility:** headings, labels, ARIA roles, alt text present in the snapshot.
+- **Theming:** dark mode renders; colours come from design tokens, not hard-coded values.
+- **Accessibility:** headings, labels, roles present in the snapshot.
 - **Content:** expected text and elements actually appear (not blank / error state).
+- **Console:** no uncaught errors behind a page that looks fine.
 
 ## Validation
 
 The design is validated when a screenshot + snapshot of the built UI have been
 captured and reviewed against the task's acceptance criteria, with no critical
-layout, responsive, theming, or accessibility issues outstanding.
+layout, responsive, theming, accessibility or console issues outstanding.
 
 ## Notes
 
-- `agent-browser` runs headless in the sandbox; no display server is required.
-- Reviewers are read-only on source code — `agent-browser` only observes, so it is
-  safe to run during audits. Save any screenshots inside the active feature's
+- `anoa` runs headless; no display server is required.
+- Reviewers are read-only on source code — `anoa` only observes, so it is safe to
+  run during audits. Save screenshots inside the active feature's
   `.jonggrang/.output/features/<feature_id>/` directory.
 - Do not put secrets/credentials in command args; use the app's own login flow.
+- `anoa terminal` renders the live page in your terminal if you want to watch a
+  flow rather than infer it from screenshots.

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -188,22 +188,28 @@ created_at: 2026-04-16T10:30:00Z
 
 ## Browser Automation (frontend design validation)
 
-The `agent-browser` CLI is preinstalled in the Jonggrang sandbox and available to every
+The `anoa` CLI is preinstalled in the Jonggrang sandbox and available to every
 agent backend (claude, opencode, codex, jonggrang). Use it to validate frontend design in
 a real headless browser — do not sign off UI work on typecheck + unit tests alone.
 
+The browser is a **session**: start it once, and every later command attaches to the
+running browser, so the page and its state survive between commands.
+
 ```bash
-agent-browser open http://localhost:3000   # open the running app
-agent-browser wait --load networkidle
-agent-browser snapshot                       # accessibility tree with @refs (a11y)
-agent-browser screenshot ui.png              # capture; review layout/contrast/dark mode
-agent-browser set viewport 375 812           # responsive re-check, then screenshot again
-agent-browser close
+anoa --headless --port 9222 &              # start once (anoa status: exit 3 = not running)
+anoa open http://localhost:3000            # open the running app
+anoa wait --load                           # or --text/--url: name what you expect
+anoa snapshot -i                           # interactive elements, each with an @ref
+anoa screenshot ui.png                     # capture; review layout/contrast
+anoa set viewport 375 812                  # responsive re-check, then screenshot again
+anoa set media dark                        # dark-mode check
+anoa errors                                # a page can look right and still throw
 ```
 
 Full workflow lives in the `validating-visual-design` skill
-(`.claude/skills/validating-visual-design/SKILL.md` or the equivalent path for your tool).
-On a bare host (outside the sandbox), run `agent-browser install` once to fetch Chrome.
+(`.claude/skills/validating-visual-design/SKILL.md` or the equivalent path for your tool);
+`anoa skills get commands` prints the complete command reference. There is nothing to
+install — anoa is a single self-contained binary that carries its own browser.
 
 ---
 

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -208,8 +208,16 @@ anoa errors                                # a page can look right and still thr
 
 Full workflow lives in the `validating-visual-design` skill
 (`.claude/skills/validating-visual-design/SKILL.md` or the equivalent path for your tool);
-`anoa skills get commands` prints the complete command reference. There is nothing to
-install — anoa is a single self-contained binary that carries its own browser.
+`anoa skills get commands` prints the complete command reference.
+
+In the sandbox anoa is already installed. On a bare host, install the binary once:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/porcupine-md/anoa-browser/master/scripts/install-linux.sh | bash
+```
+
+It carries its own browser, so there is never a second download for a browser — but
+if `anoa` is not on PATH, install it rather than reaching for another tool.
 
 ---
 

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -77,7 +77,9 @@ anoa errors                                # uncaught exceptions behind a page t
 
 Full workflow (responsive checks, interactions): read
 `.claude/skills/validating-visual-design/SKILL.md`, or run `anoa skills get commands`
-for the complete reference. Nothing to install — anoa carries its own browser.
+for the complete reference. In the sandbox anoa is already installed; on a bare
+host install the binary once (see AGENTS.md). It carries its own browser, so
+there is never a second download for a browser.
 
 ## Rules
 

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -59,26 +59,30 @@ Get the `feature_id` by running: `jonggrang task show <id>` — look for the `fe
 
 ## Browser Automation (frontend design validation)
 
-The `agent-browser` CLI is available (preinstalled in the Jonggrang sandbox) for
+The `anoa` CLI is available (preinstalled in the Jonggrang sandbox) for
 validating frontend design in a real headless browser. When your task touches the UI,
-verify the *rendered* result — not just that the code compiles — before signalling done:
+verify the *rendered* result — not just that the code compiles — before signalling done.
+
+The browser is a **session**: start it once, then drive it.
 
 ```bash
-agent-browser open http://localhost:3000   # open the running app
-agent-browser wait --load networkidle
-agent-browser snapshot                       # accessibility tree with @refs
-agent-browser screenshot ui.png              # capture + review layout/contrast/dark mode
-agent-browser close
+anoa --headless --port 9222 &              # start once (anoa status: exit 3 = not running)
+anoa open http://localhost:3000            # open the running app
+anoa wait --load
+anoa snapshot -i                           # interactive elements with @refs
+anoa screenshot ui.png                     # capture + review layout/contrast
+anoa set media dark                        # dark-mode check
+anoa errors                                # uncaught exceptions behind a page that looks fine
 ```
 
 Full workflow (responsive checks, interactions): read
-`.claude/skills/validating-visual-design/SKILL.md`. On a bare host (no sandbox), run
-`agent-browser install` once to fetch Chrome.
+`.claude/skills/validating-visual-design/SKILL.md`, or run `anoa skills get commands`
+for the complete reference. Nothing to install — anoa carries its own browser.
 
 ## Rules
 
 - Only modify files listed in your task's `"files"` array
-- Validate frontend design with `agent-browser` when the task touches UI
+- Validate frontend design with `anoa` when the task touches UI
 - Follow patterns in AGENTS.md
 - One atomic commit per task
 - Do not skip validation

--- a/templates/agents/developer.md
+++ b/templates/agents/developer.md
@@ -57,14 +57,17 @@ If any check fails, fix before signaling.
 
 **Frontend tasks — validate the rendered design too.** Typecheck + unit tests do not
 prove the UI looks right. If your task touched any component, page, layout, or styling,
-verify it in a real browser with `agent-browser` (preinstalled in the sandbox) before
-signalling. Load the `validating-visual-design` gateway skill for the full workflow:
+verify it in a real browser with `anoa` (preinstalled in the sandbox) before
+signalling. The browser is a session — start it once, then drive it. Load the
+`validating-visual-design` gateway skill for the full workflow:
 
 ```bash
-agent-browser open <app-url> && agent-browser wait --load networkidle
-agent-browser snapshot                       # a11y tree
-agent-browser screenshot ui.png              # review layout/contrast/responsive/dark mode
-agent-browser close
+anoa --headless --port 9222 &                # once; anoa status: exit 3 = not running
+anoa open <app-url> && anoa wait --load
+anoa snapshot -i                             # interactive elements with @refs
+anoa screenshot ui.png                       # review layout/contrast/responsive
+anoa set media dark                          # dark-mode check
+anoa errors                                  # uncaught exceptions
 ```
 
 ## Bugs Discovered While Implementing

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -40,9 +40,9 @@ Depends on which phase you're called for:
 - [ ] No extra scope added (scope creep)
 - [ ] Function signatures match design
 - [ ] **Frontend:** rendered UI matches the design. Verify in a real headless browser
-      with `agent-browser` (preinstalled; read-only observation, safe for Reviewer) —
-      `open` the app, take a `snapshot` + `screenshot`, and check layout, responsive
-      behavior, theming, and accessibility. See the `validating-visual-design` and
+      with `anoa` (preinstalled; read-only observation, safe for Reviewer) — start it
+      once with `anoa --headless --port 9222 &`, `open` the app, take a `snapshot -i`
+      + `screenshot`, and check layout, responsive behavior, theming, and accessibility. See the `validating-visual-design` and
       `auditing-interface-quality` skills.
 
 ### Phase 11 — Domain Compliance

--- a/test/init-refresh.test.js
+++ b/test/init-refresh.test.js
@@ -84,6 +84,30 @@ test('init --force refreshes stale sub-agent definitions', () => {
     '--force must restore the shipped sub-agent definition');
 });
 
+// Sub-agent definitions are written twice, once per tool tree. Refreshing only
+// the Claude copy would leave an OpenCode project on stale instructions.
+test('init --force refreshes the OpenCode sub-agent definitions too', () => {
+  const root = tmpProject();
+  initProject(root);
+  const agent = path.join(root, '.opencode', 'agents', 'developer.md');
+  assert.ok(fs.existsSync(agent), 'first init should install the OpenCode definition');
+  const shipped = fs.readFileSync(agent, 'utf8');
+
+  fs.writeFileSync(agent, '# stale opencode developer definition\n');
+  initProject(root, { force: true });
+  assert.strictEqual(fs.readFileSync(agent, 'utf8'), shipped,
+    '--force must restore the shipped OpenCode definition');
+});
+
+test('a plain re-init leaves an edited OpenCode definition alone', () => {
+  const root = tmpProject();
+  initProject(root);
+  const agent = path.join(root, '.opencode', 'agents', 'developer.md');
+  fs.writeFileSync(agent, '# locally edited\n');
+  initProject(root);
+  assert.strictEqual(fs.readFileSync(agent, 'utf8'), '# locally edited\n');
+});
+
 test('the browser skill a refreshed project receives names anoa, not agent-browser', () => {
   const root = tmpProject();
   initProject(root, { force: true });

--- a/test/init-refresh.test.js
+++ b/test/init-refresh.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// `jonggrang init --force` on an already-initialised project. AGENTS.md and
+// CLAUDE.md were always rewritten, but the skills and sub-agent definitions were
+// skipped whenever the file already existed — so a project initialised before a
+// tool changed kept telling agents to use the old one, with no way to refresh
+// short of deleting files by hand.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../lib/jonggrang');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+const JONGGRANG_HOME = path.join(__dirname, '..');
+
+function initProject(root, opts = {}) {
+  return lib.runInit({
+    name: 'refresh-probe', type: 'web-app', stack: 'vanilla', tool: 'claude',
+    workMode: 'solo', teamSize: '1', autonomy: 'autonomous', testing: 'none',
+    testCmd: '', ci: 'none',
+  }, JONGGRANG_HOME, root, opts);
+}
+
+function tmpProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'jg-refresh-'));
+}
+
+const SKILL = path.join('.claude', 'skills', 'core', 'anoa', 'SKILL.md');
+const AGENT = path.join('.claude', 'agents', 'developer.md');
+
+console.log('\ninit --force — refreshing jonggrang-managed files\n');
+
+test('a plain re-init leaves an existing skill untouched', () => {
+  const root = tmpProject();
+  initProject(root);
+  const skill = path.join(root, SKILL);
+  assert.ok(fs.existsSync(skill), 'first init should install the skill');
+
+  fs.writeFileSync(skill, '# locally edited, do not clobber\n');
+  initProject(root);                       // no force
+  assert.strictEqual(fs.readFileSync(skill, 'utf8'), '# locally edited, do not clobber\n',
+    'without --force an existing skill must be left alone');
+});
+
+test('init --force refreshes a stale skill', () => {
+  const root = tmpProject();
+  initProject(root);
+  const skill = path.join(root, SKILL);
+  const shipped = fs.readFileSync(skill, 'utf8');
+
+  fs.writeFileSync(skill, '# stale: tells agents to use a tool that no longer exists\n');
+  initProject(root, { force: true });
+  assert.strictEqual(fs.readFileSync(skill, 'utf8'), shipped,
+    '--force must restore the shipped skill');
+});
+
+test('init --force refreshes stale sub-agent definitions', () => {
+  const root = tmpProject();
+  initProject(root);
+  const agent = path.join(root, AGENT);
+  assert.ok(fs.existsSync(agent), 'first init should install the sub-agent definition');
+  const shipped = fs.readFileSync(agent, 'utf8');
+
+  fs.writeFileSync(agent, '# stale developer definition\n');
+  initProject(root, { force: true });
+  assert.strictEqual(fs.readFileSync(agent, 'utf8'), shipped,
+    '--force must restore the shipped sub-agent definition');
+});
+
+test('the browser skill a refreshed project receives names anoa, not agent-browser', () => {
+  const root = tmpProject();
+  initProject(root, { force: true });
+  const skill = fs.readFileSync(path.join(root, SKILL), 'utf8');
+  assert.ok(/anoa/.test(skill), 'the core skill should be the anoa one');
+  const visual = path.join(root, '.claude', 'skills', 'library', 'frontend', 'validating-visual-design', 'SKILL.md');
+  const body = fs.readFileSync(visual, 'utf8');
+  assert.ok(!/agent-browser/.test(body), 'the visual-design skill must not still name agent-browser');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
The design-studio agent had no browser at all and was installing Playwright for itself mid-task. Two separate causes, both measured on the sandbox host.

## Why it was broken

**1. The studio container was stale.** `ensureDesignContainer()` only ever *started* a container; it never noticed the image beneath it had moved. The studio container was created before a browser landed in the image, so it kept running without one:

| Container | `agent-browser` |
|---|---|
| `jonggrang-design-studio` | absent |
| `jonggrang-proj_dbdd6a3e8f21` | present |

**2. `agent-browser` never carried a browser.** The image paired `npm i -g agent-browser` with a separate `npx playwright install --with-deps chromium`, and on a bare host the skill told the agent to run `agent-browser install`. The browser was always a second download — and on arm64 it resolved to a *different* browser, because Chrome for Testing publishes no Linux arm64 build.

## What this changes

- **anoa replaces agent-browser** in both Dockerfiles: one self-contained binary with its own Chromium and native x86_64 + aarch64 builds. No npm package, no run-time download.
- **`QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu --no-sandbox"`** is set in the image, mirroring anoa's own container. Our containers run as root so bind-mounted files stay writable, and Chromium refuses to start as root without `--no-sandbox`; setting it here keeps the agent-facing recipe plain `anoa --headless --port 9222`, the same line that works on a laptop.
- **Chromium's system libraries are installed explicitly** (NSS, X11, GL, fonts). They used to arrive as a side effect of `playwright install --with-deps`; without them a clean image starts the browser, answers on CDP and renders nothing.
- **The studio container is recreated when the image drifts**, which is the actual fix for the reported symptom and stands on its own.
- **New `skills/core/anoa`**, plus rewritten `validating-visual-design`, `auditing-interface-quality` and `gateway-frontend`, and the four instruction templates.
- `scripts/anoa-smoke.sh` replaces the agent-browser smoke test; its CI step is bounded at 8 minutes (the old one once sat at 22 against a 4-6 minute norm).

## The skills were rewritten, not renamed

anoa keeps a browser alive between commands where agent-browser was one-shot. A mechanical rename would leave agents running `anoa open` against a browser that was never started — and getting silence. Every skill and template now leads with "start it once", and `anoa status` reports the failure (exit 3). The rewrite also picked up capabilities the old tool did not have: `set media dark|light`, `set device`, and `console` / `errors` / `network`.

## Verification

Built from scratch on the sandbox (amd64), not layered over the existing image — which is how the missing-libraries defect was caught, since a probe layered on the old image passed while a clean build failed.

| Check | Result |
|---|---|
| Clean build from `ubuntu:24.04` | succeeds |
| Image contents | `anoa 0.10.1`; `agent-browser` and Playwright both gone |
| Missing shared libraries (`ldd`) | 0 |
| `scripts/anoa-smoke.sh` | PASS — start/open/get text/snapshot/viewport/screenshot, valid 375×812 PNG |
| Text actually rasterizes | text page 21,243 B vs blank 5,320 B — glyphs, not boxes |
| Studio drift detection | logged `running an older … — recreating`; container replaced, anoa present |
| Agent in the studio container | page loads, `@e1 button "Get started"`, click by ref works, viewport + dark mode + `errors` |
| Agent in a work-mode container | `@e1 textbox Email` / `@e2 button Save`; `fill @e1` really sets the value (read back via `eval`) |
| `npm test` | passes |

## arm64

Verified on real aarch64 hardware (Debian 12), container only: the published `:dev` image runs `anoa 0.10.1` with **zero missing libraries**, and `scripts/anoa-smoke.sh` **passes** — the same start/open/get text/snapshot/viewport/screenshot path as amd64. This is the divergence agent-browser could never close, since Chrome for Testing publishes no Linux arm64 build.

## Two further defects found while testing, both fixed here

Updating the registry tag did **not** reach running project containers, and tracing that turned up two separate faults:

1. **Drift was compared by image NAME.** A container started from `…:dev` keeps reporting `…:dev` after that tag is rebuilt, so a republished image was invisible. Now compared by image **ID**, matching what the design studio already did.
2. **The running-container fast path never reached the check.** `sandbox/start` returned "running" on the strength of the SSH-mount and editor checks alone — and every project container is running by the time anyone asks, so the reconcile block below was unreachable for exactly the case that matters. Measured: the drift helper reported `true` while the route still answered "running" and left three containers on a months-old image.

After both fixes the three project containers recreated on the next start and now run the exact `:dev` image ID, each with anoa 0.10.1.

## Existing projects: `init --force` now refreshes them

`jonggrang init` copied skills only when the destination was missing, so there was no supported way to pick up a changed skill. `--force` now rewrites the jonggrang-managed skills and `.claude/agents` definitions too; without it nothing changes. This matters more than it sounds: a real project on the sandbox carried **neither** the old browser instructions nor the new ones, and its agent duly reached for `jsdom` instead of the browser sitting on its PATH.

## End-to-end, with a real agent

A project initialised from these templates, in a project container running the **registry** image, served a page whose content only exists after JavaScript runs. The agent was asked to report what renders, with no mention of anoa:

> **Heading:** `PROJ-V8R4` — **Button label:** `Deploy Now`

Evidence it was anoa and not something else: `anoa status` afterwards reports `attached 127.0.0.1:9222` pointed at the page, the process list shows `/usr/local/lib/anoa/anoa --headless --port 9222`, a screenshot was left at `/tmp/ui.png`, and `jsdom` was **not** installed — the direct contrast with the run above.

## Image size

An earlier revision of this description claimed the new image was 1.99GB. That was a misread; the real numbers, measured with `docker images` on the same host:

| Image | Size |
|---|---|
| `:0.17.0` — Playwright + agent-browser | 8.4GB |
| `:dev` — anoa | 8.37GB |

The swap is close to size-neutral: 656MB of Playwright Chromium and 88MB of agent-browser come out, 790MB of bundled browser goes in. The image was already this large, and the browser was never the reason — `/root/.rustup` alone was 1.5GB and `node_modules` (four agent CLIs) is 1.2GB.

Since 902MB of that Rust toolchain turned out to be offline HTML documentation, this branch also switches rustup to the minimal profile with clippy and rustfmt added back: **1.5GB to 624MB, 876MB saved**, with cargo, clippy and rustfmt all still working. Removing Rust outright would save a further 624MB but break a stack jonggrang detects and tests, so it was not done.

## Known gaps

- Nothing refreshes a project automatically; picking up changed skills is an explicit `init --force`.
- The image is 1.99GB on amd64 and larger on arm64; dropping Playwright offsets some of what the bundled browser adds, but this is not a small image.
