### PR TITLE
fix(orchestration): re-seed project settings into an existing worktree

### DIFF
--- a/apis/projects/orchestration-run.js
+++ b/apis/projects/orchestration-run.js
@@ -338,6 +338,28 @@ module.exports = function(deps) {
         } catch (err) { console.error('seedFeatureFromMain error:', err.message); }
     }
 
+    // Project settings live in .jonggrang/jonggrang.json and are seeded into a
+    // worktree when it is CREATED — so a worktree outlives every later change to
+    // them. That made project settings silently not apply: switching Claude to
+    // interactive execution, or the pipeline to compact, left an existing plan's
+    // worker running with whatever the worktree was born with. Re-seed the file
+    // on every run so the dashboard stays the source of truth for settings.
+    //
+    // Only this one file: the rest of COPY_INTO_WORKTREE (AGENTS.md, hooks,
+    // .claude, …) is branch content the agent may legitimately have changed, and
+    // re-copying that would clobber its work.
+    function seedProjectConfig(project, ctx, featureId) {
+        const rel = path.join('.jonggrang', 'jonggrang.json');
+        const wt = ctx.wt(featureId);
+        try {
+            if (ctx.mode === 'container') {
+                containerCopy(ctx, [{ src: `${ctx.root}/${rel}`, dst: `${wt}/${rel}` }]);
+            } else {
+                lib.copyToWorktree(project.path, ctx.hostWt(featureId), [rel]);
+            }
+        } catch (err) { console.error('seedProjectConfig error:', err.message); }
+    }
+
     // In-container push using the mounted SSH key (staged to a root-owned 0600 file).
     function containerPush(ctx, branch) {
         return new Promise((resolve, reject) => {
@@ -796,6 +818,9 @@ module.exports = function(deps) {
         // Pull the latest approved/appended task list from main into the worktree
         // so a reused worktree picks up tasks added since it was created.
         seedFeatureFromMain(project, ctx, g.featureId);
+        // …and the current project settings, which a long-lived worktree would
+        // otherwise keep ignoring (see seedProjectConfig).
+        seedProjectConfig(project, ctx, g.featureId);
         const group = {
             featureId: g.featureId, branch: wt.branch, title: g.title, taskIds: g.taskIds,
             status: 'running', worktreePath: wt.worktreePath, hostWorktreePath: wt.hostWorktreePath,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/init-refresh.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/worktree-config-seed.test.js && node test/init-refresh.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1111.0",

--- a/test/worktree-config-seed.test.js
+++ b/test/worktree-config-seed.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// A worktree is seeded with the project's .jonggrang/jonggrang.json when it is
+// CREATED, and used to keep that copy for its whole life. So every later change
+// to project settings silently failed to apply: switching Claude to interactive
+// execution, or the pipeline to compact, left an existing plan's worker running
+// with whatever the worktree was born with. Runs now re-seed the file, which
+// depends on the copy OVERWRITING an existing destination — pinned here.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const lib = require('../lib/jonggrang');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+const REL = path.join('.jonggrang', 'jonggrang.json');
+
+function writeConfig(root, execution) {
+  fs.mkdirSync(path.join(root, '.jonggrang'), { recursive: true });
+  fs.writeFileSync(path.join(root, REL), JSON.stringify({
+    name: 'seed-probe', tool: 'claude', tools: { claude: { execution } },
+  }, null, 2));
+}
+
+function readExecution(root) {
+  const j = JSON.parse(fs.readFileSync(path.join(root, REL), 'utf8'));
+  return j.tools?.claude?.execution;
+}
+
+function pair() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-seed-'));
+  const project = path.join(base, 'project');
+  const worktree = path.join(base, 'worktree');
+  fs.mkdirSync(project, { recursive: true });
+  fs.mkdirSync(worktree, { recursive: true });
+  return { project, worktree };
+}
+
+console.log('\nworktree config seeding — project settings must reach an existing worktree\n');
+
+test('a stale worktree config is overwritten by the project one', () => {
+  const { project, worktree } = pair();
+  writeConfig(project, 'interactive');
+  writeConfig(worktree, 'headless');          // seeded before the setting changed
+
+  lib.copyToWorktree(project, worktree, [REL]);
+
+  assert.strictEqual(readExecution(worktree), 'interactive',
+    'the worktree must pick up the current project setting, not keep its birth copy');
+});
+
+test('a worktree with no config yet receives one', () => {
+  const { project, worktree } = pair();
+  writeConfig(project, 'interactive');
+
+  lib.copyToWorktree(project, worktree, [REL]);
+
+  assert.ok(fs.existsSync(path.join(worktree, REL)), 'the config should be created');
+  assert.strictEqual(readExecution(worktree), 'interactive');
+});
+
+test('a missing project config leaves the worktree untouched rather than erasing it', () => {
+  const { project, worktree } = pair();
+  writeConfig(worktree, 'interactive');       // nothing to copy from the project
+
+  lib.copyToWorktree(project, worktree, [REL]);
+
+  assert.strictEqual(readExecution(worktree), 'interactive',
+    'a project without a config must not blank an existing worktree copy');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Interactive Claude execution was switched on for a project in the dashboard, and the agent kept running headless.

## Cause

Project settings live in `.jonggrang/jonggrang.json`. That file is seeded into a plan's worktree when the worktree is **created** — and a worktree lives much longer than that. `seedFeatureFromMain` re-seeds `.jonggrang/.output/features/<id>` on every run (tasks, manifest) but never the config, so a worker kept using whatever settings the worktree was born with.

Measured on the sandbox host:

| Location | `tools.claude.execution` |
|---|---|
| Project `helo-ops-dashboard` | `interactive` |
| Worktree `settings-page-…` (created after the change) | `interactive` |
| Worktree `helo-ops-dashboard-spa-…` (created a day earlier) | **absent → headless** |

So a run on the older plan silently chose headless while the dashboard said interactive.

**This was never specific to the browser or to interactive mode.** `orchestration.pipeline_mode` (compact), `tool`, `model` and `autonomy` were all being dropped the same way for any plan whose worktree predated the change.

## Fix

`startGroup` now re-seeds `.jonggrang/jonggrang.json` from the project on every run, in both host and container mode, next to the existing feature seeding.

Only that one file. The rest of `COPY_INTO_WORKTREE` — `AGENTS.md`, `hooks`, `.claude`, `.opencode` — is branch content an agent may legitimately have changed on its feature branch, and re-copying it every run would clobber real work.

## Verification

End to end on the sandbox, on the plan whose worktree was stale:

- before the run: worktree config read `(headless default)`
- triggered a run through the API
- after: worktree config read `interactive`

`test/worktree-config-seed.test.js` pins the copy semantics the fix depends on: a stale worktree copy is overwritten, a missing one is created, and a project with no config does **not** blank an existing worktree copy. Full suite passes.

## Note on scope

The fix is one call plus a helper. The reason the diff is worth reading is the comment explaining why exactly one file is re-seeded — that boundary is the whole safety argument.
