### PR TITLE
fix(design): tell the studio agent to validate its design in anoa

### DIFF
--- a/apis/design.js
+++ b/apis/design.js
@@ -36,6 +36,7 @@ html, body { margin: 0; background: var(--ui-canvas, #fff); color: var(--ui-text
 }
 
 module.exports = function register(app, io, _ctx) {
+  const httpServer = _ctx && _ctx.server;
   // Live preview: watch the design store so ANY change — the studio's Save button
   // OR the TUI agent writing files directly (in sandbox mode via the ~/.jonggrang
   // bind mount) — emits `design.changed` and refreshes the open preview. Polling is
@@ -266,6 +267,34 @@ module.exports = function register(app, io, _ctx) {
     designPtys.clear();
   }
 
+  // The studio agent needs a URL it can actually open, which only the running
+  // server knows. Resolved from the live bind address rather than an assumed
+  // port so a dashboard on a custom port still works.
+  //
+  // A container cannot reach the host's loopback, so a sandbox session gets the
+  // docker bridge gateway instead — which is what a sandbox deployment binds to
+  // anyway. When the dashboard is bound to loopback only, nothing inside a
+  // container can reach it; say so in the URL rather than handing the agent an
+  // address that silently times out.
+  const DOCKER_BRIDGE_HOST = '172.17.0.1';
+  function designPreviewUrl(name, sandbox) {
+    let host = '127.0.0.1';
+    let port = 7777;
+    try {
+      const addr = httpServer && httpServer.address();
+      if (addr && typeof addr === 'object') {
+        port = addr.port || port;
+        if (addr.address && addr.address !== '::' && addr.address !== '0.0.0.0') host = addr.address;
+      }
+    } catch { /* fall back to the defaults above */ }
+
+    if (sandbox) {
+      const loopback = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+      host = loopback ? DOCKER_BRIDGE_HOST : host;
+    }
+    return `http://${host}:${port}/api/design/${encodeURIComponent(name)}/preview`;
+  }
+
   function spawnDesign(name, tool, cols, rows, sandbox) {
     // Auto-resume: if this template+tool+mode has been opened before, launch the
     // tool with its resume/continue flag so it continues the prior conversation.
@@ -273,6 +302,15 @@ module.exports = function register(app, io, _ctx) {
     const resume = canResume && hasDesignSession(name, tool, !!sandbox);
     const resolved = resolveToolCommand(tool, resume);
     if (!resolved) throw new Error(`unsupported tool: ${tool}`);
+
+    // A template scaffolded before the brief existed would otherwise leave the
+    // agent with no instructions at all — write it on first open.
+    try {
+      const wrote = design.writeStudioInstructions(path.join(design.designRoot(), name), name);
+      if (wrote) console.log(`[design] wrote studio instructions into template ${name}`);
+    } catch (err) { console.error('[design] could not write studio instructions:', err.message); }
+
+    const previewUrl = designPreviewUrl(name, sandbox);
     const key = `design:${name}`;
     if (designPtys.has(key)) { try { designPtys.get(key).kill(); } catch { /* ignore */ } designPtys.delete(key); }
     const dims = { cols: Math.max(20, cols | 0), rows: Math.max(6, rows | 0) };
@@ -280,12 +318,15 @@ module.exports = function register(app, io, _ctx) {
     if (sandbox) {
       ensureDesignContainer();
       const cwd = `/root/.jonggrang/design/${name}`;
-      proc = pty.spawn('docker', ['exec', '-it', '--workdir', cwd, DESIGN_CONTAINER, resolved.cmd, ...resolved.args],
+      proc = pty.spawn('docker', ['exec', '-it', '--workdir', cwd,
+        '--env', `JONGGRANG_DESIGN_PREVIEW=${previewUrl}`,
+        DESIGN_CONTAINER, resolved.cmd, ...resolved.args],
         { name: 'xterm-256color', ...dims, cwd: os.homedir(), env: { ...process.env, TERM: 'xterm-256color' } });
     } else {
       const dir = path.join(design.designRoot(), name);
       proc = pty.spawn(resolved.cmd, resolved.args,
-        { name: 'xterm-256color', ...dims, cwd: dir, env: { ...process.env, TERM: 'xterm-256color' } });
+        { name: 'xterm-256color', ...dims, cwd: dir,
+          env: { ...process.env, TERM: 'xterm-256color', JONGGRANG_DESIGN_PREVIEW: previewUrl } });
     }
     designPtys.set(key, proc);
     // Record the session so the next open of this template+tool+mode resumes.

--- a/lib/design.js
+++ b/lib/design.js
@@ -180,7 +180,77 @@ function newTemplate(name, opts = {}) {
   fs.writeFileSync(path.join(dir, 'guide-fragment.md'), scaffoldGuide(name), 'utf8');
   fs.writeFileSync(path.join(dir, 'tokens.css.template'), scaffoldTokens(), 'utf8');
   fs.writeFileSync(path.join(dir, '.meta.json'), JSON.stringify({ created_by: 'design new', tool: opts.tool || null }, null, 2), 'utf8');
+  writeStudioInstructions(dir, name);
   return { name, dir };
+}
+
+// The studio drops an agent into a template directory with nothing but design
+// files. Without a brief it does not know what the directory is, that a rendered
+// preview exists, or that a browser is installed — so it reviews the CSS source
+// and calls that a design review, or reaches for whatever library it can find.
+// These two files are that brief. Both names are written because each backend
+// reads a different one.
+// Write the studio brief into a template. Existing templates get it the first
+// time the studio opens them, so a template scaffolded before this existed is
+// not left without instructions. Never overwrites: the brief is meant to be
+// edited per template.
+function writeStudioInstructions(dir, name) {
+  const body = scaffoldStudioInstructions(name);
+  let written = 0;
+  for (const file of ['CLAUDE.md', 'AGENTS.md']) {
+    const dest = path.join(dir, file);
+    if (fs.existsSync(dest)) continue;
+    try { fs.writeFileSync(dest, body, 'utf8'); written++; } catch { /* best effort */ }
+  }
+  return written;
+}
+
+function scaffoldStudioInstructions(name) {
+  return `# Design template: ${name}
+
+You are in a Jonggrang **design template**. The files here are the design itself:
+
+| File | Holds |
+|---|---|
+| \`tokens.css.template\` | the semantic tokens every component must use |
+| \`components/*.html\` | the components, one file each |
+| \`guide-fragment.md\` | the written direction this template carries |
+| \`manifest.yml\` | id, intent, which components exist |
+
+## Look at the rendered design, not just the source
+
+A token file that parses tells you nothing about whether the design works. This
+template renders live, and \`anoa\` — a browser — is already installed here.
+The studio exports the preview URL as **\`$JONGGRANG_DESIGN_PREVIEW\`**.
+
+The browser is a session: start it once, then drive it.
+
+\`\`\`bash
+anoa --headless --port 9222 &          # once; anoa status: exit 3 = not running
+anoa open "$JONGGRANG_DESIGN_PREVIEW"  # the whole template
+anoa screenshot preview.png            # then read the screenshot back
+anoa set media dark                    # dark mode is a design decision, check it
+anoa set viewport 375 812              # and so is narrow
+anoa errors                            # a page can look right and still throw
+\`\`\`
+
+Add \`&component=<id>\` to the URL to render one component on its own.
+
+Run \`anoa skills get core\` for the workflow and \`anoa skills get commands\`
+for every command. If \`anoa\` is not on PATH, install it rather than reaching
+for another tool.
+
+## Judge it on
+
+- **Tokens:** colours, spacing and type come from tokens, never hard-coded values.
+- **Both themes:** light and dark both render, with contrast that holds.
+- **Narrow widths:** nothing overflows or scrolls sideways at 375px.
+- **States:** hover, focus and disabled are visible, not implied.
+- **Consistency:** a new component looks like it belongs to the ones already here.
+
+Change the files, then look again. Saying it looks right without opening the
+preview is the one thing to avoid.
+`;
 }
 
 function scaffoldGuide(name) {
@@ -278,6 +348,8 @@ module.exports = {
   validateTemplate,
   getArtifact,
   newTemplate,
+  scaffoldStudioInstructions,
+  writeStudioInstructions,
   scaffoldTokens,
   promoteFromProject,
   removeTemplate,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/worktree-config-seed.test.js && node test/init-refresh.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/worktree-config-seed.test.js && node test/init-refresh.test.js && node test/design-studio-brief.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1111.0",

--- a/server.js
+++ b/server.js
@@ -55,7 +55,7 @@ const projectsCtx = { JONGGRANG_HOME, webState, orchestration, server };
 const cleanupProjects = require('./apis/projects')(app, io, projectsCtx);
 
 // Global design-template studio API (~/.jonggrang/design)
-const cleanupDesign = require('./apis/design')(app, io, { JONGGRANG_HOME });
+const cleanupDesign = require('./apis/design')(app, io, { JONGGRANG_HOME, server });
 
 // Global object-storage API (S3-compatible uploads: R2, MinIO, custom)
 const cleanupStorage = require('./apis/storage')(app, io, { JONGGRANG_HOME });

--- a/test/design-studio-brief.test.js
+++ b/test/design-studio-brief.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// The studio drops an agent into a template directory. Before this, that
+// directory held design files and nothing else — no brief, no mention of the
+// rendered preview, no mention of the browser sitting on PATH — so the agent
+// reviewed CSS source and called it a design review.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+const store = fs.mkdtempSync(path.join(os.tmpdir(), 'jg-studio-'));
+process.env.JONGGRANG_DESIGN_HOME = store;
+const design = require('../lib/design');
+
+console.log('\ndesign studio brief — the agent must know it can validate visually\n');
+
+test('a new template is scaffolded with the brief for both backends', () => {
+  const { dir } = design.newTemplate('brief-probe', { intent: 'probe', force: true });
+  for (const f of ['CLAUDE.md', 'AGENTS.md']) {
+    assert.ok(fs.existsSync(path.join(dir, f)), `${f} should be scaffolded`);
+  }
+});
+
+test('the brief names anoa, the preview URL and the session step', () => {
+  const body = design.scaffoldStudioInstructions('brief-probe');
+  assert.ok(/anoa --headless --port 9222/.test(body), 'must show how to start the browser once');
+  assert.ok(body.includes('JONGGRANG_DESIGN_PREVIEW'), 'must point at the injected preview URL');
+  assert.ok(/anoa screenshot/.test(body), 'must tell the agent to capture the rendered page');
+  assert.ok(/anoa set media dark/.test(body), 'dark mode is a design decision worth checking');
+  assert.ok(/anoa status/.test(body), 'must explain how a missing browser reports itself');
+});
+
+test('an existing template gets the brief on first open, without clobbering edits', () => {
+  const dir = path.join(store, 'legacy-template');
+  fs.mkdirSync(dir, { recursive: true });
+
+  const wrote = design.writeStudioInstructions(dir, 'legacy-template');
+  assert.strictEqual(wrote, 2, 'both files should be created for a template that had none');
+
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# hand-tuned brief\n');
+  const again = design.writeStudioInstructions(dir, 'legacy-template');
+  assert.strictEqual(again, 0, 'an existing brief must never be overwritten');
+  assert.strictEqual(fs.readFileSync(path.join(dir, 'CLAUDE.md'), 'utf8'), '# hand-tuned brief\n');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## The problem

Open a Jonggrang design studio and the agent gets no instructions of its own. It
styles by reading files and never looks at what it built — so "does this render
at 375px?" is answered from the markup.

The pieces were already there: the agent image ships `anoa`, and every project
skill names it. What was missing is that nothing in the *studio* told the agent a
browser existed, or where the preview was served.

## The fix

- **`lib/design.js`** — `scaffoldStudioInstructions()` writes the studio brief as
  the template's `CLAUDE.md` + `AGENTS.md`: start the anoa session, open
  `$JONGGRANG_DESIGN_PREVIEW`, judge from a screenshot at both widths. It never
  overwrites an existing brief — a hand-edited one belongs to the author.
- **`apis/design.js`** — resolve the preview URL from the live server (with the
  docker-bridge address substituted for sandbox loopback) and inject it as
  `JONGGRANG_DESIGN_PREVIEW` into both studio spawn paths. The brief is written
  when a studio *opens*, so templates created before this change get it too.
- **`server.js`** — pass the http server into the design context so the port is
  known at runtime rather than guessed.

## Verification

`test/design-studio-brief.test.js` (3 tests) covers the brief content, the
never-overwrite rule, and both instruction files landing.

Beyond that: deployed to the sandbox and run with a **real** agent, which started
anoa, opened the preview, and came back with measured rendered findings — three
genuine 375px overflow bugs in template `helo` — instead of markup guesses.

Co-authored-by: jonggrang-dev <koko@jonggrang.dev>
