### PR TITLE
fix(work-loop): stop a plan re-dispatching the same task forever

### DIFF
--- a/apis/projects/orchestration-run.js
+++ b/apis/projects/orchestration-run.js
@@ -43,6 +43,40 @@ const COPY_INTO_WORKTREE = [
     'hooks',
 ];
 
+// Send a control frame down the worker's stdin — how keystrokes reach the pty.
+//
+// ONLY a worker that actually opened a pty reads these frames. A headless worker
+// never reads its stdin, so a frame written there sits in the pipe until
+// something else reads a line from it — and the work loop's test-retry
+// escalation does exactly that (`readline.question`). A stray `pty_resize` from
+// a browser tab then arrives as if a human had typed feedback, which resets the
+// retry counter and re-dispatches the same task forever. So: no live pty, no
+// frames.
+//
+// A resize that arrives before the pty is live is remembered rather than dropped
+// — the browser terminal emits its geometry on mount, which is usually before
+// the agent has printed its first byte, and the TUI needs it to lay out.
+function sendPtyFrame(group, frame) {
+    if (!group) return false;
+    if (!group.ptyLive) {
+        if (frame && frame.type === 'pty_resize') group.pendingResize = frame;
+        return false;
+    }
+    const stdin = group.child && group.child.stdin;
+    if (!stdin || stdin.destroyed) return false;
+    try { stdin.write(`${JSON.stringify(frame)}\n`); return true; } catch { return false; }
+}
+
+// The worker's first pty_data frame is the proof that it runs a pty and is
+// reading control frames back. Flush any geometry the browser sent early.
+function markPtyLive(group) {
+    if (group.ptyLive) return;
+    group.ptyLive = true;
+    const pending = group.pendingResize;
+    group.pendingResize = null;
+    if (pending) sendPtyFrame(group, pending);
+}
+
 module.exports = function(deps) {
     const { fs, webState, io, JONGGRANG_HOME, activeRuns } = deps;
     const router = Router();
@@ -573,13 +607,6 @@ module.exports = function(deps) {
         }
     }
 
-    // Send a control frame down the worker's stdin — how keystrokes reach the pty.
-    function sendPtyFrame(group, frame) {
-        const stdin = group?.child?.stdin;
-        if (!stdin || stdin.destroyed) return false;
-        try { stdin.write(`${JSON.stringify(frame)}\n`); return true; } catch { return false; }
-    }
-
     function groupForSession(projectId, session) {
         const run = activeRuns.get(projectId);
         if (!run || typeof session !== 'string' || !session.startsWith('work:')) return null;
@@ -760,11 +787,13 @@ module.exports = function(deps) {
                 // browser terminal and kept as scrollback for tabs opened later.
                 if (signal && signal.type === 'pty_data' && signal.b64) {
                     const text = Buffer.from(signal.b64, 'base64').toString('utf8');
+                    markPtyLive(group);
                     pushPtyScrollback(group, text);
                     emit(project.id, 'pty.data', { project_id: project.id, session: signal.session, data: text });
                     continue;
                 }
                 if (signal && signal.type === 'pty_exit') {
+                    group.ptyLive = false;
                     emit(project.id, 'pty.exit', { project_id: project.id, session: signal.session, code: signal.code });
                     continue;
                 }
@@ -777,6 +806,7 @@ module.exports = function(deps) {
 
         child.on('close', (code) => {
             group.exitCode = code;
+            group.ptyLive = false;
             group.finishedAt = new Date().toISOString();
             if (group.manifestSync) { clearInterval(group.manifestSync); group.manifestSync = null; }
             // Decision (b): one-time snapshot of the worktree's final progress → main
@@ -1153,3 +1183,8 @@ module.exports = function(deps) {
 
     return router;
 };
+
+// The pty relay policy is the fix for a real defect (frames written into a
+// headless worker's stdin were read by its next readline prompt), so it is
+// unit-tested directly — see test/pty-relay-guard.test.js.
+module.exports.ptyRelay = { sendPtyFrame, markPtyLive };

--- a/apis/projects/sandbox-routes.js
+++ b/apis/projects/sandbox-routes.js
@@ -3,6 +3,8 @@
 const { Router } = require('express');
 const sandbox = require('../../lib/sandbox');
 
+const SERVER_VERSION = require('../../package.json').version;
+
 // Track in-progress starts to avoid duplicate starts
 const startingSet = new Set();
 
@@ -19,7 +21,14 @@ module.exports = function(deps) {
             const running = await sandbox.isRunning(project.id);
             const starting = startingSet.has(project.id);
             const status = starting ? 'starting' : running ? 'running' : 'stopped';
-            res.json({ status, container: sandbox.getContainerName(project.id) });
+            // A container can be long-lived enough to run a jonggrang several
+            // releases behind this server. The work loop's behaviour differs
+            // across those releases, so the mismatch is reported rather than
+            // left to be inferred from a run that misbehaves.
+            const agent = running
+                ? await sandbox.jonggrangVersionStatus(project.id, SERVER_VERSION)
+                : null;
+            res.json({ status, container: sandbox.getContainerName(project.id), agent });
         } catch (err) {
             res.status(500).json({ error: err.message });
         }

--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -305,6 +305,12 @@ function updateTaskMode(tasksFile, taskId, status, worktreeMode = false) {
 }
 
 const TEST_RETRY_LIMIT = 3;
+// How many times human feedback may restart the TEST_RETRY_LIMIT budget for one
+// task. Without a cap, each round resets testAttempt to 0 and runIteration never
+// returns — so work.kill_after_fails (which only counts *returned* failures)
+// can't stop it, and the same task is re-dispatched forever. Observed in the
+// wild: nine identical passes on one task, ~2.3M tokens, zero tasks completed.
+const TEST_FEEDBACK_ROUND_LIMIT = 2;
 
 /**
  * Auto-promote feature lessons → project MEMORY.md at a phase boundary.
@@ -360,8 +366,9 @@ async function runWorkLoop(tasksFile, options) {
   }
 
   let iteration = 0;
-  let consecutiveFails = 0;
-  let lastFailedTask = '';
+  // taskId → how many times it has failed in this run. Per task, not a single
+  // rolling counter: see the failure path below.
+  const failCounts = new Map();
   const killAfter = parseInt(lib.readConfig(CONFIG_FILE, 'work.kill_after_fails', '3'), 10);
 
   while (maxIterations === 0 || iteration < maxIterations) {
@@ -413,27 +420,30 @@ async function runWorkLoop(tasksFile, options) {
     const success = await runIteration(tasksFile, iteration, taskId, MODE, dryRun, worktreeMode);
 
     if (success) {
-      consecutiveFails = 0;
-      lastFailedTask = '';
+      failCounts.delete(taskId);
     } else {
-      if (lastFailedTask === taskId) {
-        consecutiveFails++;
-      } else {
-        consecutiveFails = 1;
-        lastFailedTask = taskId;
-      }
+      // Count failures PER TASK. A single "last failed task" counter is reset by
+      // any other task failing in between, so with two or more failing tasks in
+      // a group it never reaches killAfter and the queue is refilled forever —
+      // the run loops until someone cancels it.
+      const fails = (failCounts.get(taskId) || 0) + 1;
+      failCounts.set(taskId, fails);
 
-      if (consecutiveFails >= killAfter) {
-        logError(`Task ${taskId} failed ${consecutiveFails} times. Marking as blocked.`);
+      // runIteration blocks a task itself when its tests keep failing. Blocked
+      // means "a human has to look at this", so re-queuing it just burns another
+      // agent pass on the same dead end.
+      const status = lib.getTask(tasksFile, taskId)?.status;
+      if (status === 'blocked') {
+        logWarn(`Task ${taskId} is blocked — leaving it for a human instead of re-queuing.`);
+      } else if (fails >= killAfter) {
+        logError(`Task ${taskId} failed ${fails} times. Marking as blocked.`);
         updateTaskMode(tasksFile, taskId, 'blocked', worktreeMode);
-        consecutiveFails = 0;
-        lastFailedTask = '';
       } else if (groupTaskIds.length > 0) {
         // Group/worktree mode never falls back to getNextTask, so a task that
         // got reverted to pending would be dropped from the queue and the run
         // would falsely report "All tasks completed". Re-queue it to retry
         // within this run (bounded by kill_after_fails above).
-        logWarn(`Re-queuing ${taskId} for retry (attempt ${consecutiveFails}/${killAfter}).`);
+        logWarn(`Re-queuing ${taskId} for retry (attempt ${fails}/${killAfter}).`);
         taskQueue.push(taskId);
       }
     }
@@ -483,6 +493,7 @@ async function runIteration(tasksFile, iteration, taskId, mode, dryRun = false, 
   const testCmd = lib.readConfig(CONFIG_FILE, 'testing.command', '');
   let testFeedback = '';    // injected into prompt on retry
   let testAttempt = 0;
+  let feedbackRounds = 0;   // human-feedback restarts of the retry budget
 
   while (true) {
     // Build prompt — inject test failure feedback on retries
@@ -547,21 +558,29 @@ async function runIteration(tasksFile, iteration, taskId, mode, dryRun = false, 
       return false;
     }
 
+    if (feedbackRounds >= TEST_FEEDBACK_ROUND_LIMIT) {
+      logError(`Task ${taskId} marked as blocked — feedback did not make the tests pass after ${TEST_FEEDBACK_ROUND_LIMIT} rounds.`);
+      updateTaskMode(tasksFile, taskId, 'blocked', worktreeMode);
+      return false;
+    }
+
     const userInput = await askUserFeedback(
       'Provide feedback for the agent (or press Enter to mark task blocked): '
     );
 
-    if (!userInput) {
+    if (!userInput || lib.isControlFrame(userInput)) {
+      if (userInput) logWarn('Ignoring a jonggrang control frame read from stdin — that is not human feedback.');
       logError(`Task ${taskId} marked as blocked after ${TEST_RETRY_LIMIT} failed test retries.`);
       updateTaskMode(tasksFile, taskId, 'blocked', worktreeMode);
       return false;
     }
+    feedbackRounds++;
 
     // User gave feedback — inject it and reset counter for another round
     testFeedback = `User feedback: ${userInput}\n\nLast test output:\n${output}`;
     testAttempt = 0;
     lib.updateTaskStatus(tasksFile, taskId, 'pending');
-    logInfo('Retrying with user feedback...');
+    logInfo(`Retrying with user feedback... (round ${feedbackRounds}/${TEST_FEEDBACK_ROUND_LIMIT})`);
   }
 }
 

--- a/client/src/views/ProjectDetailView.vue
+++ b/client/src/views/ProjectDetailView.vue
@@ -69,6 +69,10 @@
           <span class="sbx-status-label">{{ sandboxStatus || 'stopped' }}</span>
         </div>
         <div class="sbx-container-name">{{ containerName }}</div>
+        <div v-if="sandboxAgent?.outdated" class="sbx-stale" :title="`Rebuild the sandbox to run jonggrang ${sandboxAgent.expected}`">
+          <i class="pi pi-exclamation-triangle" />
+          <span>jonggrang {{ sandboxAgent.version }} in container — server runs {{ sandboxAgent.expected }}. Rebuild.</span>
+        </div>
         <div class="sbx-actions">
           <button class="sbx-btn" :disabled="sandboxStatus === 'starting'" @click="restartSandbox" title="Restart">
             <i class="pi pi-refresh" />
@@ -161,6 +165,8 @@ const ws = useWsStore();
 const loading = ref(false);
 const showInit = ref(false);
 const sandboxStatus = ref(null);
+// { version, expected, outdated } for the jonggrang inside the container.
+const sandboxAgent = ref(null);
 const sandboxLogTail = ref('');
 const containerName = computed(() => project.value ? `jonggrang-${id.value}` : '');
 
@@ -337,14 +343,22 @@ onMounted(async () => {
       const res = await fetch(`/api/projects/${id.value}/sandbox/status`);
       const data = await res.json();
       sandboxStatus.value = data.status;
+      sandboxAgent.value = data.agent || null;
       if (data.status === 'stopped') startSandbox();
     }
 
     const socket = ws.socket;
     if (socket) {
-      socket.on('sandbox.status', ({ project_id, status }) => {
+      socket.on('sandbox.status', async ({ project_id, status }) => {
         if (project_id !== id.value) return;
         sandboxStatus.value = status;
+        // A rebuild is the fix for a stale container, so re-ask which jonggrang
+        // it runs — otherwise the warning outlives the problem until a reload.
+        if (status !== 'running') { sandboxAgent.value = null; return; }
+        try {
+          const res = await fetch(`/api/projects/${id.value}/sandbox/status`);
+          sandboxAgent.value = (await res.json()).agent || null;
+        } catch { /* the dot already shows the container state */ }
       });
       socket.on('sandbox.log', ({ project_id, line }) => {
         if (project_id !== id.value) return;
@@ -466,6 +480,11 @@ async function onInitDone() {
 .sbx-container-name {
   font-size: 9px; color: var(--jg-text-faint); font-family: monospace;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  margin-bottom: 8px;
+}
+.sbx-stale {
+  display: flex; align-items: flex-start; gap: 5px;
+  font-size: 9px; line-height: 1.4; color: var(--jg-orange);
   margin-bottom: 8px;
 }
 .sbx-actions { display: flex; gap: 6px; }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -120,7 +120,7 @@ Interactive mode degrades to headless — with a warning, never an error — whe
 |-------|------|---------|-------------|
 | `max_iterations` | number | 0 | Max loop iterations per session (`0` = unlimited — run until all tasks complete) |
 | `retry_limit` | number | 2 | Retries before skipping failed task |
-| `kill_after_fails` | number | 3 | Consecutive fails before BLOCKED exit |
+| `kill_after_fails` | number | 3 | Fails **for that task** before BLOCKED exit (counted per task, so other tasks failing in between do not reset it) |
 | `branch_prefix` | string | `feat/` | Prefix for auto-created branches |
 | `commit_prefix` | string | `feat\|fix\|...` | Allowed conventional commit types |
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -261,10 +261,12 @@ Run testCmd
          attempt 1 → inject test output into prompt → re-run agent
          attempt 2 → inject test output into prompt → re-run agent
          attempt 3 → interactive (TTY)?
-                     ├── yes → show test output + prompt:
+                     ├── yes → 2 feedback rounds already used? → task marked blocked
+                     │         else show test output + prompt:
                      │         "Provide feedback for the agent (or Enter to block): "
                      │         ├── user types feedback → inject feedback + reset counter → loop again
-                     │         └── Enter (empty)       → task marked blocked
+                     │         ├── Enter (empty)       → task marked blocked
+                     │         └── pty control frame   → ignored → task marked blocked
                      └── no (piped stdin: web/sandbox/CI) → task marked blocked, move on
 ```
 
@@ -273,6 +275,9 @@ Run testCmd
 - **Max auto-retries: 3** — the agent gets 3 attempts to fix failing tests without human intervention. Configurable via `TEST_RETRY_LIMIT` constant.
 - **Feedback injection** — on each retry, the full test output (capped at 4000 chars, tail-end preserved) is injected into the prompt under a `## Test Failure Feedback` section with the raw output in a code block. The prompt asks the agent to fix *whichever side is wrong* — the implementation, or an outdated test case — not to blindly edit the easier one.
 - **Human escalation (interactive only)** — after 3 failures **on a TTY**, the test output is displayed and the user is prompted. User feedback is combined with the last test output and injected into the next prompt. The retry counter resets, giving the agent another 3 attempts.
+- **Feedback rounds are capped at 2** (`TEST_FEEDBACK_ROUND_LIMIT`). Each accepted feedback resets the retry counter, and `runIteration` does not return while it loops — so `work.kill_after_fails`, which only counts failures the loop *returns*, cannot bound it. Without the cap one task can be re-dispatched indefinitely; a real run spent nine identical passes and ~2.3M tokens on a single task, finishing with every task still `pending`. After the second round the task is marked `blocked`.
+- **A task the loop has already blocked is not re-queued.** In group/worktree mode a failed task is pushed back onto the queue, bounded by `work.kill_after_fails` — which is counted **per task**. A single rolling "last failed task" counter was reset by any other task failing in between, so with two or more failing tasks in a plan the bound was never reached and the queue refilled forever (measured: 17 iterations and climbing on a two-task plan, every iteration a fresh agent). A task that `runIteration` marked `blocked` needs a human, so it is left alone and the run ends.
+- **A pty control frame is not feedback** — the dashboard writes `pty_resize`/`pty_input` JSON frames into a worker's stdin so keystrokes can reach an interactive agent. A *headless* worker never reads its stdin, so those frames queue in the pipe and the escalation's `readline` prompt would read one as the human's answer. Frames are now only sent to a worker with a live pty, and the worker rejects anything shaped like a control frame.
 - **Non-interactive escalation** — when stdin is **not** a TTY (web dashboard, `docker exec -i`, CI — the worker is spawned with piped stdio), there is no human to prompt, so after 3 failures the task is marked `blocked` immediately and the work loop moves on. This avoids hanging the worker on a `readline` prompt that can never be answered.
 - **Blocked exit** — if the user presses Enter without typing feedback (interactive), the task is marked `blocked` and the work loop moves to the next task.
 - **No test command** — if `testing.command` is not configured (empty string), the test step is skipped entirely and the task completes immediately after the agent finishes.

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -805,6 +805,24 @@ function buildBaseBranchContext(branchToUse) {
   Do NOT fallback to reading current local files directly if the base branch differs, as they may contain uncommitted or unrelated changes.`;
 }
 
+/**
+ * True for a line the host wrote to a worker's stdin for the pty bridge — not
+ * something a human typed. The dashboard sends these whenever a browser tab has
+ * a plan's terminal open; a headless worker never reads its stdin, so the frames
+ * queue in the pipe and the next `readline.question` swallows one as if it were
+ * the answer. Callers that prompt a human must treat this as "no input".
+ */
+function isControlFrame(line) {
+  const s = String(line == null ? '' : line).trim();
+  if (!s.startsWith('{') || !s.endsWith('}')) return false;
+  try {
+    const t = JSON.parse(s).type;
+    return typeof t === 'string' && (t.startsWith('pty_') || t === 'task_status');
+  } catch {
+    return false;
+  }
+}
+
 function buildWorkPrompt(taskId, tasksFile, mode, testFeedback) {
   const task = getTask(tasksFile, taskId);
   if (!task) return '';
@@ -3944,6 +3962,7 @@ module.exports = {
   buildDeepPlanAnalysisPrompt,
   buildDeepPlanCondensePrompt,
   buildWorkPrompt,
+  isControlFrame,
   buildPlanPrompt,
   buildReviewPrompt,
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -419,6 +419,53 @@ async function containerImageDrifted(projectId, image) {
     return running !== current;
 }
 
+/**
+ * The jonggrang version the container actually runs, or null if it can't be
+ * asked (container down, docker missing). Image drift is detected by ID, but a
+ * container started long ago from a since-rebuilt tag can also simply be *old*
+ * — and the work loop's behaviour differs across versions, so the mismatch has
+ * to be visible rather than inferred from a log that reads oddly.
+ */
+function containerJonggrangVersion(projectId) {
+    return new Promise((resolve) => {
+        const proc = spawn('docker', ['exec', getContainerName(projectId), 'jonggrang', '--version']);
+        let out = '';
+        proc.stdout.on('data', d => { out += d.toString(); });
+        proc.stderr.on('data', () => {});
+        proc.on('error', () => resolve(null));
+        proc.on('close', (code) => {
+            if (code !== 0) return resolve(null);
+            const m = out.match(/(\d+\.\d+\.\d+)/);
+            resolve(m ? m[1] : null);
+        });
+    });
+}
+
+/** Negative when a < b, 0 when equal, positive when a > b. */
+function compareVersions(a, b) {
+    const pa = String(a).split('.').map(Number);
+    const pb = String(b).split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+        const d = (pa[i] || 0) - (pb[i] || 0);
+        if (d) return d;
+    }
+    return 0;
+}
+
+/**
+ * { version, expected, outdated } for the container's jonggrang, or null when
+ * the container cannot be asked. `outdated` is strictly older — a container
+ * ahead of the host (dev image) is not a problem to report.
+ */
+function versionStatus(version, expected) {
+    if (!version) return null;
+    return { version, expected, outdated: compareVersions(version, expected) < 0 };
+}
+
+async function jonggrangVersionStatus(projectId, expected) {
+    return versionStatus(await containerJonggrangVersion(projectId), expected);
+}
+
 function remove(projectId) {
     return new Promise((resolve) => {
         const proc = spawn('docker', ['rm', '-f', getContainerName(projectId)]);
@@ -514,6 +561,7 @@ function editorMappingDrifted(project) {
 module.exports = {
     getContainerName, getContainerPath,
     sshMountDrifted, editorMappingDrifted, containerImageDrifted,
+    containerJonggrangVersion, jonggrangVersionStatus, versionStatus, compareVersions,
     resolveProjectSshKey, projectSshKeyPath, sshKeyStatus,
     writeProjectSshKey, removeProjectSshKey,
     globalSshKeyPath, globalSshKeyStatus, writeGlobalSshKey, removeGlobalSshKey,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "check": "bash scripts/check.sh",
     "check:quick": "bash scripts/check.sh --quick",
     "check:syntax": "bash scripts/check.sh --syntax-only",
-    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/worktree-config-seed.test.js && node test/init-refresh.test.js && node test/design-studio-brief.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
+    "test": "node test/backend-args.test.js && node test/claude-interactive.test.js && node test/compact-mode.test.js && node test/orchestration-output-files.test.js && node test/codemap.test.js && node test/base-branch.test.js && node test/src-flag.test.js && node test/legacy-watchers.test.js && node test/draft-placement.test.js && node test/project-drafts-api.test.js && node test/task-numbering.test.js && node test/ui-context.test.js && node test/worktree-config-seed.test.js && node test/pty-relay-guard.test.js && node test/init-refresh.test.js && node test/design-studio-brief.test.js && node test/design.test.js && node test/design-store-path.test.js && node test/design-plan-integration.test.js && node test/design-api.test.js && node test/memory.test.js && node test/memory-cli.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1111.0",

--- a/test/pty-relay-guard.test.js
+++ b/test/pty-relay-guard.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// A run that burned nine identical passes on one task, ~2.3M tokens, and
+// finished with all 16 tasks still `pending`.
+//
+// What happened: the dashboard writes `pty_resize`/`pty_input` JSON frames into
+// the worker's stdin whenever a browser tab has that plan's terminal open. A
+// HEADLESS worker never reads its stdin, so the frames queued in the pipe — until
+// the work loop's test-retry escalation called `readline.question` and swallowed
+// one as if a human had typed feedback. Non-empty "feedback" resets testAttempt
+// to 0, so the same task was re-dispatched forever, and work.kill_after_fails
+// couldn't stop it (it only counts failures runIteration actually returns).
+//
+// Four guards, one per layer:
+//   1. don't write frames to a worker with no live pty  (server)
+//   2. don't accept a control frame as human feedback   (worker)
+//   3. cap how many times feedback may restart the budget (worker)
+//   4. count failures per task, and never re-queue a blocked one (work loop)
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const { ptyRelay } = require('../apis/projects/orchestration-run');
+const { sendPtyFrame, markPtyLive } = ptyRelay;
+const lib = require('../lib/jonggrang');
+const sandbox = require('../lib/sandbox');
+
+// A group whose child records everything written to stdin.
+function fakeGroup(extra = {}) {
+  const written = [];
+  return {
+    written,
+    child: { stdin: { destroyed: false, write: (s) => { written.push(s); return true; } } },
+    ...extra,
+  };
+}
+
+// ── 1. the server side ────────────────────────────────────────────
+
+test('a headless worker gets no frames on stdin', () => {
+  const g = fakeGroup();                        // no ptyLive
+  assert.equal(sendPtyFrame(g, { type: 'pty_input', b64: 'aGk=' }), false);
+  assert.equal(sendPtyFrame(g, { type: 'pty_resize', cols: 120, rows: 40 }), false);
+  assert.deepEqual(g.written, [], 'nothing may reach a stdin nobody is reading');
+});
+
+test('a live pty gets its frames', () => {
+  const g = fakeGroup({ ptyLive: true });
+  assert.equal(sendPtyFrame(g, { type: 'pty_input', b64: 'aGk=' }), true);
+  assert.equal(g.written.length, 1);
+  assert.deepEqual(JSON.parse(g.written[0]), { type: 'pty_input', b64: 'aGk=' });
+  assert.ok(g.written[0].endsWith('\n'), 'frames are newline-delimited');
+});
+
+test('geometry sent before the pty is live is delivered once it is', () => {
+  const g = fakeGroup();
+  sendPtyFrame(g, { type: 'pty_resize', cols: 120, rows: 40 });
+  assert.deepEqual(g.written, [], 'held, not written');
+
+  markPtyLive(g);                               // first pty_data from the worker
+  assert.equal(g.written.length, 1, 'the held geometry is flushed');
+  assert.deepEqual(JSON.parse(g.written[0]), { type: 'pty_resize', cols: 120, rows: 40 });
+  assert.equal(g.pendingResize, null, 'and not flushed twice');
+});
+
+test('only the latest early geometry is kept, and keystrokes are dropped', () => {
+  const g = fakeGroup();
+  sendPtyFrame(g, { type: 'pty_resize', cols: 80, rows: 24 });
+  sendPtyFrame(g, { type: 'pty_resize', cols: 120, rows: 40 });
+  sendPtyFrame(g, { type: 'pty_input', b64: 'aGk=' });
+  markPtyLive(g);
+  assert.equal(g.written.length, 1, 'one resize, no buffered keystrokes');
+  assert.equal(JSON.parse(g.written[0]).cols, 120);
+});
+
+test('markPtyLive on an already-live group is a no-op', () => {
+  const g = fakeGroup({ ptyLive: true });
+  markPtyLive(g);
+  assert.deepEqual(g.written, []);
+});
+
+test('a destroyed stdin is not written to', () => {
+  const g = fakeGroup({ ptyLive: true });
+  g.child.stdin.destroyed = true;
+  assert.equal(sendPtyFrame(g, { type: 'pty_input', b64: 'aGk=' }), false);
+  assert.deepEqual(g.written, []);
+});
+
+// ── 2. the worker side ────────────────────────────────────────────
+
+test('control frames are not human feedback', () => {
+  assert.equal(lib.isControlFrame('{"type":"pty_resize","cols":120,"rows":40}'), true);
+  assert.equal(lib.isControlFrame('{"type":"pty_input","b64":"aGk="}'), true);
+  assert.equal(lib.isControlFrame('{"type":"task_status","taskId":"task-001"}'), true);
+  assert.equal(lib.isControlFrame('  {"type":"pty_exit","code":0}  '), true, 'whitespace tolerated');
+});
+
+test('real feedback is not mistaken for a control frame', () => {
+  assert.equal(lib.isControlFrame('scope the gate to --project shared'), false);
+  assert.equal(lib.isControlFrame(''), false);
+  assert.equal(lib.isControlFrame(null), false);
+  assert.equal(lib.isControlFrame('{ not json'), false);
+  assert.equal(lib.isControlFrame('{"type":"advice","text":"fix the test"}'), false,
+    'a JSON object that is not one of our frames is left alone');
+});
+
+// The escalation loop resets testAttempt to 0 on every accepted feedback, so the
+// only thing standing between it and an unbounded re-dispatch is this cap.
+test('the feedback round cap is wired into the escalation', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'jonggrang.js'), 'utf8');
+  assert.match(src, /const TEST_FEEDBACK_ROUND_LIMIT = \d+;/, 'a cap is declared');
+  assert.match(src, /feedbackRounds >= TEST_FEEDBACK_ROUND_LIMIT/, 'the cap is checked');
+  assert.match(src, /feedbackRounds\+\+/, 'and rounds are counted');
+  assert.match(src, /lib\.isControlFrame\(userInput\)/, 'and control frames rejected');
+});
+
+// Found by the e2e run, not by reading the code: with the escalation fixed, the
+// run STILL looped. runWorkLoop tracked a single "last failed task", so two
+// failing tasks reset each other's counter and killAfter was never reached —
+// and a task runIteration had already marked `blocked` was re-queued anyway.
+// 17 iterations and climbing on a two-task plan.
+test('the work loop counts failures per task and does not re-queue a blocked one', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'jonggrang.js'), 'utf8');
+  assert.match(src, /const failCounts = new Map\(\)/, 'failures are counted per task');
+  assert.doesNotMatch(src, /lastFailedTask/, 'the single rolling counter is gone');
+  assert.match(src, /if \(status === 'blocked'\)/, 'a blocked task is recognised');
+  assert.match(src, /leaving it for a human instead of re-queuing/, 'and not re-queued');
+});
+
+// ── 3. the stale-container warning ────────────────────────────────
+
+test('an older jonggrang in the container reads as outdated', () => {
+  assert.deepEqual(sandbox.versionStatus('0.16.0', '0.19.1'),
+    { version: '0.16.0', expected: '0.19.1', outdated: true });
+});
+
+test('same or newer is not reported', () => {
+  assert.equal(sandbox.versionStatus('0.19.1', '0.19.1').outdated, false);
+  assert.equal(sandbox.versionStatus('0.20.0', '0.19.1').outdated, false,
+    'a dev image ahead of the server is not a problem to report');
+});
+
+test('an unknown container version reports nothing rather than guessing', () => {
+  assert.equal(sandbox.versionStatus(null, '0.19.1'), null);
+});
+
+test('version comparison is numeric, not lexical', () => {
+  assert.ok(sandbox.compareVersions('0.9.0', '0.10.0') < 0, '0.9.0 < 0.10.0');
+  assert.ok(sandbox.compareVersions('1.2.3', '1.2.3') === 0);
+  assert.ok(sandbox.compareVersions('0.19.10', '0.19.9') > 0);
+});


### PR DESCRIPTION
## What happened

A web run spent **nine identical passes on one task, ~2.3M tokens**, and finished
with all 16 tasks still `pending`. Four defects stacked, each on a different
layer — and the top one hid the rest.

**1. The dashboard poisoned the worker's stdin.** The server writes
`pty_resize` / `pty_input` JSON frames into a worker's stdin so keystrokes can
reach an interactive agent. A *headless* worker never reads its stdin, so those
frames queued in the pipe — until the test-retry escalation called
`readline.question` and read one as if a human had typed feedback. Non-empty
"feedback" resets the retry budget, so the same task was re-dispatched forever.

**2. The worker accepted it as feedback.** Nothing checked whether the line was
one of our own control frames.

**3. Nothing bounded the escalation.** Each accepted feedback sets
`testAttempt = 0`, and `runIteration` does not return while it loops — so
`work.kill_after_fails`, which only counts failures the loop *returns*, could
never bound it.

**4. Found by the e2e run, not by reading the code.** With the escalation fixed,
the run **still** looped: `runWorkLoop` tracked a single "last failed task", so
two failing tasks reset each other's counter and `kill_after_fails` was never
reached — and a task `runIteration` had already marked `blocked` was re-queued
anyway. Measured at 17 iterations and climbing on a two-task plan.

Underneath it all: the container ran **jonggrang 0.16.0** against a 0.19.x
server, which is why the non-interactive escalation guard (added in v0.17.0) was
missing entirely.

## The fix, per layer

| Layer | Change |
|---|---|
| Server | `sendPtyFrame` requires a live pty (`group.ptyLive`, set by the worker's first `pty_data`). Geometry that arrives before that is held and flushed, so the TUI still lays out. |
| Worker | `lib.isControlFrame()` — a `pty_*` / `task_status` line is not human feedback; the task is blocked instead. |
| Worker | `TEST_FEEDBACK_ROUND_LIMIT = 2` caps how many times feedback may restart the retry budget. |
| Work loop | Failures counted **per task** (`failCounts`), and a task already marked `blocked` is left for a human instead of re-queued. |
| Visibility | `GET /sandbox/status` reports the container's own jonggrang version; the panel warns to rebuild when it is older than the server. |

## Verification

`test/pty-relay-guard.test.js` — 14 tests across all four layers. Full suite green.

**Measured end-to-end** on a real dashboard + real worker, with an
instrumented `strace` on the server so every write to a worker's stdin is on
record (an earlier `/proc/<pid>/fd/0` probe turned out not to read pipes at all,
so its zeros were discarded):

| scenario | frames written to worker stdin | run outcome |
|---|---|---|
| headless, pristine 0.19.0 from npm | **2** (`pty_resize` 43B, `pty_input` 50B) | looping — 78 agent spawns before cancel |
| headless, this branch | **0** | `completed`, exit 0, 2 iterations, 6 spawns |
| interactive (live pty), this branch | **2**, delivered | `got:[E2E-LEAK-PROBE] geom=45x123` |

That last row matters: geometry went 40x120 → 45x123 and the typed text reached
the TUI, so the gate does not break interactive mode or the early-resize flush.

**The original failure, reproduced.** A work loop whose stdin is a real TTY, with
one `pty_resize` frame arriving at the escalation prompt:

- old bin → `Retrying with user feedback` ×1, budget reset, 6 spawns, a *second*
  escalation prompt, still running at the 60s cutoff.
- this branch → control frame rejected, task `blocked`, **worker exits**, 3 spawns.

**Stale-container warning** against a real container reporting 0.16.0:
`agent:{version:"0.16.0",expected:"0.19.1",outdated:true}`, and the sandbox panel
shows "jonggrang 0.16.0 in container — server runs 0.19.1. Rebuild."

## Not in scope

A whole-repo suite used as the *per-task* gate is unsatisfiable for a migration
task that deliberately breaks references its later tasks will fix. This PR makes
the run stop and block the task rather than burn tokens forever; scoping that
gate is a project-config decision.

Co-authored-by: jonggrang-dev <koko@jonggrang.dev>
