### PR TITLE
fix(release): publish to npm from the tag, then pin the image to it

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,9 +112,15 @@ jobs:
 
       - run: npm test
 
+      # Trusted publishing: npm authenticates via the job's OIDC token, so there
+      # is no NPM_TOKEN to store or rotate. It needs npm >= 11.5.1, and Node 22
+      # still ships npm 10.x — hence the upgrade. The publisher is configured on
+      # npmjs.com against this repo and this workflow FILENAME, so renaming this
+      # file breaks publishing until the setting is updated to match.
+      - name: Upgrade npm (OIDC publishing support)
+        run: npm install -g npm@latest
+
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VER="$(node -p "require('./package.json').version")"
           # Idempotent: re-running a release workflow must not fail on E409.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Build & Push Docker Images
 # Builds the Jonggrang images for GitHub Container Registry, selected by event:
 #   PR update     -> jonggrang-agent:dev only
 #   merge to main -> jonggrang-agent:latest + jonggrang-tunnel:latest
-#   tag vX.Y.Z    -> agent + tunnel :X.Y.Z, :X.Y, :latest
-#   manual run    -> all images
+#   tag vX.Y.Z    -> npm publish FIRST, then agent + tunnel :X.Y.Z, :X.Y, :latest
+#   manual run    -> all images (pass `version` to re-publish an existing X.Y.Z)
 # Auth uses the built-in GITHUB_TOKEN — no extra secrets needed.
 
 on:
@@ -13,6 +13,11 @@ on:
     tags: ['v*']
   pull_request:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Re-publish the images for this already-published jonggrang version (e.g. 0.19.2). Empty = build :latest from npm latest.'
+        required: false
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -20,8 +25,11 @@ env:
 
 jobs:
   # PR commits (and manual runs) build & push the dev image only.
+  # A manual run that names a version is a release-image repair, not a dev build.
   dev:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'pull_request'
+      || (github.event_name == 'workflow_dispatch' && inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,12 +72,67 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/jonggrang-agent:dev-${{ github.sha }}
         run: bash scripts/anoa-smoke.sh "$IMAGE"
 
+  # A release tag publishes to npm BEFORE any image is built.
+  #
+  # The agent image installs jonggrang from npm, and the release ritual pushed
+  # the tag first and published by hand afterwards — so the image was built
+  # against whatever npm still served. jonggrang-agent:0.19.2 shipped 0.19.1,
+  # and every project running it was a release behind its dashboard, missing
+  # guards the server assumed were there. One publisher, one order, no race.
+  npm-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write          # npm provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Tag must match package.json
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "tag v$TAG does not match package.json $PKG — refusing to publish" >&2
+            exit 1
+          fi
+          echo "releasing $PKG"
+
+      - run: npm ci
+
+      # client/dist is in the published `files` list but is gitignored, so it has
+      # to be built here or the package ships a dashboard with no assets.
+      - run: npm run build
+
+      - run: npm test
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VER="$(node -p "require('./package.json').version")"
+          # Idempotent: re-running a release workflow must not fail on E409.
+          if npm view "jonggrang@$VER" version >/dev/null 2>&1; then
+            echo "jonggrang@$VER is already on npm — nothing to publish"
+          else
+            npm publish --provenance --access public
+          fi
+
   # Pushes to main and release tags build & push latest + tunnel (multi-arch).
   # On a release tag (vX.Y.Z) the images are also tagged X.Y.Z and X.Y.
   publish:
+    needs: [npm-release]
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
+      always()
+      && (needs.npm-release.result == 'success' || needs.npm-release.result == 'skipped')
+      && (github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -92,16 +155,28 @@ jobs:
 
       - name: Resolve release version
         id: ver
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # Version tags only on a release tag push (vX.Y.Z).
+          # A version comes from a release tag push, or from the manual `version`
+          # input — the way to repair images built before their npm version
+          # existed, without inventing a release.
+          VERSION=""
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+          elif [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="${INPUT_VERSION#v}"
+          fi
+          if [[ -n "$VERSION" ]]; then
             echo "is_release=true"      >> "$GITHUB_OUTPUT"
             echo "version=$VERSION"     >> "$GITHUB_OUTPUT"
             echo "minor=${VERSION%.*}"  >> "$GITHUB_OUTPUT"   # 1.2.3 -> 1.2
+            # Pinned, so the tag cannot outrun the package it claims to contain.
+            echo "npm_version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Release build: $VERSION"
           else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "is_release=false"   >> "$GITHUB_OUTPUT"
+            echo "npm_version=latest" >> "$GITHUB_OUTPUT"
             echo "Build: ${{ matrix.image }}:latest"
           fi
 
@@ -130,5 +205,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ matrix.image }}:latest
             ${{ steps.ver.outputs.is_release == 'true' && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.NAMESPACE, matrix.image, steps.ver.outputs.version) || '' }}
             ${{ steps.ver.outputs.is_release == 'true' && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.NAMESPACE, matrix.image, steps.ver.outputs.minor) || '' }}
+          build-args: |
+            JONGGRANG_VERSION=${{ steps.ver.outputs.npm_version }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN_OUT ?= dist/jonggrang
 
 .PHONY: install build build-binary version-major version-minor version-patch \
         release-major release-minor release-patch release publish \
-        publish-major publish-minor publish-patch
+        publish-major publish-minor publish-patch _git-tag-and-push _released
 
 install:
 	npm install
@@ -36,18 +36,22 @@ release-patch: version-patch build
 release:
 	$(MAKE) release-$(BUMP)
 
-# Bump version, build, commit, tag, and publish to npm
+# Bump version, build, commit, and push the tag. The tag is what releases:
+# .github/workflows/docker.yml publishes to npm and THEN builds the images from
+# that published version. Publishing here as well would race that job — the
+# image would be built against whichever publisher won, which is how
+# jonggrang-agent:0.19.2 ended up containing 0.19.1.
 publish-patch: version-patch build
 	$(MAKE) _git-tag-and-push
-	npm publish
+	$(MAKE) _released
 
 publish-minor: version-minor build
 	$(MAKE) _git-tag-and-push
-	npm publish
+	$(MAKE) _released
 
 publish-major: version-major build
 	$(MAKE) _git-tag-and-push
-	npm publish
+	$(MAKE) _released
 
 publish:
 	$(MAKE) publish-$(BUMP)
@@ -60,6 +64,14 @@ _git-tag-and-push:
 	git tag v$(VERSION)
 	git push origin HEAD
 	git push origin v$(VERSION)
+
+# Internal: the tag is pushed; CI does the rest.
+_released:
+	$(eval VERSION := $(shell node -p "require('./package.json').version"))
+	@echo ""
+	@echo "Tag v$(VERSION) pushed. CI now publishes jonggrang@$(VERSION) to npm,"
+	@echo "then builds jonggrang-agent:$(VERSION) pinned to it. Watch it with:"
+	@echo "  gh run watch \$$(gh run list --limit 1 --json databaseId -q '.[0].databaseId')"
 
 build-binary:
 	mkdir -p $(dir $(BIN_OUT))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,11 +46,30 @@ RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-to
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ── AI tools + jonggrang ─────────────────────────────────────────────────────
+# The tag on this image and the jonggrang inside it must be the same version.
+# Unpinned, `npm install -g jonggrang` takes whatever the registry serves at
+# build time, so an image built before its release was published shipped the
+# PREVIOUS version under the new tag — jonggrang-agent:0.19.2 contained 0.19.1.
+# A project then ran a CLI a release behind its dashboard, missing guards the
+# server assumed were there, and nothing said so.
+#
+# The release workflow now publishes to npm before building, and pins that
+# version here. The check turns a registry that served something else into a
+# failed build instead of a lying tag. `latest` (the default) means "whatever npm
+# calls latest" and skips the check — that is what non-release builds want.
+ARG JONGGRANG_VERSION=latest
 RUN npm install -g --no-fund --no-audit \
-    jonggrang \
+    jonggrang@${JONGGRANG_VERSION} \
     @anthropic-ai/claude-code \
     opencode-ai \
-    @openai/codex
+    @openai/codex \
+ && INSTALLED="$(jonggrang --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" \
+ && if [ -z "$INSTALLED" ]; then echo "jonggrang did not report a version" >&2; exit 1; fi \
+ && if [ "$JONGGRANG_VERSION" != "latest" ] && [ "$INSTALLED" != "$JONGGRANG_VERSION" ]; then \
+      echo "REFUSING: image asks for jonggrang $JONGGRANG_VERSION, npm served $INSTALLED" >&2; \
+      exit 1; \
+    fi \
+ && echo "jonggrang $INSTALLED"
 
 # ── anoa (the browser every agent drives) ─────────────────────────────────────
 # anoa ships as ONE self-contained binary with its own Chromium — no npm package

--- a/docs/QUICKSETUP.md
+++ b/docs/QUICKSETUP.md
@@ -158,32 +158,32 @@ The pin now fails that build instead of publishing a tag that lies.
 
 ### One-time setup
 
-**1. npmjs.com** — Account → *Access Tokens* → **Generate New Token**:
+Publishing uses npm **trusted publishing** (OIDC): npm trusts a named workflow in
+a named repository, so there is no token stored anywhere and nothing to rotate.
 
-- **Granular Access Token** (preferred): expiration up to 1 year, *Packages and
-  scopes* → select `jonggrang`, permission **Read and write**.
-- or **Classic Token** → type **Automation**. Automation tokens are the ones
-  exempt from the 2FA prompt, which a CI run cannot answer. A classic *Publish*
-  token still asks for an OTP and will fail the job.
+On npmjs.com → package `jonggrang` → *Settings* → **Trusted publisher**:
 
-Nothing else on npm needs changing: `jonggrang` is already public and owned by
-`anak10thn` + `ans4175`, so a token from either account has publish rights.
+| Field | Value |
+|---|---|
+| Organization or user | `porcupine-md` |
+| Repository | `jonggrang` |
+| Workflow filename | `docker.yml` |
+| Environment | *(leave empty)* |
 
-**2. GitHub** — repo → Settings → *Secrets and variables* → **Actions** → *New
-repository secret*, name it exactly `NPM_TOKEN`. Or from a terminal:
+That is the whole npm-side setup — `jonggrang` is already public and owned by
+`anak10thn` + `ans4175`, and no GitHub secret is involved.
 
-```bash
-gh secret set NPM_TOKEN            # paste the token when prompted
-```
+Two things this couples to the filename and the job:
 
-Without it `npm-release` fails and no image is built — deliberately, since an
-image pinned to an unpublished version cannot be built anyway.
+- **Renaming `.github/workflows/docker.yml` breaks publishing** until the trusted
+  publisher setting is updated to the new name. Same for moving the
+  `npm-release` job into another file.
+- The job needs **npm >= 11.5.1** for OIDC, and Node 22 still ships npm 10.x, so
+  it upgrades npm before publishing.
 
-**Provenance.** The publish runs with `--provenance`, which needs three things
-that are now in place: `id-token: write` on the job, a public repository, and a
-`repository` field in `package.json` pointing at it. Provenance is what makes the
-npm page show the commit and workflow the tarball was built from — remove the
-flag rather than let it fail if any of those ever stops being true.
+**Provenance.** `--provenance` needs `id-token: write` on the job, a public
+repository, and a `repository` field in `package.json` — all three are in place.
+It is what makes the npm page show the commit and workflow a tarball came from.
 
 **Repairing a mis-tagged image** (built before its npm version existed) — run the
 workflow manually with the version, no new release needed:

--- a/docs/QUICKSETUP.md
+++ b/docs/QUICKSETUP.md
@@ -131,9 +131,41 @@ make build-binary BIN_OUT=out/jonggrang-darwin
 ## Release Workflow
 
 ```bash
-make release                # patch bump + build
+make release                # patch bump + build, no tag (local check)
 make release BUMP=minor
 make release-major
+
+make publish                # patch bump + build + commit + push tag  → CI releases
+make publish BUMP=minor
+```
+
+**The tag is the release.** Pushing `vX.Y.Z` runs `.github/workflows/docker.yml`,
+which does two things in this order:
+
+1. `npm-release` — verifies the tag matches `package.json`, builds `client/dist`
+   (gitignored, but in the published `files`), runs the test suite, and publishes
+   `jonggrang@X.Y.Z` to npm. Re-running is safe: an already-published version is
+   skipped, not failed.
+2. `publish` — builds `jonggrang-agent` and `jonggrang-tunnel` for amd64 + arm64,
+   **pinned** to `jonggrang@X.Y.Z` via the `JONGGRANG_VERSION` build arg, and
+   tags them `X.Y.Z`, `X.Y` and `latest`.
+
+Nothing publishes to npm by hand. Two publishers race, and the loser is the
+image: the tag was pushed first and npm published afterwards, so
+`jonggrang-agent:0.19.2` was built while npm still served 0.19.1 and shipped it
+under the new tag. Projects then ran a CLI a release behind their dashboard.
+The pin now fails that build instead of publishing a tag that lies.
+
+**Requires** a repository secret `NPM_TOKEN` (an npm automation token with
+publish rights on `jonggrang`). Without it the `npm-release` job fails and no
+image is built — deliberately, since an image pinned to an unpublished version
+cannot be built anyway.
+
+**Repairing a mis-tagged image** (built before its npm version existed) — run the
+workflow manually with the version, no new release needed:
+
+```bash
+gh workflow run docker.yml -f version=0.19.2
 ```
 
 ---

--- a/docs/QUICKSETUP.md
+++ b/docs/QUICKSETUP.md
@@ -156,10 +156,34 @@ image: the tag was pushed first and npm published afterwards, so
 under the new tag. Projects then ran a CLI a release behind their dashboard.
 The pin now fails that build instead of publishing a tag that lies.
 
-**Requires** a repository secret `NPM_TOKEN` (an npm automation token with
-publish rights on `jonggrang`). Without it the `npm-release` job fails and no
-image is built — deliberately, since an image pinned to an unpublished version
-cannot be built anyway.
+### One-time setup
+
+**1. npmjs.com** — Account → *Access Tokens* → **Generate New Token**:
+
+- **Granular Access Token** (preferred): expiration up to 1 year, *Packages and
+  scopes* → select `jonggrang`, permission **Read and write**.
+- or **Classic Token** → type **Automation**. Automation tokens are the ones
+  exempt from the 2FA prompt, which a CI run cannot answer. A classic *Publish*
+  token still asks for an OTP and will fail the job.
+
+Nothing else on npm needs changing: `jonggrang` is already public and owned by
+`anak10thn` + `ans4175`, so a token from either account has publish rights.
+
+**2. GitHub** — repo → Settings → *Secrets and variables* → **Actions** → *New
+repository secret*, name it exactly `NPM_TOKEN`. Or from a terminal:
+
+```bash
+gh secret set NPM_TOKEN            # paste the token when prompted
+```
+
+Without it `npm-release` fails and no image is built — deliberately, since an
+image pinned to an unpublished version cannot be built anyway.
+
+**Provenance.** The publish runs with `--provenance`, which needs three things
+that are now in place: `id-token: write` on the job, a public repository, and a
+`repository` field in `package.json` pointing at it. Provenance is what makes the
+npm page show the commit and workflow the tarball was built from — remove the
+flag rather than let it fail if any of those ever stops being true.
 
 **Repairing a mis-tagged image** (built before its npm version existed) — run the
 workflow manually with the version, no new release needed:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.19.2",
   "description": "Deterministic AI orchestration platform — 16-phase workflow engine for autonomous software development",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/porcupine-md/jonggrang.git"
+  },
+  "homepage": "https://github.com/porcupine-md/jonggrang#readme",
+  "bugs": {
+    "url": "https://github.com/porcupine-md/jonggrang/issues"
+  },
   "main": "server.js",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## The problem

`ghcr.io/porcupine-md/jonggrang-agent:0.19.2` contains **jonggrang 0.19.1**. So
does `:latest`. Measured:

```
npm view jonggrang version                 → 0.19.2
docker run …/jonggrang-agent:0.19.2 jonggrang --version → jonggrang 0.19.1
docker run …/jonggrang-agent:latest jonggrang --version → jonggrang 0.19.1
```

The image installs jonggrang from npm, and the release ritual (`make publish-*`)
pushed the git tag **first** and ran `npm publish` by hand afterwards. CI starts
on the tag push, so it built against whatever npm still served — the previous
release — and shipped it under the new tag.

This is not cosmetic. It is the exact skew that hid the bug fixed in #104: a
project container ran jonggrang 0.16.0 against a 0.19.x dashboard, missing the
non-interactive escalation guard the server assumed was there, and a work loop
re-dispatched one task for nine agent passes and ~2.3M tokens before anyone
looked.

## The fix — one publisher, one order

**`.github/workflows/docker.yml`** — a release tag now runs a new `npm-release`
job *before* any image:

1. refuse if the tag does not match `package.json`
2. `npm ci` → `npm run build` (client/dist is in the published `files` but is
   gitignored, so it must be built here) → `npm test`
3. `npm publish --provenance`, skipped when that version is already on npm, so
   re-running a release workflow cannot fail on E409

The image job gains `needs: [npm-release]`, with `always() && (success ||
skipped)` so main and manual builds still run while a *failed* publish blocks the
image.

**`docker/Dockerfile`** — `ARG JONGGRANG_VERSION` (default `latest`) pins the
install, and the build fails if npm served a different version. A tag can no
longer lie even if something else changes upstream.

**`Makefile`** — `make publish-*` no longer runs `npm publish`. It bumps, builds,
tags, pushes, and prints what CI will do. Two publishers racing is what caused
this; now there is one.

**Repairing a mis-tagged image** — no fake release needed:

```bash
gh workflow run docker.yml -f version=0.19.2
```

That rebuilds the release images pinned to an already-published version. It also
skips the `dev` image, since a repair is not a dev build.

## Verification

Built the pinned layer against real docker, three cases:

| build arg | result |
|---|---|
| `JONGGRANG_VERSION=0.19.2` | build succeeds, `jonggrang --version` → **0.19.2** |
| `JONGGRANG_VERSION=0.99.0` (not on npm) | build **fails** — no silent fallback |
| `JONGGRANG_VERSION=latest` | succeeds, check skipped, as before |

## Required before the next release

A repository secret **`NPM_TOKEN`** (npm automation token with publish rights on
`jonggrang`). The repo currently has no secrets set, so the next tag would fail
at `npm-release` — and deliberately build no image, since an image pinned to an
unpublished version cannot be built anyway.

Co-authored-by: jonggrang-dev <koko@jonggrang.dev>
