### PR TITLE
fix(release): a repair build must not move :latest or :X.Y

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,8 @@ name: Build & Push Docker Images
 #   PR update     -> jonggrang-agent:dev only
 #   merge to main -> jonggrang-agent:latest + jonggrang-tunnel:latest
 #   tag vX.Y.Z    -> npm publish FIRST, then agent + tunnel :X.Y.Z, :X.Y, :latest
-#   manual run    -> all images (pass `version` to re-publish an existing X.Y.Z)
+#   manual run    -> all images (pass `version` to re-publish an existing
+#                    X.Y.Z; a repair does NOT move :latest or :X.Y)
 # Auth uses the built-in GITHUB_TOKEN — no extra secrets needed.
 
 on:
@@ -179,10 +180,21 @@ jobs:
             echo "minor=${VERSION%.*}"  >> "$GITHUB_OUTPUT"   # 1.2.3 -> 1.2
             # Pinned, so the tag cannot outrun the package it claims to contain.
             echo "npm_version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "Release build: $VERSION"
+            # A repair rebuilds an OLD version's images. Moving :latest there
+            # would hand every project a downgrade — the repair for 0.19.2 would
+            # have pulled :latest back from 0.19.3. Only a tag push, which is
+            # always the newest release, moves :latest.
+            if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+              echo "move_latest=true" >> "$GITHUB_OUTPUT"
+              echo "Release build: $VERSION (moves :latest)"
+            else
+              echo "move_latest=false" >> "$GITHUB_OUTPUT"
+              echo "Repair build: $VERSION (leaves :latest alone)"
+            fi
           else
             echo "is_release=false"   >> "$GITHUB_OUTPUT"
             echo "npm_version=latest" >> "$GITHUB_OUTPUT"
+            echo "move_latest=true"   >> "$GITHUB_OUTPUT"
             echo "Build: ${{ matrix.image }}:latest"
           fi
 
@@ -199,7 +211,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # tags: always :latest; plus X.Y.Z and X.Y on a release tag.
+      # tags: :latest and :X.Y float, so only a tag push (always the newest
+      # release) writes them. A repair of an older version writes :X.Y.Z ONLY —
+      # rebuilding 0.19.2 must not pull :latest back from 0.19.3.
       - name: Build & push ${{ matrix.image }} (${{ matrix.name }})
         uses: docker/build-push-action@v6
         with:
@@ -208,9 +222,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ matrix.image }}:latest
+            ${{ steps.ver.outputs.move_latest == 'true' && format('{0}/{1}/{2}:latest', env.REGISTRY, env.NAMESPACE, matrix.image) || '' }}
             ${{ steps.ver.outputs.is_release == 'true' && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.NAMESPACE, matrix.image, steps.ver.outputs.version) || '' }}
-            ${{ steps.ver.outputs.is_release == 'true' && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.NAMESPACE, matrix.image, steps.ver.outputs.minor) || '' }}
+            ${{ steps.ver.outputs.move_latest == 'true' && steps.ver.outputs.is_release == 'true' && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.NAMESPACE, matrix.image, steps.ver.outputs.minor) || '' }}
           build-args: |
             JONGGRANG_VERSION=${{ steps.ver.outputs.npm_version }}
           cache-from: type=gha,scope=${{ matrix.name }}

--- a/docs/QUICKSETUP.md
+++ b/docs/QUICKSETUP.md
@@ -186,7 +186,9 @@ repository, and a `repository` field in `package.json` — all three are in plac
 It is what makes the npm page show the commit and workflow a tarball came from.
 
 **Repairing a mis-tagged image** (built before its npm version existed) — run the
-workflow manually with the version, no new release needed:
+workflow manually with the version, no new release needed. A repair writes the
+`X.Y.Z` tag **only**: `:latest` and `:X.Y` float, and moving them to an older
+version would hand every project a downgrade.
 
 ```bash
 gh workflow run docker.yml -f version=0.19.2


### PR DESCRIPTION
## The bug

#105 added a manual repair route — `gh workflow run docker.yml -f version=X.Y.Z`
— to rebuild an image that was tagged before its npm version existed. I ran it
for 0.19.2 and cancelled it mid-build: the publish job tags `:latest`
**unconditionally**, so the repair would have pushed `:latest` and `:0.19` back
to **0.19.2** while the current release is 0.19.3.

Every project pulling `:latest` would have taken a downgrade — to fix a
historical tag. Exactly the class of skew #105 set out to remove.

## The fix

`:latest` and `:X.Y` float, so only a tag push — always the newest release —
writes them. A repair writes the exact `:X.Y.Z` it was asked for and nothing
else.

- `move_latest` output: true for a tag push and for a plain main build, false for
  a manual `version` repair.
- `:latest` and `:X.Y` are now gated on it; `:X.Y.Z` still follows `is_release`.

## Verified

`:latest` was checked immediately after the cancellation and is still
`jonggrang 0.19.3`, so nothing was clobbered. YAML parses; the release path
(v0.19.3) that produced the correct images is unchanged by this diff — only the
repair path narrows.

Co-authored-by: jonggrang-dev <koko@jonggrang.dev>