### PR TITLE
fix(interactive): answer the folder-trust dialog off the raw stream too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Build & Push Docker Images
 
 # Builds the Jonggrang images for GitHub Container Registry, selected by event:
-#   PR update     -> jonggrang-agent:dev only
+#   PR update     -> npm test + jonggrang-agent:dev
 #   merge to main -> jonggrang-agent:latest + jonggrang-tunnel:latest
 #   tag vX.Y.Z    -> npm publish FIRST, then agent + tunnel :X.Y.Z, :X.Y, :latest
 #   manual run    -> all images (pass `version` to re-publish an existing
@@ -26,6 +26,22 @@ env:
 
 jobs:
   # PR commits (and manual runs) build & push the dev image only.
+  # The suite runs on every PR, not only at release time.
+  #
+  # It used to run only inside npm-release, so a broken test surfaced as a FAILED
+  # RELEASE — v0.19.4 published nothing because of one — when a PR check would
+  # have caught it minutes after the push. Cheap: no docker, no QEMU.
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm test
+
   # A manual run that names a version is a release-image repair, not a dev build.
   dev:
     if: >-

--- a/lib/jonggrang.js
+++ b/lib/jonggrang.js
@@ -1945,17 +1945,28 @@ function runClaudeInteractive({
     let screenFallback = false;
     const pendingScreen = [];
 
+    // Confirm the folder-trust dialog once, from whichever source sees it first.
+    // A failed write is reported rather than swallowed: the whole point of this
+    // is that an unanswered dialog is invisible, so a silent catch here would
+    // hide the one thing worth knowing.
+    const answerTrust = (text) => {
+      if (trustAnswered || !autoTrust || !TUI_TRUST_RE.test(text)) return;
+      trustAnswered = true;
+      process.stdout.write('\x1b[2m[claude:interactive] folder-trust prompt — confirming automatically\x1b[0m\n');
+      try {
+        child.write('\r');
+      } catch (err) {
+        process.stderr.write(`\x1b[33m[claude:interactive] could not answer the trust prompt: ${err.message}\x1b[0m\n`);
+      }
+    };
+
     const transcript = new TuiTranscript({
       onLine: (line) => {
         if (session.active) { /* the transcript is the log */ }
         else if (screenFallback) emit(`${line}\n`);
         else if (pendingScreen.length < 500) pendingScreen.push(line);
 
-        if (!trustAnswered && autoTrust && TUI_TRUST_RE.test(line)) {
-          trustAnswered = true;
-          process.stdout.write('\x1b[2m[claude:interactive] folder-trust prompt — confirming automatically\x1b[0m\n');
-          try { child.write('\r'); } catch { /* pty already gone */ }
-        }
+        answerTrust(line);
       },
     });
 
@@ -2054,6 +2065,13 @@ function runClaudeInteractive({
       // Once we are tearing the session down, the pty only echoes our own
       // /exit and ^C keystrokes — keep them out of the transcript.
       if (closing) return;
+      // The trust dialog blocks the whole session, and answering it used to
+      // depend on the rendered-line path: a line is only emitted once its
+      // newline arrives, and an identical line already in the frame history is
+      // dropped as a redraw. Either one silently leaves the dialog unanswered,
+      // which reads as a run that did nothing. The raw stream has no such
+      // conditions, so check there too — answerTrust is idempotent.
+      answerTrust(String(data));
       transcript.push(data);
       armIdle();
     });

--- a/test/claude-interactive.test.js
+++ b/test/claude-interactive.test.js
@@ -382,6 +382,37 @@ testAsync('runClaudeInteractive: auto-confirms the folder-trust dialog in autono
   } finally { process.env.PATH = prevPath; }
 });
 
+// The dialog is answered off the RAW stream as well as off rendered lines.
+// Rendered lines only appear once a newline arrives (and an identical line is
+// dropped as a redraw), so a prompt painted without a trailing newline — a
+// normal thing for a TUI that is waiting on the same row — used to leave the
+// dialog unanswered, and the run looked like it had simply done nothing.
+testAsync('runClaudeInteractive: confirms a trust prompt that never gets a newline', async () => {
+  const root = tmpProject();
+  const { bin } = fakeClaude(root, [
+    'printf "Quick safety check: Is this a project you created or one you trust? "',
+    'read _answer',                      // blocks on the same row, no newline sent
+    'echo "TRUST_CONFIRMED"',
+    'exit 0',
+  ].join('\n'));
+  const prevPath = process.env.PATH;
+  process.env.PATH = `${bin}:${prevPath}`;
+  const chunks = [];
+  try {
+    const code = await lib.runClaudeInteractive({
+      prompt: 'p',
+      permFlags: lib.claudePermissionFlags('autonomous'),
+      projectRoot: root,
+      textChunks: chunks,
+      ...FAST,
+      idleSec: 20,                       // must finish by answering, not by idling out
+    });
+    assert.strictEqual(code, 0);
+    assert.ok(chunks.join('').includes('TRUST_CONFIRMED'),
+      `unterminated trust prompt was not answered: ${JSON.stringify(chunks.join(''))}`);
+  } finally { process.env.PATH = prevPath; }
+});
+
 testAsync('runClaudeInteractive: leaves the trust dialog alone outside autonomous mode', async () => {
   const root = tmpProject();
   const { bin } = fakeClaude(root, [


### PR DESCRIPTION
## What happened

The **v0.19.4 release build failed** — and it failed for the right reason: the new
release pipeline runs `npm test` before publishing, so nothing was pushed to npm
and no image was built. The failing test:

```
✗ runClaudeInteractive: auto-confirms the folder-trust dialog in autonomous mode
  trust prompt was not answered: "Quick safety check: Is this a project you
  created or one you trust?\n1. Yes, I trust this folder\n"
```

It passes locally, and passed on the v0.19.3 release. So the detection is
timing-dependent — which, given what it guards, is the interesting part.

## Why it is fragile

Answering the dialog hung off `TuiTranscript`'s rendered-line callback. That path
has two conditions the dialog is under no obligation to satisfy:

1. a line is only emitted **once its newline arrives** — an unterminated tail is
   held in the raw buffer;
2. a line identical to one already in the 120-line frame history is **dropped**
   as a redraw.

A TUI that prints a question and waits for input *on the same row* satisfies
neither. And an unanswered trust dialog is invisible: it looks exactly like a
finished turn to the idle detector, so the run reports success having done
nothing — the precise failure this detection exists to prevent.

## The fix

- `answerTrust()` is called from the **raw pty stream** as well as from rendered
  lines, and is idempotent, so whichever sees it first wins.
- A failed write is now **reported** instead of swallowed by `catch {}`. When the
  symptom is silence, hiding the reason defeats the purpose.

## Verification

New test paints the prompt with `printf` — no trailing newline — and waits on the
same row:

| | previous code | this branch |
|---|---|---|
| `confirms a trust prompt that never gets a newline` | ✖ | ✔ |

Full interactive suite 41/41, run five times to check for flakiness; whole suite
green.

## Release state

`v0.19.4` published nothing (npm has no 0.19.4, no image was built), so the tag
will be moved to include this fix rather than burning a version on a release that
never shipped.

Co-authored-by: jonggrang-dev <koko@jonggrang.dev>