### PR TITLE
A cache fix is not UI work, and a plan without UI tasks still approves

### DIFF
--- a/bin/jonggrang.js
+++ b/bin/jonggrang.js
@@ -2214,6 +2214,11 @@ async function cmdApprove(args, opts = {}) {
       if (previousTasksContent == null) fs.unlinkSync(approvalTasksFile);
       else fs.writeFileSync(approvalTasksFile, previousTasksContent, 'utf8');
     } catch {}
+    restoreUiHandoff();
+  };
+  // Undo only the handoff, keeping whatever tasks the decompose wrote — for the
+  // case where the plan turns out not to be UI work at all and is approved as is.
+  const restoreUiHandoff = () => {
     try {
       if (previousUiHandoff == null) fs.unlinkSync(finalUiHandoffPath);
       else fs.writeFileSync(finalUiHandoffPath, previousUiHandoff, 'utf8');
@@ -2244,6 +2249,20 @@ async function cmdApprove(args, opts = {}) {
     rollbackUiApproval();
     logError('Agent did not create any tasks. plan.md has been preserved — re-run "jonggrang approve" after fixing the issue.');
     process.exit(1);
+  }
+
+  // The UI flow starts from a keyword guess, and `page` matches "page cache" — so a
+  // backend fix can reach approval dressed as UI work. If the decomposition needed
+  // no UI context and the plan proposed no guide change, nothing was designed and
+  // nothing is lost: approve it as the plan it turned out to be. Refusing to approve
+  // at all was the worse answer, and the only one this had.
+  if (approvedUi && uiContext.isNonUiAfterDecompose({
+    uiTaskCount: newTasks.filter(task => task.ui_context).length,
+    guideStatus: approvedUi.guideStatus,
+  })) {
+    logWarn('No task needed UI context and the UI guide is unchanged — approving this as a non-UI plan.');
+    restoreUiHandoff();
+    approvedUi = null;
   }
 
   if (approvedUi) {

--- a/lib/ui-context.js
+++ b/lib/ui-context.js
@@ -248,6 +248,23 @@ function loadBaselinePack(key, catalogDir) {
   };
 }
 
+// Infrastructure work that merely mentions a page. `page` is a UI word in the
+// regex above — it has to be, for "the settings page" — but it also appears in
+// "purge the page cache", which is a cache fix with no interface in it. Reported
+// from a live dashboard: a cache-invalidation bugfix was planned as UI work, and
+// approval then refused it for having no UI task.
+//
+// The rule is narrow on purpose: caching language, and not one word naming a UI
+// concern. A plan that says `design`, `layout`, `component`, `css` — anything in
+// STRONG_UI_RE — is taken at its word regardless of how much cache it also
+// mentions, so this cannot hide real UI work.
+const CACHE_WORK_RE = /\b(cache|caching|cached|purge|purging|invalidate|invalidation|revalidat\w*|cdn|nginx|varnish|redis|dragonfly|ttl)\b/i;
+const STRONG_UI_RE = /\b(ui|ux|frontend|front-end|design|layout|visual|responsive|accessibility|a11y|component|button|input|select|dropdown|form|dialog|modal|toast|tooltip|icon|animation|screen|sidebar|navigation|theme|dark mode|light mode|stylesheet|css|tailwind|storybook|figma|dashboard|landing page|mobile app)\b/i;
+
+function isCacheWorkWithoutUiConcern(text) {
+  return CACHE_WORK_RE.test(text) && !STRONG_UI_RE.test(text);
+}
+
 function detectUiWork(description, opts = {}) {
   const textParts = [description || ''];
   if (opts.srcPath) {
@@ -256,7 +273,26 @@ function detectUiWork(description, opts = {}) {
     try { textParts.push(fs.readFileSync(opts.srcPath, 'utf8').slice(0, 20000)); } catch {}
   }
   if (Array.isArray(opts.files) && opts.files.some(file => UI_FILE_RE.test(file))) return true;
-  return UI_DESCRIPTION_RE.test(textParts.join('\n'));
+  const text = textParts.join('\n');
+  if (isCacheWorkWithoutUiConcern(text)) return false;
+  return UI_DESCRIPTION_RE.test(text);
+}
+
+/**
+ * After decomposition, was this a UI plan after all?
+ *
+ * detectUiWork guesses from words, and `page` matches "page cache" — so a backend
+ * cache fix can arrive at approval dressed as UI work. The decomposition is the
+ * better judge: if it produced no task needing UI context, it did not see UI work
+ * either. When the plan also proposed no change to the guide there is no design to
+ * lose, so the honest answer is to approve the plan as what it turned out to be
+ * rather than refuse to approve anything.
+ *
+ * A proposed or updated guide means someone did design something — keep failing
+ * there, because dropping it silently would throw that away.
+ */
+function isNonUiAfterDecompose({ uiTaskCount, guideStatus }) {
+  return uiTaskCount === 0 && guideStatus === 'unchanged';
 }
 
 function walkProjectFiles(projectRoot, maxFiles = 4000) {
@@ -848,6 +884,8 @@ module.exports = {
   loadBaselinePack,
   validateBaselineManifest,
   detectUiWork,
+  isCacheWorkWithoutUiConcern,
+  isNonUiAfterDecompose,
   auditUiProject,
   recommendBaseline,
   validateUiGuide,

--- a/scripts/smoke-ui-false-positive.sh
+++ b/scripts/smoke-ui-false-positive.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A plan that the UI keyword guess claims and the decomposition does not.
+#
+# `detectUiWork` matches the word `page`, so "purge the page cache" reads as UI
+# work: the plan gets `ui: true`, the agent dutifully writes a UI handoff draft,
+# and then the decomposition — correctly — produces no task needing UI context.
+# Approval used to refuse the whole plan there ("UI plan produced no tasks with
+# ui_context"), which is how it was reported from a live dashboard.
+#
+# Fake agent, no real model: the decompose branch writes tasks WITHOUT ui_context
+# on purpose, which is the condition the live failure needed and could not be
+# reproduced on demand (the same plan produced one UI task on a later run).
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/jonggrang-ui-falsepos.XXXXXX")"
+FAKE_BIN="$TMP/fake-bin"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$FAKE_BIN" "$TMP/project/src/components" "$TMP/project/src/styles" "$TMP/project/.jonggrang"
+
+cat > "$FAKE_BIN/opencode" <<'NODE'
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const prompt = process.argv[process.argv.length - 1] || '';
+const cwd = process.cwd();
+const cli = process.env.JONGGRANG_SMOKE_CLI;
+const emit = (text) => process.stdout.write(JSON.stringify({ type: 'text', part: { text } }) + '\n');
+const write = (file, content) => { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, content); };
+const match = (re, label) => { const found = prompt.match(re); if (!found) throw new Error(`fake agent: missing ${label}`); return found[1]; };
+
+if (prompt.includes('Clarify Before Planning')) { emit('NO_QUESTIONS\n'); process.exit(0); }
+
+if (prompt.includes('Generate Draft Plan')) {
+  const planPath = match(/Write it to `([^`]+\/plan\.md)`/, 'plan path');
+  const sessionDir = path.dirname(planPath);
+  // What the real agent produced for this description: UI flagged, guide
+  // untouched, baseline the existing project.
+  write(planPath, `---
+feature: page-cache-purge
+branch: feat/page-cache-purge
+base: "main"
+work_type: BUGFIX
+ui: true
+ui_guide_status: unchanged
+ui_baseline: existing-project
+ui_token_status: ready
+description: Purge the nginx page cache when a fundraising edit is saved
+---
+
+# Plan: Page Cache Purge
+
+## Approach
+Invalidate the cached detail page and both checkout pages after an edit is saved.
+`);
+  write(path.join(sessionDir, 'UI_HANDOFF.md'), `# UI handoff draft: page cache purge
+
+Guide: .jonggrang/UI.md
+Baseline: existing-project
+Token source: src/styles/tokens.css (ready)
+Guide status: unchanged
+
+## Feature intent
+Readers see fresh content after an edit.
+
+## Shared direction
+No visual change; the rendered pages stay as they are.
+
+## References
+- .jonggrang/UI.md#components-and-layout-patterns
+`);
+  emit(`Draft plan written to ${planPath}\n`);
+  process.exit(0);
+}
+
+if (prompt.includes('Decompose Approved Plan to Tasks')) {
+  const featureId = match(/jonggrang task import --feature ([a-zA-Z0-9._-]+)/, 'feature id');
+  const handoffAbsolute = match(/After importing tasks, write the complete handoff to `([^`]+)`/, 'handoff path');
+  // The point of this fixture: cache invalidation needs no UI context, so none
+  // of these tasks carries any.
+  const tasks = [
+    { id: 'task-001', title: 'Purge the detail page cache on save', description: 'Call the purge helper for the subType detail path after a successful edit.', priority: 1, files: ['src/libs/payment-link.js'], blocked_by: [] },
+    { id: 'task-002', title: 'Purge both checkout page caches', description: 'Purge the two fundraising checkout paths in the same code path.', priority: 2, files: ['src/libs/payment-link.js'], blocked_by: [] },
+  ];
+  const imported = spawnSync(process.execPath, [cli, 'task', 'import', '--feature', featureId, '--input', JSON.stringify(tasks), '--json'], {
+    cwd, env: process.env, encoding: 'utf8',
+  });
+  if (imported.status !== 0) throw new Error(`fake agent: task import failed: ${imported.stderr}`);
+  // It still writes the handoff it was asked for — approval must clean that up
+  // itself rather than leaving a UI artefact on a plan that has no UI task.
+  write(handoffAbsolute, `# UI handoff: page cache purge
+
+## Feature intent
+Readers see fresh content after an edit.
+
+## Shared direction
+No visual change.
+`);
+  emit('Tasks imported\n');
+  process.exit(0);
+}
+
+throw new Error('fake agent received an unexpected prompt');
+NODE
+chmod +x "$FAKE_BIN/opencode"
+
+cat > "$TMP/project/package.json" <<'JSON'
+{"name":"page-cache-fixture","dependencies":{"react":"^19.0.0"}}
+JSON
+cat > "$TMP/project/.jonggrang/jonggrang.json" <<'JSON'
+{"name":"page-cache-fixture","project":{"stack":"react"},"tool":"opencode"}
+JSON
+printf '# Fixture\n' > "$TMP/project/AGENTS.md"
+printf ':root { --ui-action: blue; }\n' > "$TMP/project/src/styles/tokens.css"
+# Enough evidence for the audit to see an existing UI system, so planning does not
+# stop to ask which starter baseline to use.
+printf 'export const Button = () => null;\n' > "$TMP/project/src/components/Button.tsx"
+
+# `ui_guide_status: unchanged` means the project guide is the approved one, so it
+# has to exist and validate. Borrow the one the lifecycle smoke writes.
+cat > "$TMP/project/.jonggrang/UI.md" <<'MD'
+---
+format: jonggrang-ui-guide/v1
+baseline: existing-project
+ui_framework: react
+token_source: src/styles/tokens.css
+token_status: ready
+component_source: src/components
+storybook: none
+references: []
+---
+
+# UI guide
+
+## Product and UX rationale
+Readers open shared links repeatedly.
+
+## Visual direction and baseline
+Keep the existing compact interface.
+
+## Source map
+- Tokens: `src/styles/tokens.css`
+- Button: `src/components/Button.tsx`
+
+## Token contract, typography, and spacing
+Use semantic tokens from the canonical source.
+
+## Components and layout patterns
+Reuse `src/components/Button.tsx` for the primary action.
+
+## Interaction, responsive, and accessibility rules
+Keep focus visible and preserve input on errors.
+
+## References and verification
+Run `npm test`. Storybook: none.
+
+## Rules summary
+Reuse local components and semantic tokens first.
+MD
+
+export PATH="$FAKE_BIN:$PATH"
+export JONGGRANG_SMOKE_CLI="$ROOT/bin/jonggrang.js"
+export JONGGRANG_TOOL=opencode
+
+printf '\n== UI keyword guess, non-UI decomposition → still approves ==\n'
+(
+  cd "$TMP/project"
+  git init -q
+  git config user.name Smoke
+  git config user.email smoke@example.com
+  git add .
+  git commit -qm 'chore: page cache fixture'
+  # A description that genuinely names a UI concern (`theme`), so the classifier is
+  # right to flag it and the project's existing guide is used unchanged. The work
+  # still turns out to be cache invalidation, so the decomposition needs no UI
+  # context — and approval must survive that, not refuse the plan.
+  node "$ROOT/bin/jonggrang.js" plan "purge the cached page after a theme change" --yes --no-ask \
+    > /tmp/jonggrang-ui-falsepos.log 2>&1
+)
+
+grep -q 'approving this as a non-UI plan' /tmp/jonggrang-ui-falsepos.log \
+  || { echo 'approval did not report dropping the UI framing' >&2; tail -20 /tmp/jonggrang-ui-falsepos.log >&2; exit 1; }
+
+FEATURE_DIR=$(find "$TMP/project/.jonggrang/.output/features" -mindepth 1 -maxdepth 1 -type d | head -1)
+[ -n "$FEATURE_DIR" ] || { echo 'no feature was approved' >&2; exit 1; }
+[ -f "$FEATURE_DIR/plan.md" ]
+[ -f "$FEATURE_DIR/jonggrang-tasks.json" ]
+[ ! -f "$FEATURE_DIR/UI_HANDOFF.md" ] || { echo 'a UI handoff survived on a plan with no UI task' >&2; exit 1; }
+
+node - "$FEATURE_DIR/jonggrang-tasks.json" <<'NODE'
+const assert = require('assert');
+const fs = require('fs');
+const tasks = JSON.parse(fs.readFileSync(process.argv[2], 'utf8')).tasks;
+assert.equal(tasks.length, 2, 'both tasks survived the approval');
+assert.equal(tasks.some(task => task.ui_context), false, 'and none of them pretends to be UI work');
+NODE
+
+printf '  ✓ approved into %s with 2 tasks and no UI artefacts\n' "$(basename "$FEATURE_DIR")"
+printf '  log: /tmp/jonggrang-ui-falsepos.log\n'

--- a/test/ui-context.test.js
+++ b/test/ui-context.test.js
@@ -149,6 +149,34 @@ token_template: tokens.css.template
   assert.equal(ui.recommendBaseline('Build an Expo mobile app'), 'mobile-app-minimalist@1');
 })();
 
+(function cacheWorkIsNotUiWorkAndApprovalSurvivesEither() {
+  // Reported from a live dashboard: this description was planned as UI work and
+  // approval then refused the whole plan — "UI plan produced no tasks with
+  // ui_context". The word `page` is in the detector, and it has to be, for "the
+  // settings page"; it also appears in "purge the page cache".
+  const cacheFix = 'Fix editPaymentLinkBySlug so fundraising edits purge the Dragonfly nginx page cache for the subType-specific detail page and both fundraising checkout pages';
+  assert.equal(ui.detectUiWork(cacheFix), false, 'caching language and no UI concern named');
+  assert.equal(ui.isCacheWorkWithoutUiConcern(cacheFix), true);
+
+  // Narrow on purpose: naming any UI concern wins, however much cache is around it.
+  assert.equal(ui.detectUiWork('Cache the dashboard component tree in redis'), true);
+  assert.equal(ui.detectUiWork('Purge the cached page after a theme change'), true);
+  assert.equal(ui.isCacheWorkWithoutUiConcern('Redesign the pricing page layout'), false);
+
+  // Nothing else moved.
+  assert.equal(ui.detectUiWork('Add a keyboard-accessible settings dialog'), true);
+  assert.equal(ui.detectUiWork('Add database retry handling'), false);
+  assert.equal(ui.detectUiWork('Add a new checkout page'), true);
+
+  // Second half of the fix: when UI *is* detected and the decomposition still
+  // needs no UI context, approval continues instead of refusing the plan — but
+  // only when no guide change was proposed, or design work would be lost.
+  assert.equal(ui.isNonUiAfterDecompose({ uiTaskCount: 0, guideStatus: 'unchanged' }), true);
+  assert.equal(ui.isNonUiAfterDecompose({ uiTaskCount: 0, guideStatus: 'update proposed' }), false);
+  assert.equal(ui.isNonUiAfterDecompose({ uiTaskCount: 0, guideStatus: 'new' }), false);
+  assert.equal(ui.isNonUiAfterDecompose({ uiTaskCount: 2, guideStatus: 'unchanged' }), false);
+  assert.equal(ui.isNonUiAfterDecompose({ uiTaskCount: 2, guideStatus: 'update proposed' }), false);
+})();
 (function auditsLocalEvidenceWithoutInventingOptionalTools() {
   const root = tempRoot();
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({


### PR DESCRIPTION
Reported from a live dashboard, approving a plan:

```
[jonggrang] UI context materialization failed: UI plan produced no tasks with ui_context
```

The plan was a backend bugfix — purge the nginx page cache after a fundraising edit — and nothing in it was UI.

## Why it happened

`detectUiWork` matches the word `page`. It has to, for "the settings page"; it also matches "purge the **page** cache". So:

1. the plan was flagged `ui: true`,
2. the planning agent dutifully wrote a UI guide handoff draft,
3. the decomposition — correctly — produced no task needing UI context,
4. approval refused the entire plan.

Step 4 is the one the user feels: a good plan cannot be approved at all.

## What changed

**Caching language with no UI concern named is not UI work.** Narrow on purpose: any word naming a UI concern — `design`, `layout`, `component`, `css`, `theme`, `screen`, … — wins regardless of how much cache surrounds it, so this cannot hide real UI work. `Cache the dashboard component tree in redis` is still UI; `purge the page cache` is not.

**A decomposition with no UI task no longer blocks approval.** When UI was detected but no task needed UI context *and the plan proposed no guide change*, there is no design to lose: approval says what it dropped and approves the plan as what it turned out to be. A proposed or updated guide still fails, because dropping that silently would throw away real design work.

## Verified

- Unit: the reported description, the phrasings that must stay UI, and the truth table of the approval rule (`test/ui-context.test.js`).
- `scripts/smoke-ui-false-positive.sh` — the live failure could not be reproduced on demand (the same plan produced one UI task on a later run), so this forces the condition with a fake agent whose decomposition writes tasks without `ui_context`. Asserts approval continues, warns, keeps both tasks, and leaves no UI handoff behind.
- The two existing UI smokes (`smoke-ui-plan-lifecycle.sh`, `smoke-ui-starter-pack.sh`) still pass, so the real UI path is untouched.
- In the browser against the reporting dashboard: the same description now plans with no UI flow at all.